### PR TITLE
feat(media): detect blank PDF renders and surface as MISSING RENDER

### DIFF
--- a/public/media.json
+++ b/public/media.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-05-22T19:18:48.608Z",
-  "total": 202,
+  "generatedAt": "2026-05-23T21:38:04.402Z",
+  "total": 203,
   "byKind": {
     "diagram": 16,
     "map": 8,
     "photograph": 82,
-    "hand-drawing": 41,
+    "hand-drawing": 42,
     "newspaper-clipping": 33,
     "photocopied-negative": 6,
     "video": 16
   },
   "byAgency": {
-    "Department of War": 45,
+    "Department of War": 46,
     "Department of State": 1,
     "FBI": 147,
     "NASA": 9
@@ -106,8 +106,9 @@
       "description": "Sketch of circle with crosshair",
       "classifier": "gemini-text-extract",
       "classifiedAt": "2026-05-20T14:25:33.923Z",
-      "imagePath": "media/krasuski-1944/p0004.png",
-      "thumbnailPath": "media/krasuski-1944/p0004.png"
+      "imagePath": null,
+      "thumbnailPath": null,
+      "missingRender": true
     },
     {
       "id": "incident-summaries-p0178",
@@ -362,8 +363,9 @@
       "description": "Diagram Description: A schematic drawing showing a railway track running horizontally. A dashed rectangular box labeled \"BUILDING OUTLINE ---- WITH SIDING INSIDE\" surrounds a section of the track. Inside this box is a \"PIT UNDER TRACKS\".",
       "classifier": "gemini-text-extract",
       "classifiedAt": "2026-05-20T14:25:33.803Z",
-      "imagePath": "media/azerbaijan-1955/p0010.png",
-      "thumbnailPath": "media/azerbaijan-1955/p0010.png"
+      "imagePath": null,
+      "thumbnailPath": null,
+      "missingRender": true
     },
     {
       "id": "azerbaijan-1955-p0005",
@@ -377,8 +379,25 @@
       "description": "Sketch of two dots with arrows pointing to them",
       "classifier": "gemini-text-extract",
       "classifiedAt": "2026-05-20T14:25:33.801Z",
-      "imagePath": "media/azerbaijan-1955/p0005.png",
-      "thumbnailPath": "media/azerbaijan-1955/p0005.png"
+      "imagePath": null,
+      "thumbnailPath": null,
+      "missingRender": true
+    },
+    {
+      "id": "azerbaijan-1955-p0006",
+      "eventId": "azerbaijan-1955",
+      "eventTitle": "USSR Trans-Caucasus Sighting",
+      "agency": "Department of War",
+      "era": "50s",
+      "page": 6,
+      "kind": "hand-drawing",
+      "title": "1: A square grid antenna on a pole",
+      "description": "Sketch 1: A square grid antenna on a pole",
+      "classifier": "gemini-text-extract",
+      "classifiedAt": "2026-05-20T14:25:33.801Z",
+      "imagePath": null,
+      "thumbnailPath": null,
+      "missingRender": true
     },
     {
       "id": "65-hs1-834228961-62-hq-83894-sub-a-p0119",

--- a/scripts/build-media-index.mjs
+++ b/scripts/build-media-index.mjs
@@ -17,6 +17,7 @@ import { existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadImage, createCanvas } from "@napi-rs/canvas";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -111,6 +112,40 @@ function curate(sc) {
   return { kind: k, reason: null };
 }
 
+// Pixel-variance check for blank renders. Some pages (hand-drawn sketches
+// on ruled paper from the 50s-era reports) render through pdf.js as a
+// near-white PNG — the source ink lives in an embedded image layer that
+// pdf.js can't reach. The file exists on disk but the tile is a visually-
+// empty box. Detect those here and surface them as "missing render"
+// instead of pretending we have an image.
+//
+// Method: downsample to 200x200, count pixels whose mean brightness is
+// below 200 (i.e. anything appreciably darker than light grey). If <1%
+// of pixels qualify as "ink", treat the render as blank.
+const blankRenderCache = new Map();   // absPath -> boolean
+async function isBlankRender(absPath) {
+  if (blankRenderCache.has(absPath)) return blankRenderCache.get(absPath);
+  let blank = false;
+  try {
+    const img = await loadImage(absPath);
+    const w = Math.min(img.width, 200);
+    const h = Math.min(img.height, 200);
+    const cv = createCanvas(w, h);
+    const ctx = cv.getContext("2d");
+    ctx.drawImage(img, 0, 0, w, h);
+    const { data } = ctx.getImageData(0, 0, w, h);
+    const total = data.length / 4;
+    let ink = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      const brightness = (data[i] + data[i + 1] + data[i + 2]) / 3;
+      if (brightness < 200) ink++;
+    }
+    blank = ink / total < 0.01;
+  } catch { /* leave blank=false if we can't decode */ }
+  blankRenderCache.set(absPath, blank);
+  return blank;
+}
+
 await mkdir(path.dirname(OUT), { recursive: true });
 
 let eventsMap = {};
