### PR TITLE
Volunteer work leasing (R7): design + brutal analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,11 +83,50 @@ Ideas surfaced during 2.0 + 2.1 work that are worth pursuing if/when someone has
 
 - **Article-level segmentation for newspaper clippings.** When a page is `kind: newspaper-clipping`, currently the volunteer just transcribes the article body into `article_text`. A future pass could segment the page into per-article bounding boxes via vision and emit one media row per article, so a single newspaper page lights up SEARCH for multiple distinct stories.
 - **Per-source quality reports surfaced in REVIEW.** The `data-raw/.source-quality.json` log accumulates vs-human gold scores per source. Once human-typed pages exist, REVIEW could show "Gemini scored 0.91 mean vs human across N pages; GPT-vision scored 0.87 across M pages." Helps a volunteer decide which provider's transcript to trust on a given page.
-- **Auto-claim-then-warn for stale claims.** Right now the volunteer rotation is deterministic per handle (hash). If two volunteers run at the same time they might overlap. A claim file in `public/claims/<handle>.json` with a TTL would let the script skip pages another volunteer already claimed in the last hour.
+- **Auto-claim-then-warn for stale claims.** Right now the volunteer rotation is deterministic per handle (hash). If two volunteers run at the same time they might overlap. A claim file in `public/claims/<handle>.json` with a TTL would let the script skip pages another volunteer already claimed in the last hour. **Now scoped in full — see R7 and [design/VOLUNTEER-LEASING.md](./design/VOLUNTEER-LEASING.md).**
 - **A "what changed" feed on the corpus-stats freshness strip.** Currently just "refreshed Nm ago"; could show "+3 vision pages from @volunteer, +2 disputes settled by reeval, +1 media context from @anotherperson."
 - **Per-event coverage page in the UI.** `npm run corpus:coverage` exists as a CLI report; could become a tab showing the matrix visually (this many events fully covered · this many have gaps · this many have mismatches).
 - **Make the FAISS rebuild incremental.** Right now it regenerates the entire 384-D index every time. With 3,300+ chunks and growing, an incremental "embed only new chunks, append to existing index" approach would scale better.
 
 ---
 
-_Updated 2026-05-19 alongside 2.1 release. To propose a new roadmap item, open an issue with the `roadmap` label._
+## R7 · Volunteer work leasing (claim tracking + stale reclaim)
+
+**Status:** DESIGNED, not built. Full design + brutal analysis in
+[design/VOLUNTEER-LEASING.md](./design/VOLUNTEER-LEASING.md).
+
+**Request:** a live-tracking server that records who's working on which page and
+auto-reassigns a page to the next volunteer after a configurable timeout
+(default 10 min, set in admin settings).
+
+**Verdict (see design doc for the full argument):** the *need* — don't let two
+volunteers duplicate a page; don't let a claim sit forever — is real and already
+flagged in R6. The *requested implementation* (an always-on, authenticated,
+admin-configurable tracking server) is the wrong order for a static-site /
+fork-and-PR project that deliberately has no backend, no auth, and promises *"no
+central server holds your work."* A lease here can only ever be advisory
+(submission is a GitHub PR, which knows nothing about leases), and an advisory
+lease needs a **file, not a server**. The 10-minute timeout is also
+mis-calibrated: real work units run 30 min (OCR slice) to days (visuals
+claim→fill→commit), so a 10-min reassign would *cause* duplicate PRs.
+
+**Phased plan:**
+1. **Phase 0 — local dedup (done).** Volunteer scripts skip pages that already
+   have a local contribution/staged template. Killed the "re-serves the same
+   lot" bug. Zero infra.
+2. **Phase 1 — static claims ledger (recommended next).** `public/claims/<eid>/p<NNN>.json`
+   with `{handle, claimed_at, lease_secs}`; default lease **24h** (matched to the
+   real work unit), configurable via committed `config/leasing.json`. Delivers
+   tracking + expiry + reassignment + configurable timeout with no server, no
+   auth, no privacy regression. Ship when a *second* real volunteer exists (i.e.
+   after R1).
+3. **Phase 2 — serverless claim function (deferred behind a trigger).** A single
+   stateless Worker/KV endpoint, *only* once there are ≥5 concurrent volunteers
+   AND duplicate PRs are a measured maintainer burden AND Phase 1's git-latency
+   is demonstrably too slow. Still advisory; still never holds the work.
+
+**Owner:** revisit when R1 lands a second contributor.
+
+---
+
+_Updated 2026-05-20: added R7 (volunteer leasing) + design doc. To propose a new roadmap item, open an issue with the `roadmap` label._

