### PR TITLE
fix: restore exact DVIDS embed markup (referrerPolicy)

### DIFF
--- a/src/components/LaunchOverlay.jsx
+++ b/src/components/LaunchOverlay.jsx
@@ -223,9 +223,10 @@ export default function LaunchOverlay({ onClose }) {
                   className="lo-swap absolute inset-0 w-full h-full"
                   src={`https://www.dvidshub.net/video/embed/${clip.videoId}`}
                   title={`${clip.code} — ${clip.tag}`}
-                  allow="autoplay; fullscreen; picture-in-picture; encrypted-media"
+                  allow="autoplay; fullscreen; picture-in-picture"
                   allowFullScreen
                   loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
                 />
               </div>
               <div key={`meta-${swapKey}`} className="lo-swap mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">

--- a/src/views/MediaView.jsx
+++ b/src/views/MediaView.jsx
@@ -357,9 +357,10 @@ export default function MediaView({ onSelect }) {
                     className="w-full h-full"
                     src={`https://www.dvidshub.net/video/embed/${focused.videoId}`}
                     title={focused.title || "DVIDS video"}
-                    allow="autoplay; fullscreen; picture-in-picture; encrypted-media"
+                    allow="autoplay; fullscreen; picture-in-picture"
                     allowFullScreen
                     loading="lazy"
+                    referrerPolicy="no-referrer-when-downgrade"
                   />
                 </div>
               ) : focused.imagePath ? (


### PR DESCRIPTION
## Summary
Restores the **exact** DVIDS embed markup that worked originally. The earlier "restore" accidentally changed two attributes:
- dropped `referrerPolicy="no-referrer-when-downgrade"` (DVIDS's embed appears to gate on the referer header — this is the likely cause of the broken box), and
- added `encrypted-media` to `allow`.

Both the launch overlay player and the Media library video modal now use the original attributes.

## Test plan
- [ ] Launch overlay featured clip plays inline.
- [ ] Media library → VIDEO tile → modal plays inline.

https://claude.ai/code/session_01FzMhp3o4GJeFW91b55k4Fe

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzMhp3o4GJeFW91b55k4Fe)_