### PR TITLE
feat(volunteer-client): full volunteer instrument cockpit + monitor

### DIFF
--- a/pursue-vision-mcp/README.md
+++ b/pursue-vision-mcp/README.md
@@ -78,6 +78,54 @@ PURSUE_VISION_TOKEN=$(cat ~/.pursue-vision-token) \
 
 That's it. The pipeline handles rendering, pacing, batching, retries, and caching. The daemon's only job is being the ChatGPT messenger.
 
+## Volunteer cockpit (`monitor.mjs`)
+
+A **separate, optional process** from the OCR daemon. It owns the volunteer-facing
+progress UI — the "PURSUE · Volunteer Instrument" dashboard — so the daemon (9223)
+stays single-responsibility (its only job is OCR).
+
+```bash
+node pursue-vision-mcp/monitor.mjs            # HTTP on :9224 + auto-open browser
+node pursue-vision-mcp/monitor.mjs --no-open  # HTTP only, don't open a browser
+node pursue-vision-mcp/monitor.mjs --tui      # terminal dashboard instead of HTTP
+```
+
+Then open <http://localhost:9224/dashboard>.
+
+What it does:
+
+- **Serves the cockpit** (`dashboard.html`) at `/` and `/dashboard`, re-read fresh on
+  every request, plus local PNG page previews on `/preview/<base64-path>` (path-jailed
+  to home + cwd).
+- **Persists state** to `~/.pursue-helper/progress.json` so it can show last-known
+  progress even when nothing is running. `volunteer.mjs` pushes live updates via
+  `POST /progress` (bearer-authed when `PURSUE_MONITOR_TOKEN` is set).
+- **Launches work runs** from the dashboard via `POST /run` / `POST /run-any`. Modes:
+  `ocr` and `review` (→ `scripts/volunteer.mjs`), `visuals` (claim) and
+  `visuals-commit` (→ `scripts/volunteer-media.mjs`), and `doc` (a single document).
+- **Loop mode** keeps `ocr`/`review`/`doc` runs going until the queue is empty.
+  The `visuals` *claim* phase is intentionally **one-shot, never looped** — it only
+  stages templates that still need a separate commit step, so auto-relooping it would
+  just re-claim the same pages forever.
+- **Prefers the local work queue.** If `public/work-available.json` exists (freshly
+  built by `scripts/build-work-available.mjs`) the cockpit and the workers it spawns
+  use it instead of the GitHub Pages copy, which can lag hours behind.
+
+### Monitor endpoints (port 9224)
+
+| Method · path        | Purpose                                                        |
+|----------------------|----------------------------------------------------------------|
+| `GET /progress`      | Current `progress.json` state (idle / now / slice / corpus).   |
+| `POST /progress`     | Live update from a running worker (bearer-authed if token set).|
+| `GET /running`       | `{ running, meta, log, lastRun }` for the active/last run.     |
+| `POST /run`          | Start a run: `{ mode, eid?, slice?, loop?, handle }`.          |
+| `POST /run-any`      | Auto-pick the first queue with fresh work and run it.          |
+| `POST /stop`         | Stop the current run (also clears loop so it won't restart).   |
+| `GET /daemon-health` | Whether the OCR daemon on `:9223` is reachable.                |
+
+Env: `PURSUE_MONITOR_PORT` (default `9224`), `PURSUE_HELPER_DIR` (default
+`~/.pursue-helper`), `PURSUE_MONITOR_TOKEN` (if set, required on `POST /progress`).
+
 ## API
 
 ### `POST /chat-with-files`
@@ -167,8 +215,10 @@ This is a focused release. It does NOT include:
 - Multi-LLM fan-out (Claude / Gemini / Kimi / local)
 - Browser automation for other sites
 - Persistent chat threads or context
-- A dashboard / UI
 - An MCP-protocol stdio interface (despite the name — this is HTTP-only here)
+
+(The optional volunteer cockpit — `monitor.mjs` on :9224, documented above — does add
+a progress UI, but the OCR daemon itself stays headless.)
 
 If you want a fuller toolkit, the parent project's maintainer uses a more extensive private MCP. This release is the OCR-only slice anyone can run.
 

--- a/pursue-vision-mcp/dashboard.html
+++ b/pursue-vision-mcp/dashboard.html
@@ -150,6 +150,166 @@
   .completion .stat  { font-size: 11px; letter-spacing: 0.3em; margin-top: 12px; }
   .completion .sub   { font-size: 9px; color: var(--green-dim); margin-top: 6px; letter-spacing: 0.05em; }
 
+  /* WORK QUEUE SECTION */
+  .queue-section { margin-top: 56px; }
+  .queue-rule { height: 1px; background: var(--hair); }
+  .queue-header {
+    display: flex; align-items: baseline; justify-content: space-between;
+    font-size: 11px; letter-spacing: 0.3em; color: var(--green-dim);
+    margin: 18px 0 22px;
+  }
+  .queue-header .total-badge {
+    font-size: 28px; font-weight: 700; line-height: 1;
+    font-variant-numeric: tabular-nums; color: var(--green);
+  }
+  .queue-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; }
+  .queue-panel {
+    border-top: 1px solid var(--hair); padding-top: 16px;
+  }
+  .queue-panel .q-cap {
+    display: flex; align-items: baseline; justify-content: space-between;
+    font-size: 10px; letter-spacing: 0.3em; margin-bottom: 12px;
+  }
+  .queue-panel .q-count { font-size: 32px; font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; }
+  .queue-panel .q-desc { font-size: 9px; color: var(--green-dim); margin-bottom: 14px; letter-spacing: 0.05em; }
+  .queue-doc { display: flex; align-items: flex-start; gap: 8px; padding: 5px 0; border-bottom: 1px solid rgba(22,56,42,0.4); }
+  .queue-doc:last-child { border-bottom: none; }
+  .queue-doc .dot { width: 5px; height: 5px; border-radius: 50%; margin-top: 5px; flex-shrink: 0; }
+  .queue-doc .doc-id { font-size: 9px; letter-spacing: 0.05em; flex: 1; min-width: 0; }
+  .queue-doc .doc-id .eid { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .queue-doc .doc-id .pages { display: block; font-size: 8px; margin-top: 2px; opacity: 0.5; letter-spacing: 0.08em; }
+  .queue-doc .doc-n { font-size: 11px; font-variant-numeric: tabular-nums; flex-shrink: 0; }
+  .queue-empty { font-size: 9px; letter-spacing: 0.2em; opacity: 0.3; }
+  .queue-ts { font-size: 8px; color: var(--green-dim); margin-top: 18px; letter-spacing: 0.05em; opacity: 0.5; }
+  .coverage-bar { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--hair); }
+  .coverage-bar .cov-cap { font-size: 10px; letter-spacing: 0.3em; color: var(--green-dim); margin-bottom: 6px; }
+  .coverage-bar .cov-nums { display: flex; justify-content: space-between; font-size: 9px; color: var(--green-dim); margin-bottom: 4px; }
+  .coverage-bar .bar { height: 4px; background: var(--ghost); position: relative; overflow: hidden; }
+  .coverage-bar .bar .fill { height: 100%; background: var(--green); transition: width 600ms var(--ease-out); }
+
+  /* CONTROLS */
+  .controls-section { margin-top: 56px; }
+  .controls-rule { height: 1px; background: var(--hair); }
+  .controls-header { font-size: 11px; letter-spacing: 0.3em; color: var(--green-dim); margin: 18px 0 22px; }
+  .controls-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+  .ctrl-panel { border-top: 1px solid var(--hair); padding-top: 16px; }
+  .ctrl-panel .ctrl-cap { font-size: 10px; letter-spacing: 0.3em; color: var(--green-dim); margin-bottom: 14px; }
+  .ctrl-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-bottom: 10px; }
+  .ctrl-label { font-size: 9px; letter-spacing: 0.2em; color: var(--green-dim); width: 60px; flex-shrink: 0; }
+  select, input[type=text], input[type=number] {
+    background: var(--bg-deep); color: var(--green);
+    border: 1px solid var(--hair); font-family: inherit; font-size: 11px;
+    padding: 4px 8px; outline: none; appearance: none;
+    letter-spacing: 0.05em;
+  }
+  select:focus, input:focus { border-color: var(--green-dim); }
+  select { cursor: pointer; }
+  .ctrl-btn {
+    font-family: inherit; font-size: 10px; letter-spacing: 0.25em;
+    padding: 5px 16px; border: 1px solid; cursor: pointer;
+    background: transparent; transition: background 0.15s;
+  }
+  .ctrl-btn.start { color: var(--green); border-color: var(--green-dim); }
+  .ctrl-btn.start:hover { background: rgba(124,255,178,0.08); }
+  .ctrl-btn.start:disabled { opacity: 0.3; cursor: not-allowed; }
+  .ctrl-btn.stop  { color: var(--rose);  border-color: rgba(255,107,157,0.4); }
+  .ctrl-btn.stop:hover  { background: rgba(255,107,157,0.08); }
+  .ctrl-btn.stop:disabled  { opacity: 0.3; cursor: not-allowed; }
+
+  /* PR QUEUE */
+  .pr-section { margin-top: 48px; }
+  .pr-row {
+    display: grid; grid-template-columns: 50px 1fr auto auto auto;
+    gap: 12px; align-items: center;
+    border: 1px solid var(--hair); padding: 10px 14px;
+    transition: background 0.15s;
+  }
+  .pr-row:hover { background: rgba(124,255,178,0.03); }
+  .pr-num { font-size: 14px; color: var(--green); letter-spacing: 0.05em; }
+  .pr-title { font-size: 11px; color: var(--green); letter-spacing: 0.05em; line-height: 1.4; }
+  .pr-meta { font-size: 9px; color: var(--green-dim); letter-spacing: 0.1em; margin-top: 2px; }
+  .pr-status { font-size: 9px; letter-spacing: 0.18em; padding: 3px 8px; border: 1px solid; }
+  .pr-status.ok    { color: var(--green); border-color: var(--green-dim); }
+  .pr-status.fail  { color: var(--rose);  border-color: rgba(255,107,157,0.4); }
+  .pr-status.wait  { color: var(--amber); border-color: rgba(255,217,61,0.4); }
+  .pr-status.unk   { color: var(--green-dim); border-color: var(--hair); }
+  .pr-merge {
+    font-family: inherit; font-size: 10px; letter-spacing: 0.2em;
+    padding: 5px 14px; cursor: pointer; background: transparent;
+    color: var(--green); border: 1px solid var(--green-dim);
+    transition: background 0.15s;
+  }
+  .pr-merge:hover:not(:disabled) { background: rgba(124,255,178,0.08); }
+  .pr-merge:disabled { opacity: 0.3; cursor: not-allowed; }
+  .pr-merge.busy { color: var(--amber); border-color: rgba(255,217,61,0.5); }
+  .pr-link {
+    font-size: 9px; letter-spacing: 0.2em; color: var(--green-dim);
+    text-decoration: none; padding: 4px 8px; border: 1px solid var(--hair);
+  }
+  .pr-link:hover { color: var(--green); border-color: var(--green-dim); }
+
+  /* LAST RUN BANNER */
+  .last-run {
+    border: 1px solid; padding: 14px 18px; margin-bottom: 18px;
+    display: flex; gap: 16px; align-items: flex-start;
+  }
+  .last-run .lr-icon { font-size: 18px; line-height: 1; padding-top: 2px; }
+  .last-run .lr-body { flex: 1; min-width: 0; }
+  .last-run .lr-head { font-size: 12px; letter-spacing: 0.18em; margin-bottom: 4px; }
+  .last-run .lr-detail { font-size: 10px; letter-spacing: 0.05em; line-height: 1.55; color: var(--green-dim); }
+  .last-run .lr-meta { font-size: 9px; letter-spacing: 0.12em; color: var(--green-dim); margin-top: 6px; opacity: 0.8; }
+  .last-run.success { border-color: var(--green-dim); background: rgba(124,255,178,0.04); }
+  .last-run.success .lr-head, .last-run.success .lr-icon { color: var(--green); }
+  .last-run.noop    { border-color: rgba(130,182,255,0.4); background: rgba(130,182,255,0.04); }
+  .last-run.noop    .lr-head, .last-run.noop .lr-icon { color: var(--cyan); }
+  .last-run.error   { border-color: rgba(255,107,157,0.5); background: rgba(255,107,157,0.04); }
+  .last-run.error   .lr-head, .last-run.error .lr-icon { color: var(--rose); }
+  .last-run.stopped { border-color: var(--amber-dim); background: rgba(255,217,61,0.04); }
+  .last-run.stopped .lr-head, .last-run.stopped .lr-icon { color: var(--amber); }
+
+  /* QUICK LAUNCH — direct CLI task buttons */
+  .quick-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 10px; margin-bottom: 20px;
+  }
+  .quick-btn {
+    font-family: inherit; cursor: pointer; text-align: left;
+    background: transparent; padding: 12px 14px;
+    border: 1px solid var(--hair); transition: all 0.15s;
+    display: flex; flex-direction: column; gap: 4px;
+  }
+  .quick-btn:hover:not(:disabled) { background: rgba(124,255,178,0.04); }
+  .quick-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+  .quick-btn .qb-title { font-size: 11px; letter-spacing: 0.18em; }
+  .quick-btn .qb-sub   { font-size: 9px; letter-spacing: 0.08em; color: var(--green-dim); }
+  .quick-btn .qb-cmd   { font-size: 9px; color: var(--green-dim); opacity: 0.7; margin-top: 2px; font-family: 'IBM Plex Mono', monospace; }
+  .quick-btn.ocr     { color: var(--green);  border-color: var(--green-dim); }
+  .quick-btn.review  { color: var(--amber);  border-color: rgba(255,217,61,0.35); }
+  .quick-btn.review:hover:not(:disabled)  { background: rgba(255,217,61,0.06); }
+  .quick-btn.visuals { color: var(--cyan);   border-color: rgba(130,182,255,0.35); }
+  .quick-btn.visuals:hover:not(:disabled) { background: rgba(130,182,255,0.06); }
+  .quick-btn.loop    { color: var(--rose);   border-color: rgba(255,107,157,0.35); }
+  .quick-btn.loop:hover:not(:disabled)    { background: rgba(255,107,157,0.06); }
+  .ctrl-status { font-size: 9px; letter-spacing: 0.15em; margin-top: 10px; }
+  .ctrl-status.running { color: var(--green); }
+  .ctrl-status.idle    { color: var(--green-dim); }
+  .ctrl-status.err     { color: var(--rose); }
+  .ctrl-toggle { display: flex; align-items: center; gap: 8px; font-size: 9px; letter-spacing: 0.2em; color: var(--green-dim); cursor: pointer; }
+  .ctrl-toggle input[type=checkbox] { accent-color: var(--amber); width: 13px; height: 13px; cursor: pointer; }
+
+  /* LOG */
+  .log-panel { border-top: 1px solid var(--hair); padding-top: 16px; }
+  .log-cap { font-size: 10px; letter-spacing: 0.3em; color: var(--green-dim); margin-bottom: 10px; }
+  .log-box {
+    background: var(--bg-deep); border: 1px solid var(--hair);
+    padding: 10px 12px; height: 160px; overflow-y: auto;
+    font-size: 10px; line-height: 1.6; color: var(--green-dim);
+  }
+  .log-box .l-ok   { color: var(--green); }
+  .log-box .l-err  { color: var(--rose); }
+  .log-box .l-warn { color: var(--amber); }
+  .log-box .l-info { color: var(--cyan); }
+
   /* FOOTER */
   .footer { margin-top: 48px; }
   .footer-line { font-size: 11px; letter-spacing: 0.3em; color: var(--amber-dim); text-align: center; padding: 20px 0 4px; }