--- a/design/VOLUNTEER-LEASING.md
+++ b/design/VOLUNTEER-LEASING.md
@@ -1,0 +1,216 @@
+# Volunteer Work Leasing — design + brutal analysis
+
+> **Status: PROPOSAL / not built.** This documents a requested feature — live
+> tracking of which volunteer is working on which page, with an auto-reassign
+> timeout — and then argues honestly about whether (and how) to build it.
+>
+> TL;DR: the *need* is real but small; the *requested implementation* (an
+> always-on tracking server with admin settings) is architecturally wrong for
+> this project. The right-sized fix is a static claims file with a TTL, with a
+> serverless function as a later escalation only if real concurrency appears.
+
+---
+
+## 1. The request
+
+> "When things check in there should be a server component that does live
+> tracking of what volunteers are working on. If they take too long the job
+> goes to the next person after a 10-minute period, but that's configurable in
+> the admin settings."
+
+Decomposed, this asks for four things:
+
+1. **Live claim tracking** — a central record of `{page → volunteer, claimed_at}`.
+2. **Lease expiry** — a claim auto-expires after a timeout (default 10 min).
+3. **Reassignment** — once expired, the page is free for the next volunteer.
+4. **Admin settings** — the timeout (and presumably other knobs) are configurable.
+
+The motivating problem is genuine: two volunteers can currently grab the same
+page, and a volunteer who claims pages then walks away leaves that work in
+limbo. This is already on the roadmap as R6 *"Auto-claim-then-warn for stale
+claims."*
+
+---
+
+## 2. What the architecture actually is today
+
+This matters because the request implicitly assumes a backend that does not
+exist.
+
+- **Hosting:** GitHub Pages. 100% static. No server process, no runtime, no
+  database, no auth. (`SQL-MIGRATION-ROADMAP.md` → *"Not a server-side
+  database. Stays static."*)
+- **Work distribution:** `scripts/build-work-available.mjs` runs at **build
+  time**, reads the maintainer's local `.vision-cache` / `.visuals`
+  directories, and writes a static `public/work-available.json`. Volunteers
+  `GET` that file. Nothing is POSTed back to any central service.
+- **Claiming:** there is no claim. `volunteer.mjs` / `volunteer-media.mjs` pick
+  pages by a deterministic rotation (`hash(handle) % docs`) plus a local
+  already-done skip. Two volunteers with different handles start at different
+  offsets; collisions are possible but not tracked.
+- **Completion path:** claim → OCR/render locally → open a **PR** → maintainer
+  merges → maintainer regenerates `work-available.json` → the page leaves the
+  queue on the next deploy. **Latency from "done" to "queue updated" is hours,
+  gated on a human merge + rebuild.**
+- **Identity:** a handle is a self-asserted CLI flag (`--my-handle=foo`). There
+  are no accounts, no tokens, no way to *authenticate* that a claim belongs to
+  who it says.
+- **Privacy promise:** the volunteer modal states verbatim: *"You stay in your
+  own GitHub account; no central server holds your work."*
+
+The whole contribution model is **fork-and-PR**, the same as any open-source
+repo. There is deliberately no central authority.
+
+---
+
+## 3. Brutal analysis
+
+### 3.1 The requested implementation fights the architecture
+
+A live-tracking lease **server** introduces, in a project that has none of
+these today:
+
+| New requirement | Cost |
+|---|---|
+| An always-on host | Money + uptime + a thing that can go down and block all volunteers |
+| Authentication | Handles are self-asserted. To trust a lease you need accounts/tokens — a login system the project explicitly avoids |
+| Volunteers phoning home | The CLI currently only does a `GET` of a static JSON. Now every run POSTs claims/heartbeats to a central service — directly contradicting *"no central server holds your work"* |
+| Admin settings UI + storage | A settings store, an admin auth boundary, a UI. More server. |
+| A new single point of failure | If the lease server is down, can volunteers work? If "yes," the lease is advisory and you didn't need the server. If "no," you just made a static, resilient system fragile. |
+
+That last row is the crux. **A lease is only enforceable if the work submission
+goes through the same authority that issued the lease.** But submission here is
+a GitHub PR — GitHub is the authority, and it has no idea about your lease. So
+the lease can never be more than *advisory*. And an advisory lease does not need
+a server — a file does.
+
+### 3.2 The problem is real but tiny at current scale
+
+- Concurrent volunteers right now: ~1 (the maintainer). R1 on the roadmap is
+  *"get literally one outside person to run the flow end-to-end"* — that is the
+  honest contributor count.
+- Collision probability with a deterministic per-handle rotation offset is
+  already low. Two volunteers collide only if they (a) run simultaneously and
+  (b) their hash offsets land on overlapping doc ranges within a slice.
+- The duplication cost when it *does* happen is one wasted OCR/render — minutes
+  of compute, then the second PR is a no-op the maintainer closes. Annoying,
+  not expensive.
+
+Building an always-on, authenticated, admin-configurable lease server to
+prevent occasional minutes-of-wasted-compute for a contributor base of ~1 is
+textbook over-engineering. It is solving a scaling problem the project does not
+yet have, at the cost of the simplicity that is currently its biggest asset.
+
+### 3.3 The 10-minute timeout is mis-calibrated for the real flow
+
+A 10-minute lease assumes a unit of work takes < 10 minutes and "abandonment"
+is detectable in that window. But:
+
+- An OCR slice of 20 pages can take ~30 minutes (the modal literally says
+  *"~30 min of mostly-idle compute"*).
+- The visuals flow is **claim → human reads/edits context → commit**, which can
+  legitimately span hours or days (you stage templates, fill them when you have
+  time).
+- The real "page is taken" signal isn't a heartbeat — it's an **open PR**.
+
+So a 10-minute reassign would actively *cause* the duplication it's meant to
+prevent: volunteer A claims a 20-page OCR slice, is 12 minutes into honest work,
+the lease expires, volunteer B grabs the same pages, and now they *both* finish
+and open competing PRs. The timeout has to be matched to the real work unit, and
+the real work unit is "until a PR appears," which is unbounded.
+
+### 3.4 What's genuinely worth solving
+
+Strip the request to its real kernel and two things are worth doing:
+
+1. **Don't let two volunteers start the same page if one already has it in
+   flight.** (Soft collision avoidance.)
+2. **Don't let a page sit "claimed" forever if the claimer never ships.**
+   (Stale-claim reclamation.)
+
+Neither requires a server. Both are R6's *"claim file in
+`public/claims/<handle>.json` with a TTL"* idea, which the maintainer already
+scoped.
+
+---
+
+## 4. Right-sized design (recommended)
+
+### Phase 0 — *already shipped in this work*
+
+Local already-done dedup: the volunteer scripts skip any page that already has a
+local contribution/staged template, so a single volunteer stops re-claiming
+their own merged-but-not-yet-regenerated work. (This was the actual bug behind
+"it re-served the same lot.") **Zero infra.**
+
+### Phase 1 — static claims ledger (recommended next; no server)
+
+A claim is a tiny JSON committed to the repo (or written to a Pages-hosted
+side-channel) under `public/claims/`:
+
+```
+public/claims/<eid>/p<NNN>.json
+{ "handle": "alice", "claimed_at": 1716200000, "lease_secs": 86400, "phase": "ocr" }
+```
+
+- **Claiming** = the volunteer script writes the file and opens (or amends) a
+  lightweight "claims" PR, OR posts it to a claims branch. Reading the queue, a
+  volunteer skips any page with a *non-expired* claim by someone else.
+- **Lease expiry** = `now > claimed_at + lease_secs`. Expired claims are
+  ignored (and garbage-collected by the build). **Default lease 24h, not 10
+  min** — matched to the real "until a PR appears" work unit, configurable per
+  run via `--lease-hours`.
+- **Reassignment** = automatic and implicit: an expired claim simply stops
+  being honored. No server decides anything.
+- **Admin settings** = a committed `config/leasing.json`
+  (`{ default_lease_secs, gc_after_secs }`) read at build time. Versioned,
+  reviewable, no admin server.
+
+This delivers all four requested behaviors (tracking, expiry, reassignment,
+configurable timeout) with **no always-on infrastructure, no auth system, and
+no breach of the "no central server holds your work" promise.** The trade-off
+is that claims propagate at git/Pages latency (minutes), not real-time — which
+is fine, because the work units are tens of minutes to days.
+
+### Phase 2 — serverless claim function (only if real concurrency appears)
+
+*Trigger criteria (do NOT build before these are true):*
+
+- Sustained **≥ 5 concurrent active volunteers**, AND
+- Observed duplicate-PR rate high enough that closing them is a real maintainer
+  burden, AND
+- Phase 1's git-latency claims are demonstrably too slow to prevent collisions.
+
+Then, and only then, a **single stateless serverless function** (Cloudflare
+Worker / Netlify / GitHub Actions `repository_dispatch`) backed by a KV store:
+
+- `POST /claim {eid, page, handle}` → returns `{granted, until}` or `{taken_by}`.
+- `POST /heartbeat` → extends the lease (for genuinely long single-page work).
+- TTL handled by KV expiry; admin config in the same KV namespace.
+- **Still advisory** — submission stays PR-based; the function only *coordinates*.
+
+This is the closest thing to the user's "server component," but it is an
+escalation gated on evidence, not a day-one build. And even here it's a
+function, not a standing server, and it never holds the volunteer's work.
+
+---
+
+## 5. Recommendation
+
+**Do not build the always-on tracking server now.** Ship Phase 1 (static claims
+ledger with a 24h default lease, configurable via committed config) when a
+*second* real volunteer exists — i.e., when R1 is satisfied and collisions
+become possible in practice. Keep Phase 2 (serverless function) on the shelf
+behind the explicit concurrency trigger above.
+
+Building the server first would trade the project's defining strength —
+zero-infra, resilient, private, fork-and-PR — for a coordination layer aimed at
+a scale the project is nowhere near. The honest move is to fix the real bug
+(done: dedup), document the lease design (this doc), and wait for evidence
+before adding infrastructure.
+
+---
+
+_Companion to [ROADMAP.md](../ROADMAP.md) R6. Supersedes the one-line R6 bullet
+"Auto-claim-then-warn for stale claims" with a phased plan + the analysis of
+why the server-first version is the wrong order._


### PR DESCRIPTION
## Summary

Scopes the requested **live volunteer work-tracking server** (record who holds which page; auto-reassign after a configurable 10-min timeout) — and argues honestly about whether/how to build it.

- Adds `design/VOLUNTEER-LEASING.md` (full design + brutal analysis + phased plan)
- Adds **ROADMAP R7** and links the R6 stale-claims bullet to it

## Brutal analysis (verdict)

The *need* is real and already on the roadmap (R6): don't let two volunteers duplicate a page; don't let a claim sit forever. But the *requested implementation* — an always-on, authenticated, admin-configurable tracking **server** — is the wrong order for this project:

- **It fights the architecture.** Hosting is 100% static GitHub Pages. No backend, no auth, no DB server. `work-available.json` is built locally and served static; volunteers only `GET` it and submit via **PR**. The volunteer modal promises *"no central server holds your work."*
- **A lease here can only be advisory.** Submission is a GitHub PR — GitHub is the authority and knows nothing about a lease. An advisory lease needs a **file, not a server**. If the server being down still lets volunteers work, you didn't need it; if it doesn't, you made a resilient system fragile.
- **The problem is tiny at current scale.** Concurrent volunteers ~= 1 (R1 is literally "get one outside person to run the flow"). A collision wastes minutes of compute, not money.
- **10 min is mis-calibrated.** Real work units run ~30 min (OCR slice) to days (visuals claim->fill->commit). A 10-min reassign would *cause* duplicate PRs.

## Phased plan

- **Phase 0 - local dedup (done in the volunteer-console work):** scripts skip pages that already have a local contribution/staged template. Killed the "re-serves the same lot" bug. Zero infra.
- **Phase 1 - static claims ledger (recommended next):** `public/claims/<eid>/p<NNN>.json` with `{handle, claimed_at, lease_secs}`; default lease **24h**, configurable via committed `config/leasing.json`. Delivers tracking + expiry + reassignment + configurable timeout, no server, no auth, no privacy regression. Ship when a *second* real volunteer exists.
- **Phase 2 - serverless claim function (deferred behind a trigger):** a single stateless Worker/KV endpoint, only once >=5 concurrent volunteers AND measured duplicate-PR burden AND Phase-1 git-latency proven too slow. Still advisory; still never holds the work.

## Recommendation

Don't build the always-on server now. Fix the real bug (done: dedup), land the design (this PR), ship Phase 1 when concurrency is possible, keep Phase 2 on the shelf behind an explicit trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)