@@ -160,8 +195,14 @@ for (const eid of await listDirs(VISUALS_DIR)) {
     // Denis's Gemini bracket markers where we have rich text metadata
     // but no local PDF to render. The UI shows a placeholder tile +
     // the description.
-    const ext = imageAbsPath ? path.extname(imageAbsPath) : null;
-    const imagePath = imageAbsPath ? `media/${eid}/p${pad4}${ext}` : null;
+    //
+    // A second null path: the file exists but the render is blank
+    // (see isBlankRender above). We null imagePath and set
+    // missingRender:true so the UI can group these separately from
+    // "no PDF available" placeholders.
+    const blank = imageAbsPath ? await isBlankRender(imageAbsPath) : false;
+    const ext = (imageAbsPath && !blank) ? path.extname(imageAbsPath) : null;
+    const imagePath = (imageAbsPath && !blank) ? `media/${eid}/p${pad4}${ext}` : null;
     items.push({
       id: `${eid}-p${pad4}`,
       eventId: eid,
@@ -180,6 +221,11 @@ for (const eid of await listDirs(VISUALS_DIR)) {
       classifiedAt: sc.classifiedAt || null,
       imagePath,
       thumbnailPath: imagePath,   // same file for now; reserved for future smaller thumbs
+      // True when a PNG/JPG exists on disk but is visually empty (pdf.js
+      // produced a near-white render for a page whose visual content
+      // lives in an embedded layer it can't reach). Distinguishes the
+      // tile from "no PDF available at all" placeholders.
+      missingRender: blank || undefined,
     });
   }
 }
@@ -252,7 +298,9 @@ await writeFile(OUT, JSON.stringify({
   items,
 }, null, 2) + "\n", "utf8");
 
+const missingRenderCount = items.filter(it => it.missingRender).length;
 console.log(`[media-index] ${items.length} media items across ${Object.keys(byEvent).length} events`);