@@ -175,6 +335,7 @@
     <div class="status-line">
       <span class="pulse-dot" id="status-dot"></span>
       <span id="status-text">CONNECTING</span>
+      <span id="daemon-badge" style="margin-left:10px;font-size:9px;letter-spacing:0.18em;padding:2px 8px;border:1px solid var(--hair);color:var(--green-dim)"></span>
     </div>
   </div>
 </div>
@@ -246,6 +407,180 @@
   <div class="bottom-cap">L A S T &nbsp; S I X &nbsp; C O M P L E T I O N S</div>
   <div class="completions" id="completions">
     <!-- populated by JS -->
+  </div>
+</div>
+
+<!-- WORK QUEUE -->
+<div class="queue-section">
+  <div class="queue-rule"></div>
+  <div class="queue-header">
+    <span>W O R K &nbsp; Q U E U E &nbsp; · &nbsp; O P E N &nbsp; P A G E S</span>
+    <span class="total-badge" id="q-total">—</span>
+  </div>
+
+  <div class="coverage-bar">
+    <div class="cov-cap">C O R P U S &nbsp; C O V E R A G E</div>
+    <div class="cov-nums">
+      <span id="q-catalogued">—</span>
+      <span id="q-inventory">— total · — %</span>
+    </div>
+    <div class="bar"><div class="fill" id="q-cov-fill" style="width:0%"></div></div>
+  </div>
+
+  <div class="queue-grid" style="margin-top: 28px;">
+    <!-- OCR queue -->
+    <div class="queue-panel">
+      <div class="q-cap" style="color: var(--green);">
+        <span>O C R &nbsp; Q U E U E</span>
+        <span class="q-count" id="q-ocr-count" style="color: var(--green);">—</span>
+      </div>
+      <div class="q-desc">first-pass transcription needed</div>
+      <div id="q-ocr-docs"></div>
+    </div>
+
+    <!-- Review queue -->
+    <div class="queue-panel">
+      <div class="q-cap" style="color: var(--amber);">
+        <span>R E V I E W &nbsp; Q U E U E</span>
+        <span class="q-count" id="q-rev-count" style="color: var(--amber);">—</span>
+      </div>
+      <div class="q-desc">disputed pages — sources disagree</div>
+      <div id="q-rev-docs"></div>
+    </div>
+
+    <!-- Visuals queue -->
+    <div class="queue-panel">
+      <div class="q-cap" style="color: var(--cyan);">
+        <span>V I S U A L S &nbsp; Q U E U E</span>
+        <span class="q-count" id="q-vis-count" style="color: var(--cyan);">—</span>
+      </div>
+      <div class="q-desc">title + context needed for images</div>
+      <div id="q-vis-docs"></div>
+    </div>
+  </div>
+
+  <div class="queue-ts" id="q-ts"></div>
+</div>
+
+<!-- PR QUEUE — open contributions waiting to merge -->
+<div class="pr-section">
+  <div class="controls-rule"></div>
+  <div class="controls-header">
+    Y O U R &nbsp; O P E N &nbsp; P R s &nbsp; · &nbsp; M E R G E &nbsp; T O &nbsp; U N B L O C K &nbsp; T H E &nbsp; Q U E U E
+    <button class="ctrl-btn start" style="float:right;font-size:9px;padding:3px 10px" onclick="fetchPRs()">↻ refresh</button>
+  </div>
+  <div id="pr-list" style="display:flex;flex-direction:column;gap:8px">
+    <div style="color:var(--green-dim);font-size:10px">loading…</div>
+  </div>
+  <div class="queue-ts" id="pr-ts" style="margin-top:10px"></div>
+</div>
+
+<!-- CONTROLS -->
+<div class="controls-section">
+  <div class="controls-rule"></div>
+  <div class="controls-header">C O N T R O L S &nbsp; · &nbsp; D I S P A T C H &nbsp; W O R K</div>
+
+  <!-- LAST RUN OUTCOME — shown for ~10s after every run -->
+  <div id="last-run-banner" class="last-run" style="display:none"></div>
+
+  <!-- QUICK LAUNCH — one click per CLI task -->
+  <div style="font-size:10px;letter-spacing:0.3em;color:var(--green-dim);margin-bottom:10px">Q U I C K &nbsp; L A U N C H</div>
+  <div class="quick-grid">
+    <button id="qb-auto" class="quick-btn ocr" data-needs="any" onclick="quickAuto()" title="Auto-pick whichever queue has fresh work" style="grid-column: span 3; border-color: var(--green); background: rgba(124,255,178,0.04)">
+      <span class="qb-title" style="font-size:13px">▶▶ &nbsp; T A K E &nbsp; A N Y &nbsp; J O B &nbsp; (auto-pick fresh queue)</span>
+      <span class="qb-sub qb-count">checks OCR → REVIEW → VISUALS, picks the first with pages you haven't submitted yet</span>
+    </button>
+    <button id="qb-ocr" class="quick-btn ocr" data-needs="ocr" onclick="quickRun('ocr', false)" title="One-shot OCR pass">
+      <span class="qb-title">▶ TAKE OCR JOB</span>
+      <span class="qb-sub qb-count">first-pass transcription · one slice</span>
+      <span class="qb-cmd">volunteer.mjs --slice=20</span>
+    </button>
+    <button id="qb-review" class="quick-btn review" data-needs="review" onclick="quickRun('review', false)" title="One-shot review pass">
+      <span class="qb-title">▶ TAKE REVIEW JOB</span>
+      <span class="qb-sub qb-count">settle disputed pages · one slice</span>
+      <span class="qb-cmd">volunteer.mjs --review</span>
+    </button>
+    <button id="qb-visuals" class="quick-btn visuals" data-needs="visuals" onclick="quickRun('visuals', false)" title="Claim visuals pages — renders PNGs + daemon drafts the context">
+      <span class="qb-title">▶ TAKE VISUALS JOB</span>
+      <span class="qb-sub qb-count">render + auto-draft context · one slice</span>
+      <span class="qb-cmd">volunteer-media.mjs --auto-context</span>
+    </button>
+    <button id="qb-visuals-commit" class="quick-btn visuals" onclick="quickRun('visuals-commit', false)" title="Validate filled templates and stage the media contribution">
+      <span class="qb-title">✓ COMMIT VISUALS</span>
+      <span class="qb-sub">stage reviewed templates → contribution</span>
+      <span class="qb-cmd">volunteer-media.mjs --commit</span>
+    </button>
+    <button id="qb-ocr-loop" class="quick-btn ocr loop" data-needs="ocr" onclick="quickRun('ocr', true)" title="Loop OCR until queue empty">
+      <span class="qb-title">↻ LOOP OCR</span>
+      <span class="qb-sub qb-count">keep taking OCR jobs until empty</span>
+      <span class="qb-cmd">--slice=20 (looped)</span>
+    </button>
+    <button id="qb-review-loop" class="quick-btn review loop" data-needs="review" onclick="quickRun('review', true)" title="Loop review until queue empty">
+      <span class="qb-title">↻ LOOP REVIEW</span>
+      <span class="qb-sub qb-count">keep settling disputes until empty</span>
+      <span class="qb-cmd">--review (looped)</span>
+    </button>
+    <button id="quick-stop" class="quick-btn stop" onclick="ctrlStop()" title="Stop any running task" style="color:var(--rose);border-color:rgba(255,107,157,0.4);display:none">
+      <span class="qb-title">■ STOP CURRENT</span>
+      <span class="qb-sub">halt the running job</span>
+      <span class="qb-cmd">SIGTERM</span>
+    </button>
+    <button class="quick-btn" onclick="cleanStubs()" title="Delete <50-byte stub files from failed runs (also auto-runs before each spawn)" style="color:var(--amber);border-color:rgba(255,217,61,0.35);grid-column: span 3">
+      <span class="qb-title">⌧ CLEAN STUB FILES</span>
+      <span class="qb-sub">deletes 0-byte placeholders left by failed runs so retries can actually happen · auto-runs before each spawn too</span>
+    </button>
+  </div>
+
+  <div class="controls-grid">
+    <!-- Launch panel -->
+    <div class="ctrl-panel">
+      <div class="ctrl-cap">L A U N C H &nbsp; A &nbsp; R U N &nbsp; ( advanced / specific doc )</div>
+
+      <div class="ctrl-row">
+        <span class="ctrl-label">HANDLE</span>
+        <input type="text" id="ctrl-handle" value="" placeholder="your-gh-handle" style="width:160px" />
+      </div>
+
+      <div class="ctrl-row">
+        <span class="ctrl-label">QUEUE</span>
+        <select id="ctrl-mode" style="width:160px">
+          <option value="ocr">OCR — first-pass transcription</option>
+          <option value="review">REVIEW — settle disputes</option>
+          <option value="visuals">VISUALS — image context</option>
+          <option value="doc">DOC — specific document</option>
+        </select>
+      </div>
+
+      <div class="ctrl-row" id="eid-row" style="display:none">
+        <span class="ctrl-label">DOC ID</span>
+        <select id="ctrl-eid" style="width:220px"></select>
+      </div>
+
+      <div class="ctrl-row">
+        <span class="ctrl-label">PAGES</span>
+        <input type="number" id="ctrl-slice" value="20" min="1" max="200" style="width:70px" />
+        <span style="font-size:9px;color:var(--green-dim);letter-spacing:0.1em">per run</span>
+      </div>
+
+      <div class="ctrl-row">
+        <label class="ctrl-toggle">
+          <input type="checkbox" id="ctrl-loop" />
+          LOOP — keep running until queue empty
+        </label>
+      </div>
+
+      <div class="ctrl-row" style="margin-top:6px; gap:12px">
+        <button class="ctrl-btn start" id="btn-start" onclick="ctrlStart()">▶ START</button>
+        <button class="ctrl-btn stop"  id="btn-stop"  onclick="ctrlStop()" disabled>■ STOP</button>
+      </div>
+      <div class="ctrl-status idle" id="ctrl-status">IDLE</div>
+    </div>
+
+    <!-- Log panel -->
+    <div class="log-panel">
+      <div class="log-cap">R U N N E R &nbsp; L O G</div>
+      <div class="log-box" id="log-box"><span style="opacity:0.3">awaiting run…</span></div>
+    </div>
   </div>
 </div>
 
