### PR TITLE
fix(chatgpt-driver): update attachment selector for ChatGPT UI ≥ May 2026

### DIFF
--- a/pursue-vision-mcp/chatgpt-driver.mjs
+++ b/pursue-vision-mcp/chatgpt-driver.mjs
@@ -135,6 +135,7 @@ export class ChatGPTDriver {
           '[data-testid="file-attachment"]',
           '[data-testid^="file-attachment"]',
           'button[aria-label*="Remove attachment"]',
+          'button[aria-label*="Remove file"]',   // ChatGPT UI ≥ May 2026: "Remove file N: name.png"
           'div[aria-label*="attachment"]',
         ];
         for (const s of sels) {


### PR DESCRIPTION
## Summary

ChatGPT changed the aria-label on the "remove file" button from `"Remove attachment"` to `"Remove file N: filename.png"`. The upload-indicator polling loop timed out because none of the existing selectors matched, causing every OCR request to fail with:

> `upload indicator did not show 1 attachment(s) within 24000ms`

The file upload itself was working — only the detection was broken.

## Fix

Added `'button[aria-label*="Remove file"]'` to the selector list in `_uploadFiles()`. The old `"Remove attachment"` selector is kept for backwards compatibility.

## Test plan

- [ ] Run `volunteer.mjs --slice=3` — confirm `ok=3 err=0` and no upload-indicator timeout errors
- [ ] Verify selectors still work if ChatGPT reverts to old label

🤖 Generated with [Claude Code](https://claude.com/claude-code)