+if (missingRenderCount) console.log(`[media-index] detected ${missingRenderCount} blank render(s) — tagged missingRender:true (PDF page produced a near-white image; surfaced separately in MEDIA)`);
 if (droppedDuplicates) console.log(`[media-index] dropped ${droppedDuplicates} duplicate image(s) (same content under a different page)`);
 console.log(`[media-index] by kind:`);
 for (const [k, n] of Object.entries(byKind).sort((a, b) => b[1] - a[1])) {

--- a/src/views/MediaView.jsx
+++ b/src/views/MediaView.jsx
@@ -101,6 +101,13 @@ export default function MediaView({ onSelect, headerFilters }) {
   // bracket markers on pages we can't render) are useful metadata
   // but look like noise when most of the grid is empty boxes.
   const [includePlaceholders, setIncludePlaceholders] = useState(false);
+  // Same idea, but for blank renders — pages where a PNG exists on
+  // disk but pdf.js produced a visually-empty image (typically 50s-era
+  // hand-sketch pages). Tagged missingRender:true by the index builder.
+  // Kept separate from placeholders because the cause is different
+  // (broken render vs. no PDF) and the user wanted them surfaced as
+  // their own group.
+  const [includeMissingRenders, setIncludeMissingRenders] = useState(false);
 
   useEffect(() => {
     fetch(`${import.meta.env.BASE_URL}media.json?t=${Date.now()}`)
@@ -116,7 +123,15 @@ export default function MediaView({ onSelect, headerFilters }) {
     return data.items.filter(it => {
       // Videos have no local image but must always be visible — they're
       // the release footage, not a metadata-only placeholder.
-      if (!includePlaceholders && !it.imagePath && it.kind !== "video") return false;
+      // Blank renders also have imagePath:null but are gated by a
+      // separate toggle (different cause from regular placeholders).
+      if (it.kind !== "video") {
+        if (it.missingRender) {
+          if (!includeMissingRenders) return false;
+        } else if (!it.imagePath) {
+          if (!includePlaceholders) return false;
+        }
+      }
       if (!filterKinds.has(it.kind)) return false;
       if (typeKinds && !typeKinds.has(it.kind)) return false;
       if (filterAgency !== "all" && (it.agency || "—") !== filterAgency) return false;
@@ -124,32 +139,40 @@ export default function MediaView({ onSelect, headerFilters }) {
       if (q && !`${it.title} ${it.description} ${it.eventTitle}`.toLowerCase().includes(q)) return false;
       return true;
     });
-  }, [data, filterKinds, filterAgency, filterType, filterEvent, query, includePlaceholders]);
+  }, [data, filterKinds, filterAgency, filterType, filterEvent, query, includePlaceholders, includeMissingRenders]);
 
-  // Counts of with-image vs placeholder-only for the toggle label.
+  // Counts by bucket for the toggle labels. Three groups:
+  //   withImage      — a real rendered PNG/JPG is attached
+  //   placeholder    — no local PDF, just Gemini-transcript metadata
+  //   missingRender  — a PNG exists but is visually blank (render failed)
   const counts = useMemo(() => {
-    if (!data?.items) return { withImage: 0, placeholder: 0 };
+    if (!data?.items) return { withImage: 0, placeholder: 0, missingRender: 0 };
     return data.items.reduce((acc, it) => {
-      if (it.imagePath) acc.withImage++;
-      else if (it.kind !== "video") acc.placeholder++;   // videos aren't placeholders
+      if (it.kind === "video") return acc;     // videos aren't in any of these buckets
+      if (it.missingRender) acc.missingRender++;
+      else if (it.imagePath) acc.withImage++;
+      else acc.placeholder++;
       return acc;
-    }, { withImage: 0, placeholder: 0 });
+    }, { withImage: 0, placeholder: 0, missingRender: 0 });
   }, [data]);
 
-  // Per-kind counts honoring the placeholder toggle. Without this, the
-  // filter pills show `data.byKind` (all items) — so PHOTOGRAPH would
-  // read "82" even when the grid is hiding 64 placeholders and only
-  // showing 18 actual photos. That mismatch is the "filter calls out
-  // images but has none attached" confusion.
+  // Per-kind counts honoring both toggles. Without this, the filter
+  // pills show `data.byKind` (all items) — so PHOTOGRAPH would read
+  // "82" even when the grid is hiding 64 placeholders and only showing
+  // 18 actual photos. That mismatch is the "filter calls out images
+  // but has none attached" confusion.
   const kindCounts = useMemo(() => {
     if (!data?.items) return {};
     const out = {};
     for (const it of data.items) {
-      if (!includePlaceholders && !it.imagePath && it.kind !== "video") continue;
+      if (it.kind !== "video") {
+        if (it.missingRender && !includeMissingRenders) continue;
+        if (!it.missingRender && !it.imagePath && !includePlaceholders) continue;
+      }
       out[it.kind] = (out[it.kind] || 0) + 1;
     }
     return out;
-  }, [data, includePlaceholders]);
+  }, [data, includePlaceholders, includeMissingRenders]);
 
   // Kinds that have any items at all (image OR placeholder) across the
   // full dataset. Used to suppress filter pills for kinds that aren't