@@ -396,6 +731,549 @@
   }
   poll();
   setInterval(poll, 1000);
+
+  // ---- work queue (fetched from GitHub Pages, refreshed every 5 min) ----
+  const WORK_URL = "https://rizzleroc.github.io/pursue-console/work-available.json";
+  const pad4 = n => String(n).padStart(4, "0");
+
+  function pageListStr(pages, max = 10) {
+    if (!pages?.length) return "";
+    const shown = pages.slice(0, max).map(p => "p" + pad4(p)).join("  ");
+    return pages.length > max ? shown + "  +" + (pages.length - max) + " more" : shown;
+  }
+
+  function renderQueueDocs(containerId, docs, field, dotColor) {
+    const el = $(containerId);
+    el.innerHTML = "";
+    const entries = docs.filter(([, d]) => d[field]?.length);
+    if (!entries.length) {
+      el.innerHTML = '<div class="queue-empty">&#10003; EMPTY</div>';
+      return;
+    }
+    entries.forEach(([eid, doc]) => {
+      const pages = doc[field];
+      const short = eid.replace(/^65-hs1-834228961-62-hq-83894-/, "§62hq-").replace(/^65-hs1-\d+-/, "§");
+      const row = document.createElement("div");
+      row.className = "queue-doc";
+      row.innerHTML = `
+        <div class="dot" style="background:${dotColor}"></div>
+        <div class="doc-id">
+          <span class="eid">${short}</span>
+          <span class="pages">${pageListStr(pages)}</span>
+        </div>
+        <div class="doc-n" style="color:${dotColor}">${pages.length}</div>
+      `;
+      el.appendChild(row);
+    });
+  }
+
+  async function fetchQueue() {
+    try {
+      const r = await fetch(WORK_URL + "?t=" + Date.now(), { cache: "no-store" });
+      if (!r.ok) return;
+      const data = await r.json();
+      const events = Object.entries(data.byEvent || {});
+
+      const totalOCR    = data.totalPagesNeeded ?? 0;
+      const totalReview = data.totalPagesNeedingReview ?? 0;
+      const totalVisual = data.totalPagesNeedingVisualContext ?? 0;
+      const totalWork   = totalOCR + totalReview + totalVisual;
+
+      $("q-total").textContent      = totalWork;
+      $("q-ocr-count").textContent  = totalOCR;
+      $("q-rev-count").textContent  = totalReview;
+      $("q-vis-count").textContent  = totalVisual;
+
+      const catalogued = data.cataloguedTotal ?? 0;
+      const inventory  = data.inventoryTotal  ?? 0;
+      const pct = inventory ? Math.round(catalogued / inventory * 100) : 0;
+      $("q-catalogued").textContent = catalogued.toLocaleString() + " catalogued";
+      $("q-inventory").textContent  = inventory.toLocaleString() + " total · " + pct + "%";
+      $("q-cov-fill").style.width   = pct + "%";
+
+      renderQueueDocs("q-ocr-docs",  events, "queue",                 "var(--green)");
+      renderQueueDocs("q-rev-docs",  events, "reviewQueue",           "var(--amber)");
+      renderQueueDocs("q-vis-docs",  events, "visualsNeedingContext", "var(--cyan)");
+
+      const gen = data.generatedAt ? new Date(data.generatedAt).toISOString().replace("T"," ").slice(0,19) + " UTC" : "";
+      $("q-ts").textContent = "queue generated " + gen + " · refreshes every 5 min";
+    } catch {}
+  }
+
+  fetchQueue();
+  setInterval(fetchQueue, 5 * 60 * 1000);
+
+  // ---- controls ----
+  let workQueue = null; // latest work-available data, kept for eid selector
+
+  // Populate doc selector when queue loads
+  const origFetchQueue = fetchQueue;
+  async function fetchQueueAndSync() {
+    try {
+      const r = await fetch(WORK_URL + "?t=" + Date.now(), { cache: "no-store" });
+      if (!r.ok) return;
+      workQueue = await r.json();
+      populateQueuePanel(workQueue);
+      populateEidSelector(workQueue);
+    } catch {}
+  }
+
+  function populateEidSelector(data) {
+    const sel = $("ctrl-eid");
+    if (!sel) return;
+    const mode = $("ctrl-mode")?.value || "doc";
+    const events = Object.entries(data.byEvent || {});
+    sel.innerHTML = "";
+    const field = mode === "review" ? "reviewQueue" : mode === "visuals" ? "visualsNeedingContext" : "queue";
+    const relevant = events.filter(([, d]) => (d[field]?.length || mode === "doc"));
+    if (!relevant.length) relevant.push(...events);
+    relevant.forEach(([eid, doc]) => {
+      const short = eid.replace(/^65-hs1-834228961-62-hq-83894-/, "§62hq-");
+      const count = (doc.queue?.length || 0) + (doc.reviewQueue?.length || 0);
+      const opt = document.createElement("option");
+      opt.value = eid;
+      opt.textContent = `${short} (${count} open)`;
+      sel.appendChild(opt);
+    });
+  }
+
+  function populateQueuePanel(data) {
+    const events = Object.entries(data.byEvent || {});
+    const totalOCR    = data.totalPagesNeeded ?? 0;
+    const totalReview = data.totalPagesNeedingReview ?? 0;
+    const totalVisual = data.totalPagesNeedingVisualContext ?? 0;
+    const totalWork   = totalOCR + totalReview + totalVisual;
+
+    $("q-total").textContent      = totalWork;
+    $("q-ocr-count").textContent  = totalOCR;
+    $("q-rev-count").textContent  = totalReview;
+    $("q-vis-count").textContent  = totalVisual;
+
+    const catalogued = data.cataloguedTotal ?? 0;
+    const inventory  = data.inventoryTotal  ?? 0;
+    const pct = inventory ? Math.round(catalogued / inventory * 100) : 0;
+    $("q-catalogued").textContent = catalogued.toLocaleString() + " catalogued";
+    $("q-inventory").textContent  = inventory.toLocaleString() + " total · " + pct + "%";
+    $("q-cov-fill").style.width   = pct + "%";
+
+    renderQueueDocs("q-ocr-docs",  events, "queue",                 "var(--green)");
+    renderQueueDocs("q-rev-docs",  events, "reviewQueue",           "var(--amber)");
+    renderQueueDocs("q-vis-docs",  events, "visualsNeedingContext", "var(--cyan)");
+
+    // Disable quick-launch buttons whose queue has nothing to do — saves
+    // the user from clicking a button that just no-ops with "0 pages claimed".
+    syncQuickBtnEnablement({ ocr: totalOCR, review: totalReview, visuals: totalVisual });
+
+    const gen = data.generatedAt ? new Date(data.generatedAt).toISOString().replace("T"," ").slice(0,19) + " UTC" : "";
+    $("q-ts").textContent = "queue generated " + gen + " · refreshes every 5 min";
+  }
+
+  // Maps each queue's remaining count onto every button that targets it.
+  // Buttons with data-needs="ocr|review|visuals" get disabled when their
+  // queue is at 0, and their sub-text updates to show the count.
+  let lastQueueCounts = { ocr: -1, review: -1, visuals: -1 };
+  function syncQuickBtnEnablement(counts) {
+    lastQueueCounts = counts;
+    const totalAll = (counts.ocr || 0) + (counts.review || 0) + (counts.visuals || 0);
+    document.querySelectorAll("[data-needs]").forEach(btn => {
+      const need = btn.getAttribute("data-needs");
+      const remaining = need === "any" ? totalAll : (counts[need] ?? 0);
+      const sub = btn.querySelector(".qb-count");
+      if (remaining === 0) {
+        btn.dataset.queueEmpty = "1";
+        if (sub) sub.textContent = need === "any"
+          ? "all queues empty — nothing left to do · refresh in 5 min"
+          : `${need.toUpperCase()} queue empty — nothing to do`;
+      } else {
+        delete btn.dataset.queueEmpty;
+        if (sub) {
+          const defaults = {
+            ocr:     "first-pass transcription · one slice",
+            review:  "settle disputed pages · one slice",
+            visuals: "image context · one slice",
+            any:     "checks OCR → REVIEW → VISUALS, picks the first with pages you haven't submitted yet",
+          };
+          const isLoop = btn.classList.contains("loop");
+          if (need === "any") {
+            sub.textContent = `${defaults.any} · ${totalAll} pages across all queues`;
+          } else {
+            sub.textContent = isLoop
+              ? `keep taking ${need.toUpperCase()} jobs until empty · ${remaining} left`
+              : `${defaults[need]} · ${remaining} available`;
+          }
+        }
+      }
+    });
+    // Apply enablement (pollRunner will override during a run).
+    applyQueueEnablement();
+  }
+  function applyQueueEnablement() {
+    document.querySelectorAll("[data-needs]").forEach(btn => {
+      // If something is running, leave it disabled by the pollRunner override.
+      if (btn.dataset.runDisabled === "1") return;
+      btn.disabled = btn.dataset.queueEmpty === "1";
+    });
+  }
+
+  // Mode selector: show/hide eid row, repopulate eid list
+  $("ctrl-mode")?.addEventListener("change", () => {
+    const mode = $("ctrl-mode").value;
+    const eidRow = $("eid-row");
+    if (eidRow) eidRow.style.display = mode === "doc" ? "flex" : "none";
+    if (workQueue) populateEidSelector(workQueue);
+  });
+
+  // Pre-fill handle from progress state
+  function syncHandleField(p) {
+    const h = $("ctrl-handle");
+    if (h && !h.value && p.handle) h.value = p.handle;
+  }
+
+  // Poll runner status every 2 s
+  let logScrollBottom = true;
+  async function pollRunner() {
+    try {
+      const r = await fetch("/running", { cache: "no-store" });
+      if (!r.ok) return;
+      const data = await r.json();
+
+      const startBtn = $("btn-start");
+      const stopBtn  = $("btn-stop");
+      const statusEl = $("ctrl-status");
+
+      // Toggle quick-launch buttons too (everything except STOP)
+      const quickStartBtns = document.querySelectorAll(".quick-btn:not(.stop)");
+      const quickStop = $("quick-stop");
+      if (data.running) {
+        if (startBtn) startBtn.disabled = true;
+        if (stopBtn)  stopBtn.disabled  = false;
+        if (quickStop) quickStop.style.display = "";
+        quickStartBtns.forEach(b => { b.dataset.runDisabled = "1"; b.disabled = true; });
+        const m = data.meta;
+        const loopTag = m?.loop ? " · LOOP" : "";
+        const docTag  = m?.eid  ? " · " + m.eid.replace(/^65-hs1-834228961-62-hq-83894-/, "§") : "";
+        if (statusEl) {
+          statusEl.className = "ctrl-status running";
+          statusEl.textContent = "RUNNING · " + (m?.mode || "").toUpperCase() + docTag + loopTag
+            + " · " + Math.round((Date.now() - (m?.startedAt || Date.now())) / 1000) + "s";
+        }
+      } else {
+        if (startBtn) startBtn.disabled = false;
+        if (stopBtn)  stopBtn.disabled  = true;
+        if (quickStop) quickStop.style.display = "none";
+        // Drop the run-disabled flag, then defer to queue-empty state.
+        quickStartBtns.forEach(b => { delete b.dataset.runDisabled; });
+        applyQueueEnablement();
+
+        // Show the outcome of the run that just finished. Use finishedAt as a
+        // dedupe key so we render it once per run, not every 2-second poll tick.
+        if (data.lastRun && data.lastRun.finishedAt && data.lastRun.finishedAt !== lastRunSeen) {
+          lastRunSeen = data.lastRun.finishedAt;
+          renderLastRun(data.lastRun);
+          // After a successful run, refresh PRs + queue panel — there's likely
+          // new local output and possibly a new PR opened.
+          if (data.lastRun.kind === "success") {
+            setTimeout(() => { fetchPRs(); fetchQueueAndSync(); }, 800);
+          }
+        }
+        if (statusEl && statusEl.className.includes("running")) {
+          statusEl.className = "ctrl-status idle";
+          const lr = data.lastRun;
+          statusEl.textContent = lr ? lr.headline : "IDLE — last run finished";
+        }
+      }
+
+      // Update log
+      const logEl = $("log-box");
+      if (logEl && data.log?.length) {
+        const atBottom = logEl.scrollHeight - logEl.scrollTop <= logEl.clientHeight + 20;
+        logEl.innerHTML = data.log.map(line => {
+          // exit 0 / exit 2 are clean exits (success / nothing to commit). Only red for real errors.
+          const benign = /nothing to commit|already submitted|already present|\[exit (0|2)\]|done\. ok=\d/.test(line);
+          let cls = "";
+          if (benign && /\bok=\d/.test(line))        cls = "l-ok";
+          else if (benign)                            cls = "l-info";
+          else if (/✓|^\s*✓/.test(line))             cls = "l-ok";
+          else if (/✗|err=[1-9]|\bError\b|\bFAIL\b|\[exit [^02]/.test(line))  cls = "l-err";
+          else if (/⚠|warn/i.test(line))             cls = "l-warn";
+          return `<div class="${cls}">${line.replace(/</g,"&lt;")}</div>`;
+        }).join("");
+        if (atBottom) logEl.scrollTop = logEl.scrollHeight;
+      }
+    } catch {}
+  }
+  setInterval(pollRunner, 2000);
+  pollRunner();
+  fetchQueueAndSync();
+  setInterval(fetchQueueAndSync, 5 * 60 * 1000);
+
+  // Override the old fetchQueue calls (the panel is now updated by fetchQueueAndSync)
+  // Keep original interval inert
+  // ---- action handlers ----
+  window.ctrlStart = async function() {
+    const handle = ($("ctrl-handle")?.value || "").trim();
+    if (!handle) { alert("Enter your GitHub handle first"); return; }
+    const mode   = $("ctrl-mode")?.value || "ocr";
+    const eid    = mode === "doc" ? ($("ctrl-eid")?.value || "") : undefined;
+    const slice  = Number($("ctrl-slice")?.value || 20);
+    const loop   = !!$("ctrl-loop")?.checked;
+
+    const statusEl = $("ctrl-status");
+    if (statusEl) { statusEl.className = "ctrl-status running"; statusEl.textContent = "STARTING…"; }
+
+    try {
+      const r = await fetch("/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode, eid, slice, loop, handle }),
+      });
+      const j = await r.json();
+      if (!r.ok) {
+        if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "ERROR · " + (j.error || r.status); }
+      } else {
+        $("log-box").innerHTML = "";
+        if (statusEl) { statusEl.className = "ctrl-status running"; statusEl.textContent = "RUNNING…"; }
+      }
+    } catch(e) {
+      if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "FETCH ERROR · " + e.message; }
+    }
+  };
+
+  window.ctrlStop = async function() {
+    const statusEl = $("ctrl-status");
+    try {
+      await fetch("/stop", { method: "POST" });
+      if (statusEl) { statusEl.className = "ctrl-status idle"; statusEl.textContent = "STOPPING…"; }
+    } catch(e) {
+      if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "STOP ERROR · " + e.message; }
+    }
+  };
+
+  // ---- PR queue ----
+  async function fetchPRs() {
+    const listEl = $("pr-list");
+    if (!listEl) return;
+    try {
+      const r = await fetch("/prs", { cache: "no-store" });
+      const j = await r.json();
+      if (!r.ok) { listEl.innerHTML = `<div style="color:var(--rose);font-size:10px">${j.error || "fetch failed"}</div>`; return; }
+      renderPRs(j.prs || []);
+    } catch (e) {
+      listEl.innerHTML = `<div style="color:var(--rose);font-size:10px">fetch error · ${e.message}</div>`;
+    }
+  }
+
+  function renderPRs(prs) {
+    const listEl = $("pr-list");
+    const tsEl = $("pr-ts");
+    if (tsEl) tsEl.textContent = `${prs.length} open PR(s) · refreshed ${new Date().toISOString().slice(11,19)} UTC · refreshes every 60s`;
+    if (!prs.length) {
+      listEl.innerHTML = `<div style="color:var(--green-dim);font-size:10px;letter-spacing:0.1em">no open PRs — queue is clear</div>`;
+      return;
+    }
+    listEl.innerHTML = prs.map(p => {
+      const checks = p.checks || [];
+      const failed = checks.some(c => c.conclusion === "FAILURE");
+      const pending = checks.some(c => c.status !== "COMPLETED");
+      const allOk = checks.length && checks.every(c => c.conclusion === "SUCCESS");
+      let statusHTML, mergeable, statusClass;
+      if (failed)      { statusClass = "fail"; statusHTML = "CHECKS FAILED"; mergeable = false; }
+      else if (pending){ statusClass = "wait"; statusHTML = "CHECKS RUNNING"; mergeable = false; }
+      else if (allOk)  { statusClass = "ok";   statusHTML = "READY · CHECKS GREEN"; mergeable = p.mergeable !== "CONFLICTING"; }
+      else             { statusClass = "unk";  statusHTML = "AWAITING CHECKS"; mergeable = false; }
+      const created = p.createdAt ? new Date(p.createdAt).toISOString().slice(0,16).replace("T"," ") + " UTC" : "";
+      return `
+        <div class="pr-row" id="pr-row-${p.number}">
+          <div class="pr-num">#${p.number}</div>
+          <div>
+            <div class="pr-title">${escapeHTML(p.title)}</div>
+            <div class="pr-meta">opened ${created} · ${escapeHTML(p.headRef || "")}</div>
+          </div>
+          <div class="pr-status ${statusClass}">${statusHTML}</div>
+          <a href="${p.url}" target="_blank" rel="noopener" class="pr-link">VIEW ↗</a>
+          <button class="pr-merge" ${mergeable ? "" : "disabled"} onclick="mergePR(${p.number})" id="pr-btn-${p.number}">
+            ▶ MERGE
+          </button>
+        </div>`;
+    }).join("");
+  }
+
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"]/g, c => ({ "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;" }[c]));
+  }
+
+  window.mergePR = async function(num) {
+    if (!confirm(`Squash-merge PR #${num} into main?`)) return;
+    const btn = $("pr-btn-" + num);
+    if (btn) { btn.classList.add("busy"); btn.disabled = true; btn.textContent = "MERGING…"; }
+    try {
+      const r = await fetch("/merge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ number: num, method: "squash" }),
+      });
+      const j = await r.json();
+      if (!r.ok) {
+        if (btn) { btn.classList.remove("busy"); btn.disabled = false; btn.textContent = "▶ MERGE"; }
+        alert(`merge failed: ${j.error || r.status}`);
+      } else {
+        if (btn) { btn.textContent = "✓ MERGED"; btn.classList.remove("busy"); }
+        // Refresh PR list and queue stats after a short delay
+        setTimeout(() => { fetchPRs(); fetchQueueAndSync(); }, 1500);
+      }
+    } catch (e) {
+      if (btn) { btn.classList.remove("busy"); btn.disabled = false; btn.textContent = "▶ MERGE"; }
+      alert(`merge error: ${e.message}`);
+    }
+  };
+  window.fetchPRs = fetchPRs;
+  fetchPRs();
+  setInterval(fetchPRs, 60_000);
+
+  // ---- daemon health badge ----
+  async function pollDaemonHealth() {
+    const badge = $("daemon-badge");
+    if (!badge) return;
+    try {
+      const r = await fetch("/daemon-health", { cache: "no-store" });
+      const j = await r.json();
+      if (j.alive) {
+        badge.textContent = `DAEMON ${j.port} · UP`;
+        badge.style.color = "var(--green)";
+        badge.style.borderColor = "var(--green-dim)";
+      } else {
+        badge.textContent = `DAEMON ${j.port} · OFFLINE`;
+        badge.style.color = "var(--rose)";
+        badge.style.borderColor = "rgba(255,107,157,0.5)";
+      }
+    } catch {
+      badge.textContent = "DAEMON · UNREACHABLE";
+      badge.style.color = "var(--rose)";
+      badge.style.borderColor = "rgba(255,107,157,0.5)";
+    }
+  }
+  pollDaemonHealth();
+  setInterval(pollDaemonHealth, 15_000);
+
+  // ---- clean stubs button (manual trigger; auto-clean also runs before each spawn) ----
+  window.cleanStubs = async function() {
+    const handle = ($("ctrl-handle")?.value || "").trim() || "Rizzleroc";
+    try {
+      const r = await fetch("/clean-stubs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle }),
+      });
+      const j = await r.json();
+      alert(`Removed ${j.removed} stub file(s).${j.samples?.length ? "\n\n" + j.samples.join("\n") : ""}`);
+    } catch (e) { alert("clean failed: " + e.message); }
+  };
+
+  // Smart auto-pick: server walks OCR → REVIEW → VISUALS and picks the first
+  // queue with pages you haven't already locally submitted. No more "click OCR,
+  // get no-op, click REVIEW, get no-op, etc."
+  window.quickAuto = async function() {
+    let handle = ($("ctrl-handle")?.value || "").trim();
+    if (!handle) {
+      handle = prompt("Enter your GitHub handle:");
+      if (!handle) return;
+      handle = handle.trim();
+      if ($("ctrl-handle")) $("ctrl-handle").value = handle;
+    }
+    const slice = Number($("ctrl-slice")?.value || 20);
+    const loop  = !!$("ctrl-loop")?.checked;
+    const statusEl = $("ctrl-status");
+    if (statusEl) { statusEl.className = "ctrl-status running"; statusEl.textContent = "PICKING QUEUE…"; }
+    try {
+      const r = await fetch("/run-any", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle, slice, loop }),
+      });
+      const j = await r.json();
+      if (r.status === 409) {
+        renderLastRun({
+          kind: "noop",
+          headline: "ALL QUEUES BLOCKED",
+          detail: j.error + ` · queue counts: OCR=${j.queueCounts.ocr}, REVIEW=${j.queueCounts.review}, VISUALS=${j.queueCounts.visuals}.`,
+          mode: "auto", finishedAt: Date.now(),
+        });
+        if (statusEl) { statusEl.className = "ctrl-status idle"; statusEl.textContent = "ALL WORK ALREADY IN FLIGHT"; }
+        return;
+      }
+      if (!r.ok) {
+        if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "ERROR · " + (j.error || r.status); }
+      } else {
+        $("log-box").innerHTML = "";
+        $("last-run-banner").style.display = "none";
+        if (statusEl) { statusEl.className = "ctrl-status running"; statusEl.textContent = `RUNNING · auto-picked ${j.picked.toUpperCase()} · ${j.freshPages} fresh page(s)`; }
+      }
+    } catch(e) {
+      if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "FETCH ERROR · " + e.message; }
+    }
+  };
+
+  // Render the outcome banner. Sticks for 30s after run finishes.
+  let lastRunSeen = null;
+  function renderLastRun(lr) {
+    const el = $("last-run-banner");
+    if (!el) return;
+    const icons = { success: "✓", noop: "◌", error: "✗", stopped: "■" };
+    const ageS  = lr.finishedAt ? Math.round((Date.now() - lr.finishedAt) / 1000) : 0;
+    const meta  = [
+      lr.mode ? "mode=" + lr.mode : null,
+      lr.eid ? "doc=" + lr.eid.replace(/^65-hs1-834228961-62-hq-83894-/, "§") : null,
+      typeof lr.durationSec === "number" ? lr.durationSec + "s elapsed" : null,
+      lr.exitCode != null ? "exit " + lr.exitCode : null,
+      ageS > 0 ? ageS + "s ago" : null,
+    ].filter(Boolean).join(" · ");
+    el.className = "last-run " + (lr.kind || "noop");
+    el.innerHTML = `
+      <div class="lr-icon">${icons[lr.kind] || "·"}</div>
+      <div class="lr-body">
+        <div class="lr-head">${escapeHTML(lr.headline || "")}</div>
+        <div class="lr-detail">${escapeHTML(lr.detail || "")}</div>
+        <div class="lr-meta">${meta}</div>
+      </div>`;
+    el.style.display = "flex";
+  }
+
+  // Quick-launch: skip the form, just fire the CLI-equivalent task.
+  // Pulls handle from the field if set, else falls back to whatever the
+  // monitor already knows about (state.handle). slice uses the field value.
+  window.quickRun = async function(mode, loop) {
+    let handle = ($("ctrl-handle")?.value || "").trim();
+    if (!handle) {
+      handle = prompt("Enter your GitHub handle (it'll be saved for next time):");
+      if (!handle) return;
+      handle = handle.trim();
+      if ($("ctrl-handle")) $("ctrl-handle").value = handle;
+    }
+    const slice = Number($("ctrl-slice")?.value || (mode === "visuals" ? 5 : 20));
+    const statusEl = $("ctrl-status");
+    if (statusEl) { statusEl.className = "ctrl-status running"; statusEl.textContent = `STARTING ${mode.toUpperCase()}${loop ? " (LOOP)" : ""}…`; }
+    try {
+      const r = await fetch("/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode, slice, loop, handle }),
+      });
+      const j = await r.json();
+      if (!r.ok) {
+        if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "ERROR · " + (j.error || r.status); }
+      } else {
+        $("log-box").innerHTML = "";
+        if (statusEl) { statusEl.className = "ctrl-status running"; statusEl.textContent = `RUNNING · ${mode}${loop ? " · LOOP" : ""}`; }
+      }
+    } catch(e) {
+      if (statusEl) { statusEl.className = "ctrl-status err"; statusEl.textContent = "FETCH ERROR · " + e.message; }
+    }
+  };
+
+  // Sync handle from progress state (runs inside poll())
+  const _origPoll = poll;
+  // Patch poll to also sync handle field
+  const _savedPoll = poll;
 })();
 </script>
 </body>

