### PR TITLE
war.gov: direct-fetch fallback + SessionStart hook + setup docs

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Claude Code on the Web — SessionStart hook for pursue-console.
+#
+# Purpose: get the sandbox ready for the pipeline scripts (build, lint,
+# and especially the war.gov ingestion flow that needs Playwright +
+# bundled Chromium). Never blocks a session — always exits 0, even if
+# parts of setup couldn't complete. The agent can re-run any missing
+# step on demand.
+#
+# What it does (in order):
+#   1. `npm install` at repo root if node_modules is missing — needed
+#      for `npm run lint`, the build, and the corpus:* scripts.
+#   2. `npm install` in pursue-vision-mcp/ if its node_modules is
+#      missing — needed before `npm start --prefix pursue-vision-mcp`
+#      can connect-over-CDP to drive war.gov.
+#   3. Check for the bundled Playwright Chromium binary at
+#      /opt/pw-browsers/chromium-1194/chrome-linux/chrome and expose
+#      PLAYWRIGHT_BROWSERS_PATH via $CLAUDE_ENV_FILE so the MCP picks
+#      it up without re-downloading.
+#
+# What it deliberately doesn't do:
+#   - Launch Chrome. The browser is opt-in; sync-war-gov.mjs only
+#     needs it when actually pulling release files. Starting it here
+#     would leak processes across compactions.
+#   - Launch the MCP daemon (`npm start --prefix pursue-vision-mcp`).
+#     Same reason — opt-in, and it expects an already-logged-in tab
+#     anyway which a headless sandbox doesn't have.
+#   - Add hostnames to the egress allowlist. That's an environment-
+#     level setting in the Claude Code Web UI, not something a hook
+#     can mutate. See docs/war-gov-setup.md for the list.
+
+set -uo pipefail
+
+# Only run in the remote (Claude Code on the Web) sandbox — local
+# clones already have their own dev setup, and we don't want to
+# stomp on a contributor's existing node_modules.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+MCP_DIR="$PROJECT_DIR/pursue-vision-mcp"
+CHROMIUM_BIN="/opt/pw-browsers/chromium-1194/chrome-linux/chrome"
+
+# Tag every line so the session log shows which step is talking.
+log() { printf '[session-start] %s\n' "$*"; }
+
+# 1. Top-level deps.
+if [ ! -d "$PROJECT_DIR/node_modules" ]; then
+  log "installing top-level deps (npm install)..."
+  ( cd "$PROJECT_DIR" && npm install --no-audit --no-fund --loglevel=error ) \
+    || log "WARN: top-level npm install failed; lint/build will be unavailable until rerun"
+else
+  log "top-level node_modules present, skipping npm install"
+fi
+
+# 2. MCP deps (playwright).
+if [ -d "$MCP_DIR" ] && [ ! -d "$MCP_DIR/node_modules" ]; then
+  log "installing pursue-vision-mcp deps (playwright)..."
+  ( cd "$MCP_DIR" && npm install --no-audit --no-fund --loglevel=error ) \
+    || log "WARN: pursue-vision-mcp npm install failed; war.gov sync via MCP will be unavailable until rerun"
+elif [ -d "$MCP_DIR/node_modules" ]; then
+  log "pursue-vision-mcp node_modules present, skipping npm install"
+fi
+
+# 3. Verify bundled Chromium + persist its location for the session.
+if [ -x "$CHROMIUM_BIN" ]; then
+  log "bundled Chromium found at $CHROMIUM_BIN"
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    echo "export PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers" >> "$CLAUDE_ENV_FILE"
+    log "PLAYWRIGHT_BROWSERS_PATH exported via CLAUDE_ENV_FILE"
+  fi
+else
+  log "WARN: bundled Chromium not found at $CHROMIUM_BIN"
+  log "      a fresh \`npx playwright install chromium\` requires cdn.playwright.dev"
+  log "      to be on the env allowlist (see docs/war-gov-setup.md)"
+fi
+
+log "ready (war.gov ingestion still needs *.war.gov in the egress allowlist;"
+log " see docs/war-gov-setup.md)"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/war-gov-setup.md
+++ b/docs/war-gov-setup.md
@@ -1,0 +1,52 @@
+# war.gov ingestion — environment setup
+
+The pipeline pulls war.gov UAP release files through `scripts/sync-war-gov.mjs`. The script auto-picks between two paths:
+
+- **MCP daemon path** (preferred): drives a logged-in Chrome tab via the [`pursue-vision-mcp`](../pursue-vision-mcp/) daemon on `:9223`. In-page `fetch()` inherits the browser's TLS handshake, which is the only thing Akamai's fingerprinting on war.gov reliably accepts.
+- **Direct path** (`scripts/lib/war-gov-direct.mjs`): plain Node `fetch`, used when the daemon isn't running. Usually trips Akamai against live war.gov; mainly useful for mirrors via `--base-url`.
+
+## Network allowlist
+
+Claude Code on the Web sandboxes restrict outbound traffic to a per-environment allowlist. For the war.gov flow to work end-to-end inside a sandbox, the following hosts have to be added to the environment's network policy in the web UI (this can't be configured from inside the sandbox):
+
+| Host | Why |
+| --- | --- |
+| `*.war.gov` | The release files and the `/UFO/` landing page. |
+| `cdn.playwright.dev` | Only if Playwright needs to download Chromium fresh. The current sandbox image ships a bundled binary at `/opt/pw-browsers/chromium-1194/`; if that's still there, this entry is optional. |
+| `*.akamaihd.net`, `*.akamai.net` | War.gov serves some assets via Akamai's CDN. Add as a wildcard to avoid one-off failures on specific releases. |
+
+Docs for the env config UI: https://code.claude.com/docs/en/claude-code-on-the-web
+
+## Running the sync
+
+Once the allowlist is set:
+
+```bash
+# Auto-pick (daemon if up on :9223, else direct):
+node scripts/sync-war-gov.mjs --release=02 --dry-run
+
+# Force the MCP path (errors out if the daemon isn't healthy):
+node scripts/sync-war-gov.mjs --release=02 --prefer-mcp
+
+# Force the direct path (skip the daemon probe entirely):
+node scripts/sync-war-gov.mjs --release=02 --prefer-direct
+
+# Point the direct path at a mirror:
+node scripts/sync-war-gov.mjs --release=02 --prefer-direct --base-url=https://example.com
+```
+
+To start the MCP daemon (it expects an already-authenticated Chrome tab and won't help in a headless sandbox by itself):
+
+```bash
+npm start --prefix pursue-vision-mcp
+```
+
+## What the SessionStart hook does
+
+`.claude/hooks/session-start.sh` runs on every sandbox boot and only inside Claude Code on the Web (`CLAUDE_CODE_REMOTE=true`). It:
+
+1. Installs top-level `node_modules` if missing.
+2. Installs `pursue-vision-mcp/node_modules` if missing.
+3. Verifies the bundled Chromium at `/opt/pw-browsers/chromium-1194/chrome-linux/chrome` and exports `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` for the session.
+
+It deliberately does **not** launch Chrome or the MCP daemon — those are opt-in and would leak processes across compactions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pursue-console",
-  "version": "0.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pursue-console",
-      "version": "0.0.0",
+      "version": "2.2.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "minisearch": "^7.2.0",
@@ -77,7 +77,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -285,6 +284,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1738,7 +1759,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1785,7 +1805,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2078,7 +2097,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2456,7 +2474,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3259,7 +3276,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4371,7 +4387,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4494,7 +4509,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4763,7 +4777,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5541,7 +5554,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5708,7 +5720,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/lib/war-gov-direct.mjs
+++ b/scripts/lib/war-gov-direct.mjs
@@ -1,0 +1,439 @@
+// war-gov-direct.mjs — Node-side war.gov index + download client.
+//
+// Mirror of the request shape implemented in
+// pursue-vision-mcp/war-gov-driver.mjs (which goes through Chrome via CDP).
+// This module is the no-daemon fallback: same discovery strategies, same
+// record normalization, same Akamai-block detection — just plain Node
+// `fetch` instead of an in-page browser fetch.
+//
+// IMPORTANT CAVEAT: the MCP driver's docstring already says it, and it's
+// still true here: live www.war.gov uses Akamai TLS fingerprinting that
+// rejects most Node-side HTTP clients. Empirically a sandboxed `curl`
+// gets HTTP 403 or "Host not in allowlist", and `node fetch` fares the
+// same. The direct path is therefore expected to *work* against:
+//   - mirrors (e.g. github.com/DenisSergeevitch/UFO-USA) when pointed at
+//     them via `baseUrl`,
+//   - any environment whose egress IP isn't on Akamai's denylist,
+//   - future war.gov endpoints that relax the fingerprint check.
+// Against live war.gov from a typical server, it will throw an Akamai
+// block error and the caller should fall back to the MCP daemon flow.
+//
+// Public surface:
+//   fetchIndexDirect({ release, baseUrl?, fetchImpl? }) → records[]
+//   downloadFileDirect({ url, destPath, timeoutMs?, onProgress?, fetchImpl? }) → { bytes, durationMs }
+
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+const DEFAULT_BASE_URL = "https://www.war.gov";
+const INDEX_LOAD_TIMEOUT = 30_000;
+const DOWNLOAD_TIMEOUT_DEFAULT = 30 * 60_000;
+const CHUNK_BYTES = 8 * 1024 * 1024;
+const LARGE_FILE_THRESHOLD = 50 * 1024 * 1024;
+
+// Pretend to be a real browser. Akamai will still fingerprint the TLS
+// handshake itself (which is what the in-page fetch sidesteps), but a
+// realistic UA + Accept headers at least don't get rejected on the
+// trivial heuristics.
+const BROWSER_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.9",
+};
+
+const AKAMAI_BLOCK_STATUS = new Set([403, 406, 429, 503]);
+const AKAMAI_BODY_PATTERNS = [
+  /access\s+denied/i,
+  /reference\s*#\s*\d+\.[0-9a-f]+/i,
+  /pardon\s+our\s+interruption/i,
+  /www\.war\.gov\s+blocked\b/i,
+];
+
+const INDEX_CANDIDATE_PATHS = [
+  "/UFO/api/records",
+  "/UFO/api/records.json",
+  "/UFO/api/files",
+  "/UFO/index.json",
+  "/UFO/records.json",
+  "/UFO/records.csv",
+  "/UFO/manifest.json",
+];
+
+function recordMatchesRelease(rec, releaseN) {
+  const tag = `release_${releaseN}`;
+  const r = rec.release ?? rec.releaseId ?? rec.release_number ?? rec.release_id;
+  if (r != null) {
+    const s = String(r).toLowerCase();
+    if (s === tag) return true;
+    if (s === String(releaseN)) return true;
+  }
+  const u = String(rec.url || rec.href || rec.path || rec.file_url || "").toLowerCase();
+  if (u.includes(`/${tag}/`)) return true;
+  return false;
+}
+
+function normalizeRecord(rec, baseUrl) {
+  const url = rec.url || rec.href || rec.file_url || rec.download_url || rec.path;
+  if (!url) return null;
+  const absUrl = url.startsWith("http") ? url : new URL(url, baseUrl).href;
+  const filename = rec.filename || rec.name || path.basename(new URL(absUrl).pathname);
+  const ext = (path.extname(filename) || "").toLowerCase().replace(/^\./, "");
+  const type = rec.type || rec.media_type ||
+    (["pdf"].includes(ext) ? "pdf"
+      : ["mp3", "wav", "m4a", "ogg", "flac"].includes(ext) ? "audio"
+      : ["mp4", "mov", "webm", "mkv", "avi"].includes(ext) ? "video"
+      : "other");
+  return {
+    filename,
+    url: absUrl,
+    agency: rec.agency || rec.org || rec.source || null,
+    type,
+    sizeBytes: rec.sizeBytes ?? rec.size_bytes ?? rec.size ?? null,
+  };
+}
+
+function looksLikeAkamaiBlock(status, body) {
+  if (status && AKAMAI_BLOCK_STATUS.has(Number(status))) return true;
+  if (typeof body === "string") {
+    for (const re of AKAMAI_BODY_PATTERNS) if (re.test(body)) return true;
+  }
+  return false;
+}
+
+function safeParseJson(text) {
+  try { return JSON.parse(text); } catch { return null; }
+}
+
+function splitCsvLine(line) {
+  const out = [];
+  let cur = "";
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQ) {
+      if (ch === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (ch === '"') inQ = false;
+      else cur += ch;
+    } else {
+      if (ch === ',') { out.push(cur); cur = ""; }
+      else if (ch === '"') inQ = true;
+      else cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+function parseCsv(text) {
+  const lines = text.replace(/\r\n/g, "\n").split("\n").filter(l => l.length);
+  if (!lines.length) return [];
+  const cells = lines.map(splitCsvLine);
+  const header = cells[0].map(h => h.trim());
+  return cells.slice(1).map(row => {
+    const obj = {};
+    for (let i = 0; i < header.length; i++) obj[header[i]] = row[i] ?? "";
+    return obj;
+  });
+}
+
+// Scrape HTML for /medialink/ufo/release_<n>/ anchors. Cheap; works when
+// the DoW page renders its file list server-side, even with no JS. We
+// regex over the raw HTML rather than parsing because the page shape is
+// unverified and we only need href + visible link text.
+function scrapeAnchorsForRelease(html, releaseN, baseUrl) {
+  const tag = `/medialink/ufo/release_${releaseN}/`;
+  const re = /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  const seen = new Set();
+  const out = [];
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const href = m[1];
+    if (!href.toLowerCase().includes(tag.toLowerCase())) continue;
+    const absUrl = href.startsWith("http") ? href : new URL(href, baseUrl).href;
+    if (seen.has(absUrl)) continue;
+    seen.add(absUrl);
+    const text = m[2].replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    out.push({
+      url: absUrl,
+      filename: decodeURIComponent(absUrl.split("/").pop().split("?")[0]),
+      agency: text || null,
+    });
+  }
+  return out;
+}
+
+async function fetchWithTimeout(fetchImpl, url, init, timeoutMs) {
+  const ctl = new AbortController();
+  const to = setTimeout(() => ctl.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: ctl.signal });
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+async function tryFetchIndexUrl(fetchImpl, url) {
+  let res;
+  try {
+    res = await fetchWithTimeout(
+      fetchImpl, url,
+      { headers: { ...BROWSER_HEADERS, Accept: "application/json, text/csv, */*" } },
+      INDEX_LOAD_TIMEOUT,
+    );
+  } catch {
+    return null;
+  }
+  const text = await res.text().catch(() => "");
+  if (!res.ok) {
+    if (looksLikeAkamaiBlock(res.status, text)) {
+      throw new Error(
+        `war-gov: Akamai block on ${url} (status ${res.status}). ` +
+        `The direct path can't bypass TLS fingerprinting; start the MCP daemon ` +
+        `(npm start --prefix pursue-vision-mcp) and re-run.`
+      );
+    }
+    return null;
+  }
+  const ct = (res.headers.get("content-type") || "").toLowerCase();
+  let parsed;
+  if (ct.includes("csv") || /\.csv(\?|$)/i.test(url)) parsed = parseCsv(text);
+  else parsed = safeParseJson(text);
+  if (!Array.isArray(parsed)) {
+    if (parsed && typeof parsed === "object") {
+      for (const k of ["records", "data", "files", "items", "results"]) {
+        if (Array.isArray(parsed[k])) return parsed[k];
+      }
+    }
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Fetch the war.gov release-files index via Node-side fetch.
+ *
+ * Strategies, in order:
+ *   1. Probe likely JSON/CSV index paths under baseUrl.
+ *   2. Fetch the /UFO/ landing page HTML and scrape `/medialink/ufo/release_<n>/`
+ *      anchors out of it.
+ *
+ * (The MCP driver also has a network-intercept strategy on a real page
+ * load — we can't do that without a browser, so it's omitted.)
+ */
+export async function fetchIndexDirect({
+  release,
+  baseUrl = DEFAULT_BASE_URL,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const releaseN = Number(String(release).replace(/^release[_-]?/i, ""));
+  if (!Number.isInteger(releaseN) || releaseN < 1) {
+    throw new Error(`fetchIndexDirect: invalid release '${release}' (expected '1', '2', 'release_2', etc.)`);
+  }
+
+  // (1) Probe likely index URLs.
+  for (const candidatePath of INDEX_CANDIDATE_PATHS) {
+    const candidateUrl = new URL(candidatePath, baseUrl).href;
+    const records = await tryFetchIndexUrl(fetchImpl, candidateUrl);
+    if (records?.length) {
+      return records
+        .filter(r => recordMatchesRelease(r, releaseN))
+        .map(r => normalizeRecord(r, baseUrl))
+        .filter(Boolean);
+    }
+  }
+
+  // (2) Scrape the landing page HTML.
+  const landingUrl = new URL("/UFO/", baseUrl).href;
+  let html = "";
+  try {
+    const res = await fetchWithTimeout(
+      fetchImpl, landingUrl, { headers: BROWSER_HEADERS }, INDEX_LOAD_TIMEOUT,
+    );
+    const body = await res.text().catch(() => "");
+    if (!res.ok) {
+      if (looksLikeAkamaiBlock(res.status, body)) {
+        throw new Error(
+          `war-gov: Akamai block on ${landingUrl} (status ${res.status}). ` +
+          `The direct path can't bypass TLS fingerprinting; start the MCP daemon ` +
+          `(npm start --prefix pursue-vision-mcp) and re-run.`
+        );
+      }
+      throw new Error(`war-gov: landing page fetch failed (status ${res.status})`);
+    }
+    if (looksLikeAkamaiBlock(200, body)) {
+      throw new Error(
+        `war-gov: Akamai challenge body on ${landingUrl}. ` +
+        `Start the MCP daemon and clear the challenge in a real browser tab.`
+      );
+    }
+    html = body;
+  } catch (e) {
+    // Re-throw Akamai errors clearly; let network errors bubble too.
+    throw new Error(`war-gov: index discovery failed — ${e.message || e}`);
+  }
+  const scraped = scrapeAnchorsForRelease(html, releaseN, baseUrl);
+  if (scraped.length) {
+    return scraped.map(r => normalizeRecord(r, baseUrl)).filter(Boolean);
+  }
+
+  throw new Error(
+    `war-gov: could not locate a release-${releaseN} file index via direct fetch. ` +
+    `Tried ${INDEX_CANDIDATE_PATHS.length} candidate paths + landing-page DOM scrape. ` +
+    `If the daemon is available, run with --prefer-mcp; otherwise inspect ${landingUrl} ` +
+    `manually and extend INDEX_CANDIDATE_PATHS.`
+  );
+}
+
+async function renameAtomic(src, dest) {
+  try { await rename(src, dest); }
+  catch {
+    await new Promise(r => setTimeout(r, 100));
+    await rename(src, dest);
+  }
+}
+
+/**
+ * Download a single war.gov asset via Node-side fetch.
+ * Big files use HTTP Range requests in 8 MB chunks streamed straight to
+ * disk; small/no-range files use a one-shot GET.
+ *
+ * Throws on Akamai block so we never write a challenge HTML body to disk
+ * pretending it's a PDF.
+ */
+export async function downloadFileDirect({
+  url,
+  destPath,
+  timeoutMs = DOWNLOAD_TIMEOUT_DEFAULT,
+  onProgress,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (!url) throw new Error("downloadFileDirect: url required");
+  if (!destPath) throw new Error("downloadFileDirect: destPath required");
+
+  await mkdir(path.dirname(destPath), { recursive: true });
+  const partPath = destPath + ".part";
+  await rm(partPath, { force: true });
+
+  const t0 = Date.now();
+
+  // Probe with a tiny Range request to learn size + range support.
+  const probe = await fetchWithTimeout(
+    fetchImpl, url,
+    { headers: { ...BROWSER_HEADERS, Range: "bytes=0-0" } },
+    INDEX_LOAD_TIMEOUT,
+  );
+  if (!probe.ok && probe.status !== 206) {
+    const body = await probe.text().catch(() => "");
+    if (looksLikeAkamaiBlock(probe.status, body)) {
+      throw new Error(`war-gov: Akamai block on probe of ${url} (status ${probe.status})`);
+    }
+    throw new Error(`war-gov: probe failed for ${url} (status ${probe.status})`);
+  }
+  // Discard probe body to free the connection.
+  await probe.arrayBuffer().catch(() => {});
+
+  const contentRange = probe.headers.get("content-range");
+  const contentLength = probe.headers.get("content-length");
+  const acceptRanges = (probe.headers.get("accept-ranges") || "").toLowerCase();
+  let totalBytes = null;
+  const m = (contentRange || "").match(/\/(\d+)$/);
+  if (m) totalBytes = Number(m[1]);
+  else if (contentLength) totalBytes = Number(contentLength);
+  const rangesOk = acceptRanges.includes("bytes") || !!contentRange;
+
+  // Small / no-range path: stream the whole body to disk in one GET.
+  if (!totalBytes || totalBytes <= LARGE_FILE_THRESHOLD || !rangesOk) {
+    if (totalBytes && totalBytes > LARGE_FILE_THRESHOLD && !rangesOk) {
+      throw new Error(
+        `war-gov: ${url} is ${(totalBytes / 1024 / 1024).toFixed(1)} MB and the server ` +
+        `did not advertise byte ranges; refusing one-shot transfer.`
+      );
+    }
+    const res = await fetchWithTimeout(
+      fetchImpl, url, { headers: BROWSER_HEADERS }, timeoutMs,
+    );
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      if (looksLikeAkamaiBlock(res.status, body)) {
+        throw new Error(`war-gov: Akamai block on ${url} (status ${res.status})`);
+      }
+      throw new Error(`war-gov: fetch failed for ${url} (status ${res.status})`);
+    }
+    if (!res.body) {
+      // Some fetch impls give no body stream — fall back to buffered write.
+      const buf = Buffer.from(await res.arrayBuffer());
+      await writeFile(partPath, buf);
+    } else {
+      await pipeline(Readable.fromWeb(res.body), createWriteStream(partPath));
+    }
+    await renameAtomic(partPath, destPath);
+    const { size } = await import("node:fs/promises").then(m => m.stat(destPath));
+    if (onProgress) onProgress({ bytes: size, total: size, done: true });
+    return { bytes: size, durationMs: Date.now() - t0 };
+  }
+
+  // Big file → range-chunk to disk.
+  const stream = createWriteStream(partPath, { flags: "w" });
+  let writtenBytes = 0;
+  try {
+    for (let start = 0; start < totalBytes; start += CHUNK_BYTES) {
+      if (Date.now() - t0 > timeoutMs) {
+        throw new Error(
+          `war-gov: download timeout after ${timeoutMs}ms (got ${writtenBytes}/${totalBytes} bytes)`,
+        );
+      }
+      const end = Math.min(start + CHUNK_BYTES - 1, totalBytes - 1);
+      const res = await fetchWithTimeout(
+        fetchImpl, url,
+        { headers: { ...BROWSER_HEADERS, Range: `bytes=${start}-${end}` } },
+        INDEX_LOAD_TIMEOUT,
+      );
+      if (!res.ok && res.status !== 206) {
+        const body = await res.text().catch(() => "");
+        if (looksLikeAkamaiBlock(res.status, body)) {
+          throw new Error(`war-gov: Akamai block on Range ${start}-${end} of ${url}`);
+        }
+        throw new Error(`war-gov: Range ${start}-${end} failed — status ${res.status}`);
+      }
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (buf.length !== (end - start + 1)) {
+        // Some CDNs ignore Range and send the whole body on the first
+        // request. If that's the case on chunk 0, just take it and stop.
+        if (start === 0 && buf.length === totalBytes) {
+          if (!stream.write(buf)) await new Promise(r => stream.once("drain", r));
+          writtenBytes = buf.length;
+          break;
+        }
+        throw new Error(
+          `war-gov: short chunk at bytes=${start}-${end} (got ${buf.length}, expected ${end - start + 1})`,
+        );
+      }
+      if (!stream.write(buf)) await new Promise(r => stream.once("drain", r));
+      writtenBytes += buf.length;
+      if (onProgress) onProgress({ bytes: writtenBytes, total: totalBytes, done: false });
+    }
+  } catch (e) {
+    stream.destroy();
+    try { await rm(partPath, { force: true }); } catch {}
+    throw e;
+  }
+  await new Promise((resolve, reject) => stream.end(err => err ? reject(err) : resolve()));
+  await renameAtomic(partPath, destPath);
+  if (onProgress) onProgress({ bytes: writtenBytes, total: totalBytes, done: true });
+  return { bytes: writtenBytes, durationMs: Date.now() - t0 };
+}
+
+// Exposed for tests + the sync script's filter logic.
+export const _internals = {
+  INDEX_CANDIDATE_PATHS,
+  recordMatchesRelease,
+  normalizeRecord,
+  looksLikeAkamaiBlock,
+  parseCsv,
+  scrapeAnchorsForRelease,
+};

--- a/scripts/sync-war-gov.mjs
+++ b/scripts/sync-war-gov.mjs
@@ -1,23 +1,22 @@
-// sync-war-gov.mjs — pull a war.gov release directly via the MCP daemon.
+// sync-war-gov.mjs — pull a war.gov release. Prefers the MCP daemon on
+// :9223 (Chrome / in-page fetch, Akamai-bypass) when it's running; falls
+// back to a direct Node-side fetch otherwise. The fallback uses
+// scripts/lib/war-gov-direct.mjs and will fail loudly with a clear
+// "Akamai block" message when run against live war.gov from an
+// IP/TLS-fingerprint the WAF rejects.
 //
-// @unverified — never run against live www.war.gov. The maintainer's
-// real Chrome (with a logged-in war.gov tab that has cleared any one-time
-// Akamai challenge) is the first live test. Until that happens, this
-// script is scaffold-only.
-//
-// What it does:
-//   1. Asks the daemon for the release-N file index (the daemon does
-//      the in-page TLS-bypass fetch through Chrome).
-//   2. Filters by file type (pdf / audio / video / other).
-//   3. Asks the daemon to download every URL into
-//      data-raw/war-gov/release_<n>/ (jail-checked daemon-side).
-//   4. Reports per-file ok/error and prints a follow-up command for
-//      whisper transcription of audio/video.
+// @unverified — the live-test gate still applies. Neither path has been
+// run end-to-end against a real release. The MCP path needs the
+// maintainer's logged-in Chrome with a cleared Akamai challenge; the
+// direct path needs an egress that war.gov's WAF doesn't reject.
 //
 // Usage:
-//   node scripts/sync-war-gov.mjs                                  # release 2, all types
+//   node scripts/sync-war-gov.mjs                                  # release 2, all types, auto-pick path
 //   node scripts/sync-war-gov.mjs --release=02 --types=pdf         # PDFs only
 //   node scripts/sync-war-gov.mjs --dry-run                        # plan only, no download
+//   node scripts/sync-war-gov.mjs --prefer-direct                  # skip daemon probe, use Node fetch
+//   node scripts/sync-war-gov.mjs --prefer-mcp                     # require the daemon (error if missing)
+//   node scripts/sync-war-gov.mjs --base-url=https://example.com/  # point the direct path at a mirror
 //
 // Options:
 //   --release=02                Release number (default 02)
@@ -25,16 +24,21 @@
 //   --daemon=http://127.0.0.1:9223
 //   --dry-run                   Fetch index, print plan, don't download
 //   --token-file=~/.pursue-vision-token
+//   --prefer-direct             Skip the daemon and go straight to Node fetch
+//   --prefer-mcp                Require the daemon; exit 1 if it isn't healthy
+//   --base-url=<url>            Override war.gov base for the direct path (e.g. a mirror)
 //
 // Exit codes:
 //   0  every file succeeded
-//   1  setup error (no daemon, bad args, etc.)
+//   1  setup error (no daemon AND prefer-mcp, bad args, etc.)
 //   2  partial completion (some files succeeded, some failed)
 
-import { readFile } from "node:fs/promises";
+import { readFile, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { fetchIndexDirect, downloadFileDirect } from "./lib/war-gov-direct.mjs";
 
 process.on("unhandledRejection", e => console.error("  ! unhandled:", e?.message || e));
 
@@ -54,27 +58,64 @@ const DAEMON = (args.daemon || "http://127.0.0.1:9223").replace(/\/+$/, "");
 const DRY = !!args["dry-run"];
 const TYPES_ARG = String(args.types || "pdf,audio,video,other").toLowerCase();
 const TYPE_FILTER = new Set(TYPES_ARG.split(",").map(s => s.trim()).filter(Boolean));
+const PREFER_DIRECT = !!args["prefer-direct"];
+const PREFER_MCP = !!args["prefer-mcp"];
+const BASE_URL = args["base-url"] || "https://www.war.gov";
+
+if (PREFER_DIRECT && PREFER_MCP) {
+  console.error("error: --prefer-direct and --prefer-mcp are mutually exclusive");
+  process.exit(1);
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const DEST_DIR = path.join(ROOT, "data-raw", "war-gov", `release_${RELEASE_N}`);
 const TOKEN_FILE = (args["token-file"] || "~/.pursue-vision-token").replace(/^~/, os.homedir());
 
-// Reuse the same token-discovery shape volunteer.mjs uses so a
-// maintainer with the primary MCP already running (~/.whipgen-token)
-// doesn't have to set anything.
+// ----- daemon probe -----
+async function isDaemonHealthy() {
+  try {
+    const r = await fetch(`${DAEMON}/health`, { signal: AbortSignal.timeout(2000) });
+    return r.ok;
+  } catch { return false; }
+}
+
+// Token discovery — same shape volunteer.mjs uses so a maintainer with
+// the primary MCP already running (~/.whipgen-token) doesn't have to set
+// anything. Only required when we actually go through the daemon.
 async function loadToken() {
   if (process.env.PURSUE_VISION_TOKEN) return process.env.PURSUE_VISION_TOKEN;
   if (process.env.WHIPGEN_TOKEN) return process.env.WHIPGEN_TOKEN;
   for (const p of [path.join(os.homedir(), ".whipgen-token"), TOKEN_FILE]) {
     try { return (await readFile(p, "utf8")).trim(); } catch {}
   }
-  console.error(`error: no token. Start the daemon first (it writes ${TOKEN_FILE}), or set PURSUE_VISION_TOKEN.`);
+  return null;
+}
+
+// ----- pick a path -----
+const daemonUp = !PREFER_DIRECT && await isDaemonHealthy();
+const usingMcp = daemonUp && !PREFER_DIRECT;
+
+if (PREFER_MCP && !daemonUp) {
+  console.error(`error: --prefer-mcp set but daemon at ${DAEMON} is not healthy.`);
+  console.error("       start it with:  npm start --prefix pursue-vision-mcp");
   process.exit(1);
 }
-const TOKEN = await loadToken();
 
-async function jsonFetch(method, urlPath, body) {
+console.log(
+  `[sync-war-gov] release ${RELEASE_N} · types [${[...TYPE_FILTER].join(",")}] · ` +
+  `via ${usingMcp ? `MCP daemon ${DAEMON}` : `direct fetch (${BASE_URL})`}`
+);
+if (!usingMcp && !PREFER_DIRECT) {
+  console.log(
+    "[sync-war-gov] note: MCP daemon not reachable on " + DAEMON + " — falling back to direct fetch.\n" +
+    "               Direct fetch usually trips Akamai on live war.gov; if that happens, start the daemon."
+  );
+}
+
+// ----- MCP path: HTTP calls into the daemon -----
+let TOKEN = null;
+async function jsonFetchDaemon(method, urlPath, body) {
   const url = `${DAEMON}${urlPath}`;
   const init = {
     method,
@@ -84,7 +125,6 @@ async function jsonFetch(method, urlPath, body) {
     init.headers["Content-Type"] = "application/json";
     init.body = JSON.stringify(body);
   }
-  // No client-side timeout: /war-gov/download is long-running by design.
   const res = await fetch(url, init);
   const text = await res.text();
   let parsed;
@@ -96,26 +136,71 @@ async function jsonFetch(method, urlPath, body) {
   return parsed;
 }
 
-// 1. Pull the release index. The daemon's /war-gov/index does the
-//    Akamai-bypass dance through Chrome.
-console.log(`[sync-war-gov] release ${RELEASE_N} · types [${[...TYPE_FILTER].join(",")}] · daemon ${DAEMON}`);
-let indexRes;
+async function fetchIndexViaMcp() {
+  const indexRes = await jsonFetchDaemon("GET", `/war-gov/index?release=${RELEASE_N}`);
+  return Array.isArray(indexRes.records) ? indexRes.records : [];
+}
+
+async function downloadViaMcp(urls) {
+  const download = await jsonFetchDaemon("POST", "/war-gov/download", {
+    urls, destDir: DEST_DIR,
+  });
+  return Array.isArray(download.results) ? download.results : [];
+}
+
+// ----- Direct path: Node fetch via scripts/lib/war-gov-direct.mjs -----
+async function fetchIndexViaDirect() {
+  return await fetchIndexDirect({ release: RELEASE_N, baseUrl: BASE_URL });
+}
+
+async function downloadViaDirect(records) {
+  await mkdir(DEST_DIR, { recursive: true });
+  const results = [];
+  for (const rec of records) {
+    const destPath = path.join(DEST_DIR, rec.filename);
+    try {
+      const { bytes, durationMs } = await downloadFileDirect({
+        url: rec.url, destPath,
+      });
+      results.push({ url: rec.url, ok: true, bytes, destPath, durationMs });
+    } catch (e) {
+      results.push({ url: rec.url, ok: false, error: e.message || String(e) });
+    }
+  }
+  return results;
+}
+
+// ----- run -----
+if (usingMcp) {
+  TOKEN = await loadToken();
+  if (!TOKEN) {
+    console.error(
+      `error: daemon is up but no token found.\n` +
+      `       Restart the daemon to regenerate ${TOKEN_FILE}, or set PURSUE_VISION_TOKEN.`
+    );
+    process.exit(1);
+  }
+}
+
+let records;
 try {
-  indexRes = await jsonFetch("GET", `/war-gov/index?release=${RELEASE_N}`);
+  records = usingMcp ? await fetchIndexViaMcp() : await fetchIndexViaDirect();
 } catch (e) {
   console.error(`error: ${e.message}`);
-  console.error("       (is the daemon up?  npm start --prefix pursue-vision-mcp)");
+  if (usingMcp) {
+    console.error("       (is the daemon up?  npm start --prefix pursue-vision-mcp)");
+  } else {
+    console.error("       (direct fetch likely hit Akamai; try the daemon path instead)");
+  }
   process.exit(1);
 }
-const records = Array.isArray(indexRes.records) ? indexRes.records : [];
 console.log(`[sync-war-gov] index returned ${records.length} record(s) for release ${RELEASE_N}`);
 
-// 2. Filter by type.
+// Filter by type.
 const wanted = records.filter(r => TYPE_FILTER.has((r.type || "other").toLowerCase()));
 const skipped = records.length - wanted.length;
 if (skipped) console.log(`[sync-war-gov]   skipped ${skipped} by --types filter`);
 
-// Group + show plan.
 const byType = wanted.reduce((acc, r) => {
   const t = (r.type || "other").toLowerCase();
   (acc[t] ||= []).push(r);
@@ -132,29 +217,30 @@ if (!wanted.length) {
 
 if (DRY) {
   console.log(`\n[sync-war-gov] --dry-run: would download into ${DEST_DIR}`);
-  for (const r of wanted) console.log(`  ${r.type.padEnd(6)} ${r.filename}  ${r.url}`);
+  for (const r of wanted) console.log(`  ${(r.type || "other").padEnd(6)} ${r.filename}  ${r.url}`);
   process.exit(0);
 }
 
-// 3. Hand off to the daemon. The daemon writes into DEST_DIR (jail
-//    is enforced daemon-side, so home + cwd are the allowed roots).
 console.log(`\n[sync-war-gov] downloading ${wanted.length} file(s) → ${DEST_DIR}`);
-console.log("[sync-war-gov] (long-running; the daemon streams big files in 8 MB ranges)");
+if (usingMcp) {
+  console.log("[sync-war-gov] (long-running; the daemon streams big files in 8 MB ranges)");
+} else {
+  console.log("[sync-war-gov] (direct fetch; big files stream via Range chunks)");
+}
 
 const t0 = Date.now();
-let download;
+let results;
 try {
-  download = await jsonFetch("POST", "/war-gov/download", {
-    urls: wanted.map(r => r.url),
-    destDir: DEST_DIR,
-  });
+  if (usingMcp) {
+    results = await downloadViaMcp(wanted.map(r => r.url));
+  } else {
+    results = await downloadViaDirect(wanted);
+  }
 } catch (e) {
   console.error(`error: ${e.message}`);
   process.exit(1);
 }
 
-// 4. Per-file results.
-const results = Array.isArray(download.results) ? download.results : [];
 let okCount = 0, failCount = 0, byteCount = 0;
 for (const r of results) {
   if (r.url === "__abort__") {
@@ -173,7 +259,6 @@ for (const r of results) {
 const tookS = ((Date.now() - t0) / 1000).toFixed(1);
 console.log(`\n[sync-war-gov] ${okCount} ok · ${failCount} fail · ${(byteCount / 1024 / 1024).toFixed(1)} MB total · ${tookS}s`);
 
-// 5. Follow-up suggestion: audio/video need Whisper.
 const haveAudioVideo = wanted.some(r => r.type === "audio" || r.type === "video");
 if (okCount && haveAudioVideo) {
   console.log("");


### PR DESCRIPTION
## Summary
- `scripts/lib/war-gov-direct.mjs` — pure-Node port of the MCP driver's index discovery + range-chunked downloader. Lets `sync-war-gov.mjs` keep working when the daemon isn't running (e.g. against mirrors via `--base-url`). Documents the Akamai limitation honestly.
- `scripts/sync-war-gov.mjs` — auto-picks the path: probes `:9223/health` and uses the daemon if up, falls back to the direct module if not. New flags: `--prefer-mcp`, `--prefer-direct`, `--base-url=<mirror>`. CLI surface unchanged otherwise.
- `.claude/hooks/session-start.sh` + `.claude/settings.json` — synchronous, idempotent SessionStart hook for Claude Code on the Web. Installs top-level + `pursue-vision-mcp/` deps if missing, verifies the bundled Chromium at `/opt/pw-browsers/chromium-1194`, exports `PLAYWRIGHT_BROWSERS_PATH`. Does NOT auto-launch Chrome or the MCP daemon (opt-in).
- `docs/war-gov-setup.md` — lists the egress-allowlist hostnames the Web sandbox needs (`*.war.gov`, `cdn.playwright.dev`, `*.akamaihd.net`, `*.akamai.net`) and quick-reference `sync-war-gov.mjs` usage.
- `package-lock.json` — reconciled (version `0.0.0` → `2.2.0` match against `package.json`, plus optional `@emnapi/*` entries).

## Test plan
- [x] `node --check` on both modified scripts.
- [x] `node scripts/sync-war-gov.mjs --prefer-mcp` (no daemon) exits 1 with the expected "start the daemon" error.
- [x] `node scripts/sync-war-gov.mjs --prefer-direct --dry-run` reaches www.war.gov and surfaces the Akamai/proxy block cleanly (exit 1, no .part files left behind).
- [x] `.claude/hooks/session-start.sh` end-to-end: first run installs 339 root packages + verifies Chromium + writes `PLAYWRIGHT_BROWSERS_PATH` to `$CLAUDE_ENV_FILE`. Second run skips installs (idempotent). Exit 0 in both.
- [x] `npx eslint scripts/lib/war-gov-direct.mjs scripts/sync-war-gov.mjs` clean.
- [x] `node scripts/test-parse-template.mjs` — 12/12 pass.
- [ ] End-to-end war.gov ingestion is still gated on adding `*.war.gov` to the environment's egress allowlist (see `docs/war-gov-setup.md`); not testable from inside the sandbox.

https://claude.ai/code/session_01Q2RzM6xN7x9KFJCv6cag1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2RzM6xN7x9KFJCv6cag1e)_