### PR TITLE
fix(launch): use real DVIDS id (1007713) for featured spherical UAP clip

### DIFF
--- a/src/components/LaunchOverlay.jsx
+++ b/src/components/LaunchOverlay.jsx
@@ -11,7 +11,7 @@ const SEEN_KEY = "pursue:launch-2.0-seen";
 
 // Curated, ranked. Each clip is real DVIDS sensor footage from Release 01.
 const CLIPS = [
-  { videoId: "DOD_111719732", code: "PR-54", tag: "SPHERICAL UAP · ERRATIC", loc: "Middle East · 2022", flag: "anchor", line: 'Metallic spherical orb over the Middle East exhibiting erratic movement — the headline clip of the release. (DOW-UAP-PR-54, 2022.)' },
+  { videoId: "1007713", code: "PR-55", tag: "SPHERICAL UAP · OVER AFGHANISTAN", loc: "Afghanistan · 23 Nov 2020", flag: "anchor", line: 'Spherical UAP over Afghanistan, emerging from and moving out of the clouds — the headline clip of the release. (DOW-UAP-PR-55, 23 Nov 2020.)' },
   { videoId: "1006073", code: "PR-28", tag: "SWIR-ONLY DIAMOND",   loc: "Mediterranean Sea", flag: "anchor", line: 'Diamond with a probe at ~434 kts — visible ONLY on short-wave IR. Invisible to the naked eye.' },
   { videoId: "1006106", code: "PR-46", tag: "FOOTBALL-SHAPED BODY", loc: "East China Sea",     flag: "anchor", line: "Football body with three radial projections. The most distinctive morphology in the tranche." },
   { videoId: "1006080", code: "PR-34", tag: 'SEA-SKIM "90° TURNS"', loc: "Aegean Sea",         flag: "anchor", line: 'Multiple 90-degree turns at ~80 mph, just above the ocean surface.' },


### PR DESCRIPTION
## Summary
Swaps the placeholder asset id for the real numeric DVIDS video id and corrects the metadata for the headline clip:
- `videoId`: **1007713**
- **PR-55** — "Spherical UAP over Afghanistan, out of clouds, 23 Nov 2020"
- Source: https://www.dvidshub.net/video/1007713/dow-uap-pr055-spherical-uap-over-afg-and-out-clouds-23-nov-2020

This is the first/default clip in the launch overlay reel.

https://claude.ai/code/session_01FzMhp3o4GJeFW91b55k4Fe

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzMhp3o4GJeFW91b55k4Fe)_