### PR TITLE
fix: Windows ESM path, pdfjs file URLs, and token fallback

### DIFF
--- a/pursue-vision-mcp/start.mjs
+++ b/pursue-vision-mcp/start.mjs
@@ -1,8 +1,9 @@
 // One-shot entry point: ensure Chrome is up on the debug port, start the daemon.
 //
 // Usage:
-//   npm start                    — auto-launch Chrome if needed, start daemon
+//   npm start                    — use primary MCP if running, else auto-launch Chrome + daemon
 //   npm start -- --no-chrome     — assume Chrome is already running on CDP port
+//   npm start -- --no-primary    — skip primary MCP check, always spin up own instance
 //
 // The actual ChatGPT login is your problem (and your computer's). We never
 // see your credentials; we only attach to a tab you already authenticated in.
@@ -10,13 +11,29 @@
 import { spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const CDP_PORT = Number(process.env.PURSUE_CDP_PORT || 9222);
 const NO_CHROME = process.argv.includes("--no-chrome");
+const NO_PRIMARY = process.argv.includes("--no-primary");
+const PRIMARY_MCP_PORT = Number(process.env.PURSUE_PRIMARY_MCP_PORT || 9223);
+
+async function probeMcp(port) {
+  try {
+    const r = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(2000) });
+    return r.ok;
+  } catch { return false; }
+}
+
+// If the primary MCP is already running, delegate to it — no Chrome needed.
+if (!NO_PRIMARY && await probeMcp(PRIMARY_MCP_PORT)) {
+  console.log(`[start] primary MCP already running on :${PRIMARY_MCP_PORT} — skipping Chrome + daemon startup`);
+  console.log(`[start] use DAEMON=http://127.0.0.1:${PRIMARY_MCP_PORT} in your scripts`);
+  process.exit(0);
+}
 
 async function probeCdp() {
   try {
@@ -58,11 +75,12 @@ async function ensureChrome() {
     console.error(`[start] Chrome not found in the usual locations. Install Chrome or start it yourself with --remote-debugging-port=${CDP_PORT} and pass --no-chrome.`);
     process.exit(2);
   }
+  const profileSuffix = process.env.PURSUE_CHROME_PROFILE || `pursure-${CDP_PORT}`;
   const userDataDir = platform() === "win32"
-    ? `${process.env.LOCALAPPDATA}/Google/Chrome/User Data`
+    ? `${process.env.LOCALAPPDATA}/Google/Chrome/User Data - ${profileSuffix}`
     : platform() === "darwin"
-    ? `${process.env.HOME}/Library/Application Support/Google/Chrome`
-    : `${process.env.HOME}/.config/google-chrome`;
+    ? `${process.env.HOME}/Library/Application Support/Google/Chrome-${profileSuffix}`
+    : `${process.env.HOME}/.config/google-chrome-${profileSuffix}`;
   console.log(`[start] launching Chrome with --remote-debugging-port=${CDP_PORT}`);
   console.log(`[start] using profile ${userDataDir}`);
   spawn(chrome, [
@@ -82,4 +100,4 @@ async function ensureChrome() {
 await ensureChrome();
 
 // Hand off to the daemon — same Node process.
-await import(path.join(__dirname, "daemon.mjs"));
+await import(pathToFileURL(path.join(__dirname, "daemon.mjs")).href);

--- a/scripts/vision-ocr.mjs
+++ b/scripts/vision-ocr.mjs
@@ -18,7 +18,7 @@ import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createCanvas } from "@napi-rs/canvas";
 
 // pdfjs occasionally emits an AbortException from internal aborted-render
@@ -231,8 +231,8 @@ function splitTextAndVisuals(raw) {
 
 // ---- pdf → png rendering (same factory as ocr-scanned.mjs) ----
 const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
-const PDFJS_WASM_URL = "file://" + path.join(ROOT, "node_modules/pdfjs-dist/wasm/").replaceAll("\\", "/");
-const PDFJS_FONTS_URL = "file://" + path.join(ROOT, "node_modules/pdfjs-dist/standard_fonts/").replaceAll("\\", "/");
+const PDFJS_WASM_URL  = pathToFileURL(path.join(ROOT, "node_modules/pdfjs-dist/wasm")).href + "/";
+const PDFJS_FONTS_URL = pathToFileURL(path.join(ROOT, "node_modules/pdfjs-dist/standard_fonts")).href + "/";
 
 class NodeCanvasFactory {
   create(width, height) {

--- a/scripts/volunteer.mjs
+++ b/scripts/volunteer.mjs
@@ -30,7 +30,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createCanvas } from "@napi-rs/canvas";
 
 process.on("unhandledRejection", e => console.error("  ! unhandled:", e?.message || e));
@@ -70,8 +70,11 @@ const TOKEN_FILE = (args["token-file"] || "~/.pursue-vision-token").replace(/^~/
 async function loadToken() {
   if (process.env.PURSUE_VISION_TOKEN) return process.env.PURSUE_VISION_TOKEN;
   if (process.env.WHIPGEN_TOKEN) return process.env.WHIPGEN_TOKEN;
-  try { return (await readFile(TOKEN_FILE, "utf8")).trim(); }
-  catch { console.error(`error: no token. Start the daemon first (it writes ${TOKEN_FILE}), or set PURSUE_VISION_TOKEN`); process.exit(1); }
+  for (const p of [TOKEN_FILE, path.join(os.homedir(), ".whipgen-token")]) {
+    try { return (await readFile(p, "utf8")).trim(); } catch {}
+  }
+  console.error(`error: no token. Start the daemon first (it writes ${TOKEN_FILE}), or set PURSUE_VISION_TOKEN`);
+  process.exit(1);
 }
 const TOKEN = await loadToken();
 
@@ -131,8 +134,8 @@ const live = claims.filter(c => !c.skip);
 
 // ----- step 4: render + OCR via daemon -----
 const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
-const PDFJS_WASM_URL  = "file://" + path.join(ROOT, "node_modules/pdfjs-dist/wasm/").replaceAll("\\","/");
-const PDFJS_FONTS_URL = "file://" + path.join(ROOT, "node_modules/pdfjs-dist/standard_fonts/").replaceAll("\\","/");
+const PDFJS_WASM_URL  = pathToFileURL(path.join(ROOT, "node_modules/pdfjs-dist/wasm")).href + "/";
+const PDFJS_FONTS_URL = pathToFileURL(path.join(ROOT, "node_modules/pdfjs-dist/standard_fonts")).href + "/";
 class NCF {
   create(w, h) { const c = createCanvas(w, h); return { canvas: c, context: c.getContext("2d") }; }
   reset(cv, w, h) { cv.canvas.width = w; cv.canvas.height = h; }


### PR DESCRIPTION
## Summary

- **`pursue-vision-mcp/start.mjs`** — fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows by using `pathToFileURL` for the dynamic `import()` of `daemon.mjs`; detect a running primary MCP on `:9223` at startup and skip Chrome/daemon launch if found (pass `--no-primary` to force own instance); isolate the Chrome user-data profile per CDP port so multiple instances don't collide
- **`scripts/volunteer.mjs`** — fix pdfjs wasm/font base URLs (`file://C:/...` → `file:///C:/...` via `pathToFileURL`) so JBIG2 codec and standard fonts load correctly on Windows, eliminating all RENDER errors; extend token loading to fall back to `~/.whipgen-token` so the script works against both daemon flavours without extra config
- **`scripts/vision-ocr.mjs`** — same `pathToFileURL` fix for pdfjs asset URLs

## Test plan

- [ ] `npm start` in `pursue-vision-mcp/` on Windows exits cleanly when primary MCP is running on `:9223`
- [ ] `npm start` launches Chrome + daemon when no primary is detected
- [ ] `node scripts/volunteer.mjs --my-handle=... --dry-run` resolves token without error
- [ ] PDF render no longer logs font/wasm warnings on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)