### PR TITLE
feat(dashboard): dim quick-launch buttons when queue has no FRESH work for the handle

### DIFF
--- a/pursue-vision-mcp/dashboard.html
+++ b/pursue-vision-mcp/dashboard.html
@@ -862,7 +862,7 @@
     });
   }
 
-  function populateQueuePanel(data) {
+  async function populateQueuePanel(data) {
     const events = Object.entries(data.byEvent || {});
     const totalOCR    = data.totalPagesNeeded ?? 0;
     const totalReview = data.totalPagesNeedingReview ?? 0;
@@ -885,9 +885,20 @@
     renderQueueDocs("q-rev-docs",  events, "reviewQueue",           "var(--amber)");
     renderQueueDocs("q-vis-docs",  events, "visualsNeedingContext", "var(--cyan)");
 
-    // Disable quick-launch buttons whose queue has nothing to do — saves
-    // the user from clicking a button that just no-ops with "0 pages claimed".
-    syncQuickBtnEnablement({ ocr: totalOCR, review: totalReview, visuals: totalVisual });
+    // Disable quick-launch buttons whose queue has nothing FRESH to do
+    // (queue ∩ not-already-merged-to-main). The raw totals from
+    // work-available.json count pages that may already be merged via this
+    // handle's previous PRs — clicking TAKE OCR then would no-op instantly.
+    // The /queue-counts endpoint runs the same findFreshWork() check as
+    // /run-any. Fall back to raw totals if the endpoint fails.
+    const rawCounts = { ocr: totalOCR, review: totalReview, visuals: totalVisual };
+    let freshCounts = null;
+    try {
+      const handle = $("ctrl-handle")?.value || "";
+      const r = await fetch("/queue-counts" + (handle ? "?handle=" + encodeURIComponent(handle) : ""));
+      if (r.ok) freshCounts = (await r.json()).counts;
+    } catch {}
+    syncQuickBtnEnablement(freshCounts || rawCounts);
 
     const gen = data.generatedAt ? new Date(data.generatedAt).toISOString().replace("T"," ").slice(0,19) + " UTC" : "";
     $("q-ts").textContent = "queue generated " + gen + " · refreshes every 5 min";
@@ -907,8 +918,8 @@
       if (remaining === 0) {
         btn.dataset.queueEmpty = "1";
         if (sub) sub.textContent = need === "any"
-          ? "all queues empty — nothing left to do · refresh in 5 min"
-          : `${need.toUpperCase()} queue empty — nothing to do`;
+          ? "all queues already submitted by you — wait for the queue to refresh"
+          : `${need.toUpperCase()} queue empty for you — all listed pages already submitted/merged`;
       } else {
         delete btn.dataset.queueEmpty;
         if (sub) {

--- a/pursue-vision-mcp/monitor.mjs
+++ b/pursue-vision-mcp/monitor.mjs
@@ -681,6 +681,42 @@ const server = http.createServer(async (req, res) => {
       return sendJson(res, 200, { alive, port: state.daemonPort });
     }
 
+    // Fresh-work counts for the dashboard's quick-launch buttons. The raw
+    // queue's totalPagesNeeded counts pages whose ORIGINAL OCR is incomplete
+    // — but if every one of them has already been submitted/merged to main by
+    // this handle (the common case after the auto-refresh workflow hasn't
+    // re-run yet), clicking TAKE OCR / LOOP OCR is an instant no-op. This
+    // endpoint runs the same findFreshWork() check /run-any does and returns
+    // per-queue counts of pages this handle still has fresh work for. The
+    // dashboard uses these (not the raw queue totals) to drive button
+    // enablement so users don't see "12 available" while it's actually zero.
+    if (req.method === "GET" && req.url.startsWith("/queue-counts")) {
+      const u = new URL(req.url, "http://localhost");
+      const handle = u.searchParams.get("handle") || state.handle || "Rizzleroc";
+      try {
+        const queue = await fetchQueue();
+        const buckets = [
+          { mode: "ocr",     dir: "gpt-vision",        field: "queue" },
+          { mode: "review",  dir: "gpt-vision-review", field: "reviewQueue" },
+          { mode: "visuals", dir: "media-staging",     field: "visualsNeedingContext" },
+        ];
+        const counts = { ocr: 0, review: 0, visuals: 0 };
+        const raw    = {
+          ocr:     queue.totalPagesNeeded ?? 0,
+          review:  queue.totalPagesNeedingReview ?? 0,
+          visuals: queue.totalPagesNeedingVisualContext ?? 0,
+        };
+        for (const b of buckets) {
+          const { totalFresh } = await findFreshWork(handle, b.dir, queue.byEvent || {}, b.field);
+          counts[b.mode] = totalFresh;
+        }
+        return sendJson(res, 200, { counts, raw, handle, checkedAt: Date.now() });
+      } catch (e) {
+        return sendJson(res, 500, { error: e.message });
+      }
+    }
+
+
     // Visuals staging state — so the COMMIT VISUALS button reflects reality
     // instead of always looking "ready". `committable` = filled templates that
     // would actually produce a contribution (Title ≥4, Context ≥20, image


### PR DESCRIPTION
## Summary

User reported the **TAKE OCR JOB** / **LOOP OCR** buttons still light up showing "12 available" / "12 left" even when all 12 pages have already been merged to main by the current handle — clicking either is an instant no-op (volunteer immediately exits with "nothing to commit, exiting" / `[exit 2]`). The dashboard was using the raw totals from `work-available.json`, which don't dedupe against the handle's already-merged contributions.

### Changes

- **`monitor.mjs`** — new `GET /queue-counts` endpoint. Runs the same `findFreshWork()` check that `/run-any` uses (queue ∩ not-merged-to-main via the handle's contributions). Returns per-queue counts of pages this handle still has FRESH work for, plus the raw queue totals for reference. Accepts `?handle=<name>` or falls back to the monitor's state handle.

- **`dashboard.html`** — `populateQueuePanel()` (now async) fetches `/queue-counts` after `WORK_URL` and uses the filtered counts to drive button enablement via `syncQuickBtnEnablement()`. Falls back to raw totals if the endpoint fails. The "queue empty" sub-text now reads "all listed pages already submitted/merged" so the user understands it's their own dedup, not an actually-empty queue.

### Test plan

- [ ] Stale queue (current state — all 12 OCR pages merged): TAKE OCR JOB and LOOP OCR are visually dimmed, text reads "OCR queue empty for you — all listed pages already submitted/merged", buttons disabled.
- [ ] Fresh queue with new pages: buttons re-enable with accurate "N available" / "N left".
- [ ] Endpoint down / 500: buttons fall back to raw totals (current behaviour) — no UI regression.

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj)_