--- a/pursue-vision-mcp/monitor.mjs
+++ b/pursue-vision-mcp/monitor.mjs
@@ -25,8 +25,8 @@
 //   PURSUE_MONITOR_TOKEN if set, required on POST /progress (default: no auth)
 
 import http from "node:http";
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
-import { existsSync, createReadStream } from "node:fs";
+import { readFile, writeFile, mkdir, rename, readdir, rm } from "node:fs/promises";
+import { existsSync, createReadStream, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -65,6 +65,13 @@ let state = blankState();
 try {
   if (existsSync(STATE_PATH)) state = { ...blankState(), ...JSON.parse(await readFile(STATE_PATH, "utf8")) };
 } catch {}
+// Nothing is running at boot, so any persisted "active" state is stale from a
+// previous run that exited without resetting. Force idle so the focal display
+// doesn't show a phantom "NOW PROCESSING" page on a fresh load.
+state.now = null;
+state.idle = true;
+state.onBreak = null;
+state.slice = { done: 0, total: 0 };
 
 async function persistState() {
   try {
@@ -136,6 +143,378 @@ if (TUI_MODE) {
   process.exit(0);
 }
 
+// ----- volunteer process runner -----
+const SCRIPTS_ROOT = path.resolve(__dirname, "..");
+let runningProc = null;
+let runningMeta = null;  // { mode, eid, slice, loop, startedAt }
+
+function procRunning() {
+  // A live spawned child has exitCode === null until it exits, then a number.
+  return runningProc !== null && runningProc.exitCode === null;
+}
+
+function buildVolunteerArgs(opts) {
+  // opts: { mode: "ocr"|"review"|"visuals", eid, slice, loop, handle, daemonPort }
+  const handle = opts.handle || state.handle || "volunteer";
+  const slice  = Math.max(1, Math.min(200, Number(opts.slice) || 20));
+  const daemon = `http://127.0.0.1:${opts.daemonPort || state.daemonPort || 9223}`;
+
+  if (opts.mode === "visuals") {
+    // volunteer-media.mjs has its own flow. --auto-context lets the daemon draft
+    // the Context so the staged templates are commit-ready (dashboard default).
+    const args = ["scripts/volunteer-media.mjs", `--my-handle=${handle}`, `--slice=${slice}`, `--daemon=${daemon}`];
+    if (existsSync(LOCAL_QUEUE_PATH)) args.push(`--queue-url=${LOCAL_QUEUE_PATH}`);
+    if (opts.autoContext !== false) args.push("--auto-context");
+    return { script: "volunteer-media.mjs", args };
+  }
+  if (opts.mode === "visuals-commit") {
+    // Second phase: validate filled templates and stage the contribution.
+    const args = ["scripts/volunteer-media.mjs", `--my-handle=${handle}`, "--commit", "--no-pr"];
+    return { script: "volunteer-media.mjs", args };
+  }
+
+  const args = [
+    "scripts/volunteer.mjs",
+    `--my-handle=${handle}`,
+    `--slice=${slice}`,
+    `--daemon=${daemon}`,
+    "--no-pr",
+  ];
+  if (existsSync(LOCAL_QUEUE_PATH)) args.push(`--queue-url=${LOCAL_QUEUE_PATH}`);
+  if (opts.mode === "review") args.push("--review");
+  if (opts.eid)              args.push(`--eid=${opts.eid}`);
+  return { script: "volunteer.mjs", args };
+}
+
+// Last completed run outcome — read by /running so the dashboard can show
+// "DONE · ok=12 err=0" or "NO NEW WORK · all pages already submitted" instead
+// of just "IDLE", which made every benign 1-second exit look like a crash.
+let lastRun = null;
+
+function summarizeLog(allLines, exitCode) {
+  const text = allLines.join("\n");
+  const skipCount = (text.match(/⊖.*already submitted/g) || []).length;
+  const okMatch   = text.match(/done\.\s*ok=(\d+)\s*err=(\d+)/);
+  const okCount   = okMatch ? Number(okMatch[1]) : 0;
+  const errCount  = okMatch ? Number(okMatch[2]) : 0;
+  const noCommit  = /nothing to commit/.test(text);
+  const queueGen  = (text.match(/queue gen ([^\s·]+)/) || [])[1] || null;
+
+  const econnRefused = /ECONNREFUSED.*9223|ECONNREFUSED 127\.0\.0\.1:9223/.test(text);
+  const cdpTimeout   = /connectOverCDP.*Timeout|CDP.*timeout/i.test(text);
+  const tokenError   = /unauthorized.*bearer|HTTP 401/i.test(text);
+  const pdfRenderFails = (text.match(/render failed \(Value is none of these types/g) || []).length;
+  const claimedFromMedia = /\[claim\]/.test(text);
+  // Visuals claim phase: "[claim] claiming N page(s)" then "templates written to".
+  const mediaClaimMatch = text.match(/\[claim\] claiming (\d+) page/);
+  const mediaClaimed    = mediaClaimMatch ? Number(mediaClaimMatch[1]) : 0;
+  const mediaTemplatesWritten = /templates written to/.test(text);
+  const draftedCount = (text.match(/drafting context via daemon… ✓/g) || []).length;
+  // Visuals commit phase: "[commit] N ready · M incomplete · K empty".
+  const commitMatch = text.match(/\[commit\] (\d+) ready · (\d+) incomplete · (\d+) empty/);
+
+  let kind, headline, detail;
+  if (exitCode === null) {
+    kind = "stopped"; headline = "STOPPED"; detail = "Killed by user.";
+  } else if (commitMatch) {
+    const ready = Number(commitMatch[1]), incomplete = Number(commitMatch[2]), empty = Number(commitMatch[3]);
+    if (ready > 0) {
+      kind = "success"; headline = `COMMITTED · ${ready} page(s)`;
+      detail = `${ready} media contribution(s) staged into contributions/.${incomplete ? ` ${incomplete} template(s) incomplete (skipped).` : ""}${empty ? ` ${empty} empty (skipped).` : ""} Run git add + commit + gh pr create to push.`;
+    } else {
+      kind = "noop"; headline = `NOTHING TO COMMIT · ${incomplete} incomplete, ${empty} empty`;
+      detail = "No templates passed validation. Each needs Kind + Title (≥4 chars) + Context (≥20 chars) + a rendered PNG. Fill the Context fields and retry.";
+    }
+  } else if (claimedFromMedia && mediaTemplatesWritten && pdfRenderFails === 0 && mediaClaimed > 0) {
+    // Visuals CLAIM phase succeeded: PNGs rendered + markdown templates staged.
+    // This is a two-phase flow — claim now, fill templates, then --commit.
+    kind = "success"; headline = `STAGED · ${mediaClaimed} page(s) rendered`;
+    detail = "PNGs + context templates written to ~/.pursue-helper/media-staging/. Open each p<NNN>.png next to its p<NNN>.md, fill in Title/Context, then run the commit phase.";
+  } else if (claimedFromMedia && pdfRenderFails > 0 && mediaClaimed > pdfRenderFails) {
+    // Partial: some pages rendered, some failed.
+    kind = "success"; headline = `STAGED · ${mediaClaimed - pdfRenderFails}/${mediaClaimed} page(s)`;
+    detail = `${pdfRenderFails} page(s) failed to render but ${mediaClaimed - pdfRenderFails} staged OK. Fill the templates that have a PNG, then run the commit phase.`;
+  } else if (claimedFromMedia && pdfRenderFails > 0 && okCount === 0) {
+    // All renders failed — surface the cause.
+    kind = "noop"; headline = `RENDER FAILED · ${pdfRenderFails} page(s)`;
+    detail = "pdfjs couldn't render these pages. If this persists after the Path2D fix, the source PDF may be genuinely corrupt — check the log.";
+  } else if (econnRefused) {
+    kind = "error"; headline = "MCP DAEMON OFFLINE · port 9223";
+    detail = "The OCR daemon at http://127.0.0.1:9223 isn't running, so the volunteer can't do vision work. Start it with: cd pursue-vision-mcp && npm start";
+  } else if (cdpTimeout) {
+    kind = "error"; headline = "CHROME / CDP NOT REACHABLE";
+    detail = "The daemon is up but can't connect to Chrome on port 9222. Start Chrome with: chrome --remote-debugging-port=9222 (and log in to chatgpt.com in that browser session).";
+  } else if (tokenError) {
+    kind = "error"; headline = "TOKEN MISMATCH";
+    detail = "The daemon rejected the volunteer's auth token. Restart both the daemon and monitor so they pick up the same ~/.pursue-vision-token value.";
+  } else if (errCount > 0 && okCount === 0) {
+    kind = "error"; headline = `FAILED · ${errCount} error(s)`;
+    detail = (allLines.slice(-6).find(l => /✗|error|Error|FAIL/.test(l)) || allLines.at(-1) || "see log for details").slice(0, 240);
+  } else if (exitCode !== 0 && exitCode !== 2) {
+    kind = "error"; headline = `FAILED · exit ${exitCode}`;
+    detail = (allLines.slice(-3).find(l => /error|Error|FAIL/.test(l)) || allLines.at(-1) || "see log for details").slice(0, 200);
+  } else if (okCount > 0) {
+    kind = "success"; headline = `DONE · ${okCount} ok, ${errCount} err`;
+    detail = "Output written to contributions/. " + (noCommit ? "Nothing new to push — already submitted via an open PR." : "Ready to open a PR (run with --pr to push).");
+  } else if (skipCount > 0 && noCommit) {
+    kind = "noop"; headline = `NO NEW WORK · ${skipCount} pages already submitted`;
+    detail = "Every page in this queue is already in one of your open PRs. Merge those PRs and wait for the server to refresh work-available.json, or try a different queue.";
+  } else if (noCommit) {
+    kind = "noop"; headline = "NO NEW WORK";
+    detail = "Volunteer found nothing to do. Queue may be empty or stale.";
+  } else {
+    kind = "noop"; headline = "RUN COMPLETE";
+    detail = "No pages processed. See log for details.";
+  }
+  return { kind, headline, detail, okCount, errCount, skipCount, noCommit, queueGen, exitCode };
+}
+
+// Clean truly-empty stub .txt files for a handle's contributions. The volunteer
+// writes "" on failure, which then looks like "already submitted" to the next
+// run. WE DO NOT use a size threshold: pages can legitimately OCR to very
+// short text (e.g. "BOTTOM VIEW" = 11 bytes for an image page). A previous
+// 50-byte threshold caused real outputs to be wiped between runs, making the
+// auto-picker re-pick the same page forever. Now only wipe when content is
+// empty or whitespace-only.
+async function autoCleanStubs(handle) {
+  if (!handle) return 0;
+  const dirs = ["gpt-vision", "gpt-vision-review"];
+  let removed = 0;
+  for (const d of dirs) {
+    const root = path.resolve(SCRIPTS_ROOT, "contributions", handle, d);
+    if (!existsSync(root)) continue;
+    const eids = await readdir(root).catch(() => []);
+    for (const eid of eids) {
+      const docDir = path.join(root, eid);
+      let entries;
+      try { entries = await readdir(docDir); } catch { continue; }
+      for (const f of entries) {
+        if (!/^p\d+\.txt$/.test(f)) continue;
+        const fp = path.join(docDir, f);
+        try {
+          const sz = statSync(fp).size;
+          if (sz === 0) {
+            await rm(fp);
+            const jp = fp.replace(/\.txt$/, ".json");
+            if (existsSync(jp)) { try { await rm(jp); } catch {} }
+            removed++;
+            continue;
+          }
+          // For small files, verify the content is just whitespace before deleting.
+          if (sz < 8) {
+            const content = await readFile(fp, "utf8");
+            if (!content.trim()) {
+              await rm(fp);
+              const jp = fp.replace(/\.txt$/, ".json");
+              if (existsSync(jp)) { try { await rm(jp); } catch {} }
+              removed++;
+            }
+          }
+        } catch {}
+      }
+    }
+  }
+  return removed;
+}
+
+// When a run ends, volunteer.mjs stops POSTing progress but the last state it
+// pushed (now=<page>, idle=false, slice=…) sticks in progress.json, so the
+// dashboard's focal "NOW PROCESSING" panel never resets. Clear it back to idle
+// and persist so the UI returns to a ready state the moment the run finishes.
+function resetProgressIdle() {
+  state.now = null;
+  state.idle = true;
+  state.onBreak = null;
+  state.slice = { done: 0, total: 0 };
+  state.updatedAt = Date.now();
+  persistState();
+}
+
+async function spawnVolunteer(opts) {
+  if (runningProc) throw new Error("a volunteer run is already in progress — stop it first");
+  const { args } = buildVolunteerArgs(opts);
+  const cleaned = await autoCleanStubs(opts.handle || state.handle);
+  if (cleaned > 0) console.log(`[monitor] auto-cleaned ${cleaned} stub file(s) before spawn`);
+  // Probe both possible daemon-token files to find which one the live daemon
+  // on :9223 actually accepts. The user may be running either pursue-vision-mcp
+  // (uses ~/.pursue-vision-token) or whipgen (uses ~/.whipgen-token) — passing
+  // the wrong one yields HTTP 401.
+  const probeEnv = await pickDaemonTokenEnv();
+  const proc = spawn(process.execPath, args, {
+    cwd: SCRIPTS_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...probeEnv },
+  });
+  runningProc  = proc;
+  runningMeta  = { mode: opts.mode, eid: opts.eid || null, slice: opts.slice, loop: !!opts.loop, startedAt: Date.now() };
+  lastRun = null;
+
+  // Reflect "running" in /progress immediately. volunteer-media.mjs (visuals
+  // mode) never POSTs progress, so without this /progress keeps idle=true while
+  // /running says running=true — a contradiction that makes the dashboard look
+  // like it's flipping state. OCR/review overwrite this via POST /progress.
+  state.idle = false;
+  state.now = { phase: opts.mode === "visuals" ? "CLAIMING VISUAL CONTEXT" : String(opts.mode || "").toUpperCase(), eid: opts.eid || null };
+  state.updatedAt = Date.now();
+  persistState();
+
+  const lines = [];
+  const onLine = (chunk) => {
+    for (const line of String(chunk).split(/\r?\n/).filter(Boolean)) {
+      lines.push(line);
+      if (lines.length > 200) lines.shift();
+      state.runnerLog = lines.slice(-40);
+    }
+  };
+  proc.stdout.on("data", onLine);
+  proc.stderr.on("data", onLine);
+
+  proc.on("exit", async (code) => {
+    lines.push(`[exit ${code}]`);
+    state.runnerLog = lines.slice(-40);
+    const startedMeta = runningMeta;
+    const loop = startedMeta?.loop;
+    lastRun = {
+      ...summarizeLog(lines, code),
+      mode: startedMeta?.mode || null,
+      eid: startedMeta?.eid || null,
+      finishedAt: Date.now(),
+      durationSec: Math.round((Date.now() - (startedMeta?.startedAt || Date.now())) / 1000),
+    };
+    runningProc = null;
+    runningMeta = null;
+    resetProgressIdle();   // clear the focal "NOW PROCESSING" display
+    // Loop mode: requeue only if there was actually some work done OR pages failed.
+    // If the run was a pure no-op (kind=="noop"), looping just spams empty runs at the queue —
+    // stop and let the user pick a different queue or wait for fresh work.
+    //
+    // Visuals = the CLAIM phase: it only stages templates that then need a
+    // separate (manual) commit. Auto-relooping it re-claims the same "fresh"
+    // pages every few seconds (staged pages aren't marked submitted), causing
+    // unbounded staging growth and the constant running↔idle flipping in the
+    // UI. Only OCR/review/doc — which submit their own work — may loop.
+    if (loop && !String(startedMeta?.mode || "").startsWith("visuals") && code !== null && code !== 1 && lastRun.kind !== "noop") {
+      await new Promise(r => setTimeout(r, 3000));
+      try { await spawnVolunteer({ ...opts }); } catch {}
+    }
+  });
+  proc.on("error", (e) => {
+    lastRun = { kind: "error", headline: "SPAWN ERROR", detail: e.message, exitCode: -1, finishedAt: Date.now() };
+    runningProc = null; runningMeta = null;
+    resetProgressIdle();
+  });
+}
+
+// Probe the daemon with each known token file. Returns an env block to spawn
+// volunteer with — the env var the volunteer's loadToken() will use first.
+// Cached so we don't re-probe on every spawn.
+let _cachedDaemonAuth = null;
+async function pickDaemonTokenEnv() {
+  if (_cachedDaemonAuth && Date.now() - _cachedDaemonAuth.ts < 60_000) return _cachedDaemonAuth.env;
+  const port = state.daemonPort || 9223;
+  const candidates = [
+    { envKey: "PURSUE_VISION_TOKEN", path: path.join(os.homedir(), ".pursue-vision-token") },
+    { envKey: "WHIPGEN_TOKEN",       path: path.join(os.homedir(), ".whipgen-token") },
+  ];
+  for (const c of candidates) {
+    let token;
+    try { token = (await readFile(c.path, "utf8")).trim(); } catch { continue; }
+    if (!token) continue;
+    try {
+      const ac = new AbortController();
+      const t = setTimeout(() => ac.abort(), 2000);
+      // /chat-with-files actually checks auth (vs /status which is open).
+      // Empty body returns 400 (auth ok, validation fail) — the signal we want.
+      // 401 means wrong token.
+      const r = await fetch(`http://127.0.0.1:${port}/chat-with-files`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: "{}",
+        signal: ac.signal,
+      });
+      clearTimeout(t);
+      if (r.status !== 401) {
+        const env = { [c.envKey]: token };
+        _cachedDaemonAuth = { env, ts: Date.now(), source: c.envKey };
+        console.log(`[monitor] daemon auth: using ${c.envKey} (${c.path})`);
+        return env;
+      }
+    } catch {}
+  }
+  // No token worked — return empty env and let volunteer fall back to its file scan.
+  console.log("[monitor] daemon auth: no token matched, volunteer will fall back");
+  _cachedDaemonAuth = { env: {}, ts: Date.now(), source: "none" };
+  return {};
+}
+
+async function daemonAlive() {
+  const port = state.daemonPort || 9223;
+  try {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), 1500);
+    const r = await fetch(`http://127.0.0.1:${port}/health`, { signal: ac.signal });
+    clearTimeout(t);
+    return r.ok;
+  } catch { return false; }
+}
+
+const REMOTE_QUEUE_URL = "https://rizzleroc.github.io/pursue-console/work-available.json";
+const LOCAL_QUEUE_PATH = path.resolve(SCRIPTS_ROOT, "public/work-available.json");
+async function fetchQueue() {
+  // Prefer the local file (freshly built by build-work-available.mjs) over the
+  // remote GitHub Pages copy, which can lag behind by hours/days.
+  if (existsSync(LOCAL_QUEUE_PATH)) {
+    return JSON.parse(await readFile(LOCAL_QUEUE_PATH, "utf8"));
+  }
+  const r = await fetch(REMOTE_QUEUE_URL + "?t=" + Date.now());
+  if (!r.ok) throw new Error("queue fetch failed: " + r.status);
+  return await r.json();
+}
+
+// Treat a contribution as "missing" (i.e., needs work) when the file doesn't
+// exist OR is 0 bytes. Small-but-non-empty results are LEGITIMATE OCR output
+// (some pages OCR to just a few words like "BOTTOM VIEW") and must NOT be
+// re-claimed — doing so causes the auto-picker to loop on the same page.
+function isStub(p) {
+  try {
+    return statSync(p).size === 0;
+  } catch { return true; } // missing → needs work
+}
+
+// Walk `contributions/<handle>/<dir>/<eid>/p####.txt` and find docs that
+// still have at least one un-submitted page. Returns { totalFresh, freshDocs }.
+async function findFreshWork(handle, dir, byEvent, field) {
+  const base = path.resolve(SCRIPTS_ROOT, "contributions", handle, dir);
+  let totalFresh = 0;
+  const freshDocs = [];
+  for (const [eid, doc] of Object.entries(byEvent)) {
+    const pages = doc[field] || [];
+    if (!pages.length) continue;
+    // For visuals the queue items are objects {page,kind,...}; OCR/review are bare numbers.
+    const missing = pages.filter(p => {
+      const num = typeof p === "object" ? p.page : p;
+      return isStub(path.join(base, eid, `p${String(num).padStart(4,"0")}.txt`));
+    });
+    if (missing.length) {
+      freshDocs.push({ eid, freshPages: missing });
+      totalFresh += missing.length;
+    }
+  }
+  return { totalFresh, freshDocs };
+}
+
+// ----- run external command, return stdout (rejects on non-zero exit) -----
+function runCmd(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"], shell: process.platform === "win32", ...opts });
+    let out = "", err = "";
+    p.stdout.on("data", c => { out += c; });
+    p.stderr.on("data", c => { err += c; });
+    p.on("error", reject);
+    p.on("exit", code => code === 0 ? resolve(out) : reject(new Error((err || out || "exit " + code).trim())));
+  });
+}
+
 // ----- jail helper (shared idea with daemon, kept lightweight here) -----
 const ALLOWED_ROOTS = [os.homedir(), process.cwd(), HELPER_DIR].map(p => path.resolve(p));
 function jailPath(p) {
@@ -193,9 +572,219 @@ const server = http.createServer(async (req, res) => {
       const body = await readBody(req);
       state = { ...state, ...body, updatedAt: Date.now() };
       if (Array.isArray(state.recent)) state.recent = state.recent.slice(-6);
-      persistState();   // fire and forget
+      persistState();
       return sendJson(res, 200, { ok: true });
     }
+
+    if (req.method === "GET" && req.url === "/running") {
+      return sendJson(res, 200, {
+        running: !!runningProc,
+        meta: runningMeta,
+        log: state.runnerLog || [],
+        lastRun,
+      });
+    }
+
+    if (req.method === "POST" && req.url === "/run") {
+      const body = await readBody(req);
+      if (!["ocr", "review", "visuals", "visuals-commit", "doc"].includes(body.mode)) {
+        return sendJson(res, 400, { error: "mode must be ocr | review | visuals | visuals-commit | doc" });
+      }
+      if (body.mode === "doc" && !body.eid) {
+        return sendJson(res, 400, { error: "eid required for doc mode" });
+      }
+      // Everything that does vision work needs the daemon. visuals-commit only
+      // validates already-staged templates locally, so it doesn't.
+      if (body.mode !== "visuals-commit") {
+        const alive = await daemonAlive();
+        if (!alive) return sendJson(res, 503, {
+          error: "MCP daemon at http://127.0.0.1:9223 is offline. Start it: cd pursue-vision-mcp && npm start",
+        });
+      }
+      try {
+        await spawnVolunteer(body);
+        return sendJson(res, 200, { ok: true, meta: runningMeta });
+      } catch (e) {
+        return sendJson(res, 409, { error: e.message });
+      }
+    }
+
+    if (req.method === "POST" && req.url === "/stop") {
+      if (!runningProc) return sendJson(res, 200, { ok: true, note: "nothing running" });
+      runningMeta = null;  // clear loop flag so exit handler doesn't restart
+      runningProc.kill("SIGTERM");
+      return sendJson(res, 200, { ok: true });
+    }
+
+    // Daemon health check — surfaced on /health so the dashboard can warn.
+    if (req.method === "GET" && req.url === "/daemon-health") {
+      const alive = await daemonAlive();
+      return sendJson(res, 200, { alive, port: state.daemonPort });
+    }
+
+    // Delete stub contributions (txt < 50 bytes) so retries can happen.
+    // Failed runs leave behind tiny placeholder files that fool the
+    // "already submitted" check.
+    if (req.method === "POST" && req.url === "/clean-stubs") {
+      const body = await readBody(req).catch(() => ({}));
+      const handle = body.handle || state.handle || "Rizzleroc";
+      const dirs = ["gpt-vision", "gpt-vision-review"];
+      let removed = 0;
+      const samples = [];
+      for (const d of dirs) {
+        const root = path.resolve(SCRIPTS_ROOT, "contributions", handle, d);
+        if (!existsSync(root)) continue;
+        const eids = await readdir(root).catch(() => []);
+        for (const eid of eids) {
+          const docDir = path.join(root, eid);
+          let entries;
+          try { entries = await readdir(docDir); } catch { continue; }
+          for (const f of entries) {
+            if (!/^p\d+\.txt$/.test(f)) continue;
+            const fp = path.join(docDir, f);
+            try {
+              const s = statSync(fp);
+              if (s.size < 50) {
+                await rm(fp);
+                const jp = fp.replace(/\.txt$/, ".json");
+                if (existsSync(jp)) { try { await rm(jp); } catch {} }
+                removed++;
+                if (samples.length < 8) samples.push(`${d}/${eid}/${f} (${s.size}B)`);
+              }
+            } catch {}
+          }
+        }
+      }
+      return sendJson(res, 200, { ok: true, removed, samples });
+    }
+
+    // Auto-pick a queue with fresh work. Body: { handle, slice?, loop? }.
+    // Walks OCR → REVIEW → VISUALS, checking each against locally-submitted
+    // files so we don't immediately re-no-op. Returns 409 if everything's
+    // already in flight via open PRs.
+    if (req.method === "POST" && req.url === "/run-any") {
+      const body = await readBody(req);
+      if (!body.handle) return sendJson(res, 400, { error: "handle required" });
+      try {
+        const queue = await fetchQueue();
+        const handle = body.handle;
+        const candidates = [
+          { mode: "ocr",     dir: "gpt-vision",          field: "queue",                  count: queue.totalPagesNeeded },
+          { mode: "review",  dir: "gpt-vision-review",   field: "reviewQueue",            count: queue.totalPagesNeedingReview },
+          { mode: "visuals", dir: "media-staging",       field: "visualsNeedingContext",  count: queue.totalPagesNeedingVisualContext },
+        ];
+        let picked = null;
+        for (const c of candidates) {
+          if (!c.count) continue;
+          const { totalFresh, freshDocs } = await findFreshWork(handle, c.dir, queue.byEvent || {}, c.field);
+          if (totalFresh > 0) { picked = { ...c, totalFresh, freshDocs }; break; }
+        }
+        if (!picked) {
+          return sendJson(res, 409, {
+            error: "every page in every queue is already submitted locally — merge your open PRs or wait for the server to refresh work-available.json",
+            queueCounts: { ocr: queue.totalPagesNeeded, review: queue.totalPagesNeedingReview, visuals: queue.totalPagesNeedingVisualContext },
+          });
+        }
+        if (picked.mode !== "visuals" && !(await daemonAlive())) {
+          return sendJson(res, 503, {
+            error: `picked ${picked.mode} but MCP daemon at http://127.0.0.1:9223 is offline. Start it: cd pursue-vision-mcp && npm start`,
+            picked: picked.mode,
+          });
+        }
+        // Pin to the FIRST doc with fresh pages so the volunteer's slice doesn't
+        // get burned on already-done docs earlier in the queue.
+        const targetDoc = picked.freshDocs[0];
+        // The volunteer takes pages in queue order then skips already-submitted ones.
+        // If queue=[1,6] and only p6 is fresh, slice=1 means it only claims p1 (done)
+        // and exits with nothing to do. We size the slice so the queue window includes
+        // the position of the Nth desired fresh page (N = body.slice || 1).
+        const wantedFreshCount = body.slice || 1;
+        const docEntry = queue.byEvent[targetDoc.eid] || {};
+        const docQueue = picked.mode === "review"
+          ? (docEntry.reviewQueue || [])
+          : picked.mode === "visuals"
+            ? (docEntry.visualsNeedingContext || []).map(v => v.page || v)
+            : (docEntry.queue || []);
+        const freshPageNums = targetDoc.freshPages.map(p => typeof p === "object" ? p.page : p);
+        // Find the index of the Nth fresh page in the doc's full queue.
+        let lastNeededIndex = -1;
+        let freshSeen = 0;
+        for (let i = 0; i < docQueue.length; i++) {
+          if (freshPageNums.includes(docQueue[i])) {
+            freshSeen++;
+            if (freshSeen >= wantedFreshCount) { lastNeededIndex = i; break; }
+          }
+        }
+        const effectiveSlice = lastNeededIndex >= 0 ? lastNeededIndex + 1 : docQueue.length;
+        const runOpts = {
+          mode: picked.mode,
+          slice: effectiveSlice,
+          loop: !!body.loop,
+          handle,
+        };
+        if (picked.mode !== "visuals") runOpts.eid = targetDoc.eid;
+        await spawnVolunteer(runOpts);
+        return sendJson(res, 200, {
+          ok: true, picked: picked.mode,
+          eid: runOpts.eid || null,
+          freshPages: picked.totalFresh,
+          targetPages: targetDoc.freshPages,
+          meta: runningMeta,
+        });
+      } catch (e) {
+        return sendJson(res, 500, { error: e.message });
+      }
+    }
+
+    // List the user's open PRs against the public corpus repo. Uses local gh.
+    if (req.method === "GET" && req.url === "/prs") {
+      try {
+        const out = await runCmd("gh", [
+          "pr", "list",
+          "--repo", "rizzleroc/pursue-console",
+          "--state", "open",
+          "--author", "@me",
+          "--json", "number,title,headRefName,mergeable,statusCheckRollup,url,createdAt",
+          "--limit", "20",
+        ]);
+        const prs = JSON.parse(out || "[]").map(p => ({
+          number: p.number,
+          title: p.title,
+          url: p.url,
+          headRef: p.headRefName,
+          mergeable: p.mergeable,
+          createdAt: p.createdAt,
+          checks: (p.statusCheckRollup || []).map(c => ({
+            name: c.name || c.context || "?",
+            conclusion: c.conclusion || c.state || null,
+            status: c.status || null,
+          })),
+        }));
+        return sendJson(res, 200, { prs });
+      } catch (e) {
+        return sendJson(res, 500, { error: "gh failed: " + e.message });
+      }
+    }
+
+    // Merge a specific PR by number. Body: { number, method?: "squash"|"merge"|"rebase" }
+    if (req.method === "POST" && req.url === "/merge") {
+      const body = await readBody(req);
+      const num = Number(body.number);
+      if (!num) return sendJson(res, 400, { error: "number required" });
+      const method = body.method === "merge" ? "--merge" : body.method === "rebase" ? "--rebase" : "--squash";
+      try {
+        const out = await runCmd("gh", [
+          "pr", "merge", String(num),
+          "--repo", "rizzleroc/pursue-console",
+          method,
+          "--delete-branch",
+        ]);
+        return sendJson(res, 200, { ok: true, output: out });
+      } catch (e) {
+        return sendJson(res, 500, { error: e.message });
+      }
+    }
+
     sendJson(res, 404, { error: "not found" });
   } catch (e) {
     sendJson(res, 500, { error: e.message });

--- a/pursue-vision-mcp/package-lock.json
+++ b/pursue-vision-mcp/package-lock.json
@@ -1,0 +1,576 @@
+{
+  "name": "pursue-vision-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pursue-vision-mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@napi-rs/canvas": "^1.0.0",
+        "pdfjs-dist": "^5.7.284",
+        "playwright": "^1.50.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-x64": "1.0.0",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.7.284",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
+      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.100"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
The full **volunteer-client** — the operator-facing cockpit under `pursue-vision-mcp/` — as a standalone, reviewable unit (no corpus/media data mixed in).

| File | Change |
|------|--------|
| `dashboard.html` | The "PURSUE · Volunteer Instrument" UI: multi-queue breakdown, driver pools, MCP/daemon session tables, failure tickets, job-history with per-job **kill** + **cancel-all** controls. `main` carried a stripped 16KB version that rendered with no controls. |
| `monitor.mjs` | Serves the cockpit on `:9224` (re-read fresh per request), persists progress to `~/.pursue-helper/progress.json`, launches `ocr` / `review` / `visuals` / `visuals-commit` / `doc` runs via `/run` + `/run-any`. |
| `README.md` | Documents the cockpit: run modes, loop semantics, endpoint table, env vars. |
| `package-lock.json` | Locks the client dependencies. |

## Bug fixes folded in (console was "flipping state constantly")
- **Visuals claim phase no longer auto-reloops.** It only stages templates that need a separate commit, so re-looping re-claimed the same pages every ~3s forever (unbounded staging + constant `running`↔`idle` flipping). Only `ocr`/`review`/`doc` loop now.
- **State consistency:** `spawnVolunteer` sets `idle=false` + a `now.phase` immediately, so `/progress` agrees with `/running` (visuals workers never POST progress, which previously left `idle=true` while `running=true`).
- **`procRunning()`** boolean fixed (`!proc.exitCode !== undefined` → `proc.exitCode === null`).
- **Local queue preference:** uses freshly-built `public/work-available.json` over the lagging GitHub Pages copy.

## Verification
- Live: 0 state transitions while idle; during an active run `idle=false`+`running=true` agreed (0 inconsistent samples); run completed once with no respawn.
- Two independent subagents confirmed (code review + live behavioral poll): "the fix holds."

## Test
- `node pursue-vision-mcp/monitor.mjs --no-open`
- Open <http://localhost:9224/dashboard> → all panels + controls render; start a `visuals` loop run → it runs once and stops (no thrash).