@@ -201,13 +224,15 @@ export default function MediaView({ onSelect, headerFilters }) {
         </h2>
         <div className="font-mono text-[10px] text-emerald-700">
           {/*
-            Denominator matches the placeholder toggle — without this,
-            "X of 198" stays static even when 115 placeholders are
-            hidden, so the user sees "18 of 198" and can't tell whether
-            their filters threw out 180 tiles or whether 115 were
-            placeholders hidden by the toggle.
+            Denominator matches whichever buckets the user has toggled
+            on — without this, "X of 198" stays static even when 115
+            placeholders are hidden, so the user sees "18 of 198" and
+            can't tell whether their filters threw out 180 tiles or
+            whether 115 were placeholders hidden by the toggle.
           */}
-          {filtered.length} of {includePlaceholders ? counts.withImage + counts.placeholder : counts.withImage} visuals · {data.eventCount} events
+          {filtered.length} of {counts.withImage
+            + (includePlaceholders ? counts.placeholder : 0)
+            + (includeMissingRenders ? counts.missingRender : 0)} visuals · {data.eventCount} events
         </div>
       </div>
 
@@ -250,7 +275,7 @@ export default function MediaView({ onSelect, headerFilters }) {
         */}
         <button onClick={() => setIncludePlaceholders(v => !v)}
           title={includePlaceholders
-            ? `showing all ${counts.withImage + counts.placeholder} visuals (incl. ${counts.placeholder} metadata-only placeholders)`
+            ? `also showing ${counts.placeholder} metadata-only placeholders (no local PDF)`
             : `showing only ${counts.withImage} pages with a rendered image · click to also show ${counts.placeholder} placeholder entries (no local PDF available)`}
           className={`flex items-center gap-1.5 px-2.5 py-1 rounded-sm border font-mono text-[10px] tracking-wider transition-colors ${
             includePlaceholders
@@ -258,9 +283,35 @@ export default function MediaView({ onSelect, headerFilters }) {
               : "text-emerald-300 border-emerald-700/50 hover:border-emerald-500/60"}`}>
           <span className={`w-1.5 h-1.5 rounded-full ${includePlaceholders ? "bg-cyan-400" : "bg-emerald-400"}`} />
           {includePlaceholders
-            ? <>ALL <span className="opacity-60 ml-0.5">{counts.withImage + counts.placeholder}</span></>
+            ? <>+ PLACEHOLDERS <span className="opacity-60 ml-0.5">{counts.placeholder}</span></>
             : <>WITH IMAGE <span className="opacity-60 ml-0.5">{counts.withImage}</span><span className="opacity-40 ml-1.5">+ {counts.placeholder} hidden</span></>}
         </button>
+        {/*
+          Missing-render toggle. A separate bucket from placeholders:
+          here a PNG actually exists on disk but pdf.js produced a
+          visually-blank render (typical of hand-sketches in 50s-era
+          reports where the visual lives in a layer pdf.js can't reach).
+          The classifier still has a useful description from Gemini's
+          transcript, so we surface the metadata via the same tile UI
+          but flag the broken render distinctly. Hidden until the user
+          opts in — only renders this affects today are 4 pages across
+          Krasuski + USSR Trans-Caucasus.
+        */}
+        {counts.missingRender > 0 && (
+          <button onClick={() => setIncludeMissingRenders(v => !v)}
+            title={includeMissingRenders
+              ? `also showing ${counts.missingRender} pages whose PDF render produced a blank image`
+              : `${counts.missingRender} pages have a description but the PDF rendered blank · click to surface them`}
+            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-sm border font-mono text-[10px] tracking-wider transition-colors ${
+              includeMissingRenders
+                ? "text-amber-300 border-amber-500/50 bg-amber-950/20"
+                : "text-emerald-300 border-emerald-700/50 hover:border-amber-500/60"}`}>
+            <span className={`w-1.5 h-1.5 rounded-full ${includeMissingRenders ? "bg-amber-400" : "bg-amber-700"}`} />
+            {includeMissingRenders
+              ? <>+ MISSING RENDER <span className="opacity-60 ml-0.5">{counts.missingRender}</span></>
+              : <>MISSING RENDER <span className="opacity-40 ml-1.5">{counts.missingRender} hidden</span></>}
+          </button>
+        )}
         {/* Title/description search + agency dropdown have moved to the
             header filter bar so they share state across the whole site.
             The per-event selector is kept here — it's media-specific. */}
@@ -284,6 +335,18 @@ export default function MediaView({ onSelect, headerFilters }) {
                 ) : it.thumbnailPath ? (
                   <img src={`${import.meta.env.BASE_URL}${it.thumbnailPath}`} alt={it.title || it.kind}
                     className="w-full h-full object-cover opacity-90 group-hover:opacity-100" loading="lazy" />
+                ) : it.missingRender ? (
+                  // PNG exists on disk but pdf.js produced a blank
+                  // render — distinct amber treatment so the user can
+                  // see at a glance these are broken renders, not the
+                  // cyan "no PDF available" placeholders.
+                  <div className="w-full h-full flex flex-col items-center justify-center p-3 bg-amber-950/20">
+                    <span className="w-2 h-2 rounded-full bg-amber-400 mb-2" />
+                    <span className="font-mono text-[9px] tracking-widest text-amber-300 opacity-80 mb-1">MISSING RENDER</span>
+                    <span className="font-mono text-[10px] text-amber-200 opacity-90 text-center line-clamp-4">
+                      {it.description || it.title || it.kind}
+                    </span>
+                  </div>
                 ) : (
                   // No local render available (e.g. extracted from a Gemini
                   // transcript marker for an event we don't have the PDF
@@ -379,6 +442,21 @@ export default function MediaView({ onSelect, headerFilters }) {
               ) : focused.imagePath ? (
                 <img src={`${import.meta.env.BASE_URL}${focused.imagePath}`} alt={focused.title || focused.kind}
                   className="max-w-full max-h-[70vh] object-contain" />
+              ) : focused.missingRender ? (
+                <div className="text-center max-w-xl">
+                  <div className="inline-flex items-center gap-2 px-3 py-1 rounded-sm border border-amber-500/40 mb-4">
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+                    <span className="font-mono text-[10px] tracking-widest text-amber-300">
+                      {KIND_LABELS[focused.kind]} · MISSING RENDER
+                    </span>
+                  </div>
+                  <div className="font-mono text-amber-100 text-sm leading-relaxed text-left">
+                    {focused.description || focused.title}
+                  </div>
+                  <div className="font-mono text-amber-700 text-[10px] mt-4 leading-relaxed">
+                    The source PDF contains this visual but pdf.js rendered the page as a blank image — typically a hand-sketch on otherwise-empty paper whose ink lives in a layer pdf.js can't reach. The description above came from Gemini's transcript of the same page. Open the original document at war.gov/UFO to see the actual sketch.
+                  </div>
+                </div>
               ) : (
                 <div className="text-center max-w-xl">
                   <div className={`inline-flex items-center gap-2 px-3 py-1 rounded-sm border ${KIND_COLORS[focused.kind].ring} mb-4`}>


### PR DESCRIPTION
## Summary

Some hand-sketch pages — USSR Trans-Caucasus Sighting p5/p6/p10, Krasuski 1944 p4 — had a PNG on disk but pdf.js produced a visually-blank image (the actual ink lives in an embedded layer pdf.js can't reach). The tiles rendered as empty white boxes in the MEDIA grid. Detect those at index-build time and surface them as a distinct **MISSING RENDER** bucket instead of pretending we have an image.

- **`scripts/build-media-index.mjs`** — decodes each rendered image with `@napi-rs/canvas` (already a transitive dep), samples down to 200×200, counts pixels with brightness < 200. If <1% qualify as "ink", the entry is tagged `missingRender: true` and `imagePath` is nulled. Affects 4 items today; threshold is conservative enough not to flag the next-smallest real image (81 KB photograph). Build log now reports the count.
- **`src/views/MediaView.jsx`** — adds a third bucket alongside `withImage` and `placeholder`. New amber `MISSING RENDER` toggle pill (only shown when any exist), distinct amber tile + modal treatment, and modal copy that explains the render-failure mode rather than just showing an empty box. Per-kind filter counts and the `X of Y` denominator both honor the new toggle.

## Verification

Drove the running dev server with Playwright. Screenshotted: toggle row (`MISSING RENDER 4 hidden`), grid with the amber tiles surfaced after toggle, and the modal showing the new "missing render" treatment with the explanatory copy. No new console errors.

## Test plan

- [ ] `node scripts/build-media-index.mjs` reports `detected 4 blank render(s)` and exits 0
- [ ] MEDIA view shows the `MISSING RENDER 4 hidden` pill in the second toggle row
- [ ] Clicking the pill surfaces 4 amber tiles (Krasuski 1944 p4 + USSR Trans-Caucasus p5/p6/p10)
- [ ] Opening one shows the amber `· MISSING RENDER` badge + the Gemini-transcript description + the pdf.js failure-mode explanation
- [ ] Per-kind filter pill counts (`HAND DRAWING`, `DIAGRAM`) update when the toggle is flipped
- [ ] No regression for the existing cyan "no local image" placeholders (131 of them) — separate toggle, separate color, independent counting

https://claude.ai/code/session_011qE6oRoaHycYsVhXMAejGP

---
_Generated by [Claude Code](https://claude.ai/code/session_011qE6oRoaHycYsVhXMAejGP)_