### PR TITLE
fix(volunteer): close pdfjs server before exit to avoid Windows libuv crash

### DIFF
--- a/pursue-vision-mcp/monitor.mjs
+++ b/pursue-vision-mcp/monitor.mjs
@@ -201,7 +201,11 @@ let lastRun = null;
 
 function summarizeLog(allLines, exitCode) {
   const text = allLines.join("\n");
-  const skipCount = (text.match(/⊖.*already submitted/g) || []).length;
+  // volunteer.mjs prints "⊖ <eid> p<N> already done (local or merged to main)"
+  // — the older "already submitted" pattern never matched, so skipCount was
+  // always 0 and the dashboard headline collapsed to a generic "NO NEW WORK"
+  // instead of "NO NEW WORK · N pages already submitted".
+  const skipCount = (text.match(/⊖.*already (?:submitted|done)/g) || []).length;
   const okMatch   = text.match(/done\.\s*ok=(\d+)\s*err=(\d+)/);
   const okCount   = okMatch ? Number(okMatch[1]) : 0;
   const errCount  = okMatch ? Number(okMatch[2]) : 0;

--- a/scripts/lib/pdfjs-assets.mjs
+++ b/scripts/lib/pdfjs-assets.mjs
@@ -47,6 +47,10 @@ export async function getPdfjsAssetUrls() {
     createReadStream(filePath).on("error", () => res.end()).pipe(res);
   });
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  // Without unref(), the listening socket keeps the event loop alive, and on
+  // Windows process.exit() can hit a libuv UV_HANDLE_CLOSING race tearing down
+  // an unused listener (Assertion failed in src\win\async.c → exit 3221226505).
+  server.unref();
   const { port } = server.address();
   const base = `http://127.0.0.1:${port}`;
   return {

--- a/scripts/volunteer.mjs
+++ b/scripts/volunteer.mjs
@@ -246,7 +246,7 @@ const live = claims.filter(c => !c.skip);
 globalThis.Path2D = Path2D;
 globalThis.DOMMatrix = DOMMatrix;
 const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
-const { wasmUrl: PDFJS_WASM_URL, standardFontDataUrl: PDFJS_FONTS_URL } = await getPdfjsAssetUrls();
+const { wasmUrl: PDFJS_WASM_URL, standardFontDataUrl: PDFJS_FONTS_URL, server: PDFJS_SERVER } = await getPdfjsAssetUrls();
 class NCF {
   create(w, h) { const c = createCanvas(w, h); return { canvas: c, context: c.getContext("2d") }; }
   reset(cv, w, h) { cv.canvas.width = w; cv.canvas.height = h; }
@@ -487,6 +487,13 @@ await reportProgress({
 const elapsed = ((Date.now() - tAll) / 60_000).toFixed(1);
 console.log(`\n[volunteer] done. ok=${pagesOK} err=${pagesErr}  [${elapsed} min]`);
 console.log(`[volunteer] files at: ${CONTRIB_ROOT}`);
+
+// Drain the pdfjs assets server before exit — on Windows, calling process.exit()
+// while a TCP listener is still in the event loop can trip a libuv assertion
+// (UV_HANDLE_CLOSING in src\win\async.c) and the process dies with exit code
+// 3221226505 instead of the intended 0/2. The monitor then misclassifies the
+// clean "no new work" result as a crash and re-loops.
+await new Promise(r => PDFJS_SERVER.close(() => r()));
 
 if (pagesOK === 0) { console.log("[volunteer] nothing to commit, exiting."); process.exit(2); }
 


### PR DESCRIPTION
## Summary

Three small fixes to make `npm run monitor` → `volunteer.mjs` behave cleanly on Windows when the local queue has no fresh work.

The user reported `[exit 3221226505]` and an `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76` every time `volunteer.mjs` hit the "nothing to commit, exiting" branch. Root cause is the pdfjs asset HTTP server in `scripts/lib/pdfjs-assets.mjs` — it stays listening on an ephemeral port and on Windows `process.exit()` can trip a libuv close-race tearing down an idle listener.

The crash exit code (3221226505) doesn't equal 0/2, so `monitor.mjs#summarizeLog` classified the run as `error` → `kind !== "noop"` → loop mode kept restarting the volunteer against a queue where every page was already merged to main.

### Changes

- **`scripts/lib/pdfjs-assets.mjs`** — `server.unref()` after `listen()` so the listener never blocks exit (defensive, primary fix).
- **`scripts/volunteer.mjs`** — capture the server and `await new Promise(r => server.close(() => r()))` before the done/exit block (definitive, belt-and-suspenders).
- **`pursue-vision-mcp/monitor.mjs`** — fix `summarizeLog` skip-line regex: volunteer prints `⊖ <eid> p<N> already done (local or merged to main)` but the old pattern looked for `already submitted`, so `skipCount` was always 0 and the headline collapsed to a generic "NO NEW WORK".

### Test plan

- [ ] On Windows, run `npm run monitor` then trigger an OCR run against a queue with no fresh pages — volunteer should exit cleanly with code 2, monitor headline should read "NO NEW WORK · N pages already submitted", and loop mode should not relaunch.
- [ ] On Windows, run OCR against a queue with fresh pages — first run completes ok=N, second run no-ops cleanly without the libuv assertion.
- [ ] Linux/macOS regression: `node --check` syntax verified; behavior unchanged because `unref()` + `server.close()` are no-ops in practice on a server that was about to be torn down anyway.

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj)_