### PR TITLE
fix(volunteer): polyfill globalThis.DOMMatrix to fix beginGroup render crash

### DIFF
--- a/scripts/volunteer.mjs
+++ b/scripts/volunteer.mjs
@@ -32,7 +32,7 @@ import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createCanvas, Path2D } from "@napi-rs/canvas";
+import { createCanvas, Path2D, DOMMatrix } from "@napi-rs/canvas";
 
 process.on("unhandledRejection", e => console.error("  ! unhandled:", e?.message || e));
 process.on("uncaughtException",  e => console.error("  ! uncaught:",  e?.message || e));
@@ -210,6 +210,7 @@ console.log(`[volunteer] pdfjs asset server → http://127.0.0.1:${assetPort}/`)
 // pdfjs creates `new Path2D()` from whatever is in scope; @napi-rs/canvas's
 // clip/fill only accept their own Path2D class. Wire it up before import.
 globalThis.Path2D = Path2D;
+globalThis.DOMMatrix = DOMMatrix;
 const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
 const PDFJS_WASM_URL  = `http://127.0.0.1:${assetPort}/wasm/`;
 const PDFJS_FONTS_URL = `http://127.0.0.1:${assetPort}/standard_fonts/`;


### PR DESCRIPTION
## Summary

Fixes a render crash on PDFs that use transparency groups with a matrix transform (`beginGroup` with `group.matrix` set).

## Root cause

pdfjs's `beginGroup` builds a clip path like this:

```js
const path = new Path2D();
path.addPath(clip, new DOMMatrix(group.matrix));
groupCtx.clip(path);
```

`@napi-rs/canvas`'s `Path2D.addPath()` Rust binding requires the transform to be its own `DOMMatrix` class. When passed Node's built-in `DOMMatrix`, the resulting path is invalid and `ctx.clip()` throws:
> `Value is none of these types 'String', 'Path'`

## Fix

Set `globalThis.DOMMatrix = DOMMatrix` (imported from `@napi-rs/canvas`) before importing `pdfjs-dist`, alongside the existing `Path2D` polyfill. This ensures both `new Path2D()` and `new DOMMatrix()` inside pdfjs use the same compatible implementation.

## Test plan

- [ ] Run `node scripts/volunteer.mjs --my-handle=<handle> --slice=5` on Windows with a PDF that has transparency groups (e.g., `1949-discs.pdf`)
- [ ] Confirm no `beginGroup` RENDER errors in output
- [ ] Confirm `ok=N err=0` in final summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)