### PR TITLE
Unify COMMIT button across OCR, review, and visuals

### DIFF
--- a/pursue-vision-mcp/dashboard.html
+++ b/pursue-vision-mcp/dashboard.html
@@ -513,10 +513,10 @@
       <span class="qb-sub qb-count">render + auto-draft context · one slice</span>
       <span class="qb-cmd">volunteer-media.mjs --auto-context</span>
     </button>
-    <button id="qb-visuals-commit" class="quick-btn visuals" onclick="quickRun('visuals-commit', false)" title="Commit filled templates as a media contribution PR">
-      <span class="qb-title">✓ COMMIT VISUALS</span>
-      <span class="qb-sub" id="qb-commit-sub">stage reviewed templates → contribution</span>
-      <span class="qb-cmd">volunteer-media.mjs --commit</span>
+    <button id="qb-visuals-commit" class="quick-btn visuals" onclick="quickRun('commit-all', false)" title="Commit whatever's pending — OCR, review, and visuals — as per-source PRs">
+      <span class="qb-title">✓ COMMIT</span>
+      <span class="qb-sub" id="qb-commit-sub">publish all pending work → per-source PRs</span>
+      <span class="qb-cmd">commit-all.mjs</span>
     </button>
     <button id="qb-ocr-loop" class="quick-btn ocr loop" data-needs="ocr" onclick="quickRun('ocr', true)" title="Loop OCR until queue empty">
       <span class="qb-title">↻ LOOP OCR</span>
@@ -1267,22 +1267,27 @@
   pollDaemonHealth();
   setInterval(pollDaemonHealth, 15_000);
 
-  // ---- COMMIT VISUALS readiness ----
-  // Make the commit button reflect actual staging state instead of always
-  // looking ready: enabled + "N ready to commit" only when there are filled
-  // templates, disabled otherwise (so it stops inviting a pointless resubmit).
+  // ---- COMMIT readiness (unified across OCR, review, visuals) ----
+  // The commit button is no longer visuals-only. It calls commit-all.mjs
+  // which scans every contribution source and opens per-source PRs. The
+  // sublabel breaks down what's about to publish so the volunteer knows
+  // before clicking; button stays disabled when nothing is pending.
   async function pollStaging() {
     const btn = $("qb-visuals-commit"), sub = $("qb-commit-sub");
     if (!btn) return;
     if (btn.dataset.runDisabled === "1") return; // a run is active — pollRunner owns the lock
     try {
-      const s = await fetch("/staging", { cache: "no-store" }).then(r => r.json());
-      if (s.committable > 0) {
+      const p = await fetch("/pending", { cache: "no-store" }).then(r => r.json());
+      const parts = [];
+      if (p.ocr)     parts.push(`${p.ocr} OCR`);
+      if (p.review)  parts.push(`${p.review} review`);
+      if (p.visuals) parts.push(`${p.visuals} visuals`);
+      if (p.total > 0) {
         btn.disabled = false;
-        if (sub) sub.textContent = `${s.committable} ready to commit` + (s.incomplete ? ` · ${s.incomplete} still need drafting` : "");
+        if (sub) sub.textContent = `${parts.join(" · ")} ready to publish`;
       } else {
         btn.disabled = true;
-        if (sub) sub.textContent = s.total ? `nothing ready — ${s.total} staged still need drafting` : "no staged visuals to commit";
+        if (sub) sub.textContent = "nothing pending to commit";
       }
     } catch {}
   }

--- a/pursue-vision-mcp/monitor.mjs
+++ b/pursue-vision-mcp/monitor.mjs
@@ -179,6 +179,17 @@ function buildVolunteerArgs(opts) {
     const args = ["scripts/volunteer-media.mjs", `--my-handle=${handle}`, "--commit"];
     return { script: "volunteer-media.mjs", args };
   }
+  if (opts.mode === "commit-all") {
+    // Unified commit: drives scripts/commit-all.mjs which scans every
+    // contribution source (gpt-vision OCR, gpt-vision-review, media visuals)
+    // and opens a per-source PR for anything pending. This is what the
+    // dashboard's single COMMIT button calls regardless of which job ran
+    // — previously COMMIT was hard-wired to visuals only, so OCR/review
+    // contributions piled up on disk with no obvious way to publish.
+    const args = ["scripts/commit-all.mjs", `--my-handle=${handle}`];
+    if (opts.sources) args.push(`--sources=${opts.sources}`);
+    return { script: "commit-all.mjs", args };
+  }
 
   const args = [
     "scripts/volunteer.mjs",
@@ -419,7 +430,10 @@ async function spawnVolunteer(opts) {
     // pages every few seconds (staged pages aren't marked submitted), causing
     // unbounded staging growth and the constant running↔idle flipping in the
     // UI. Only OCR/review/doc — which submit their own work — may loop.
-    if (loop && !String(startedMeta?.mode || "").startsWith("visuals") && code !== null && code !== 1 && lastRun.kind !== "noop") {
+    // commit-all is a one-shot publish step — looping it would just re-scan
+    // an empty staging area forever and rate-limit `gh pr create`.
+    const startedMode = String(startedMeta?.mode || "");
+    if (loop && !startedMode.startsWith("visuals") && startedMode !== "commit-all" && code !== null && code !== 1 && lastRun.kind !== "noop") {
       await new Promise(r => setTimeout(r, 3000));
       try { await spawnVolunteer({ ...opts }); } catch {}
     }
@@ -646,15 +660,16 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method === "POST" && req.url === "/run") {
       const body = await readBody(req);
-      if (!["ocr", "review", "visuals", "visuals-commit", "doc"].includes(body.mode)) {
-        return sendJson(res, 400, { error: "mode must be ocr | review | visuals | visuals-commit | doc" });
+      if (!["ocr", "review", "visuals", "visuals-commit", "commit-all", "doc"].includes(body.mode)) {
+        return sendJson(res, 400, { error: "mode must be ocr | review | visuals | visuals-commit | commit-all | doc" });
       }
       if (body.mode === "doc" && !body.eid) {
         return sendJson(res, 400, { error: "eid required for doc mode" });
       }
-      // Everything that does vision work needs the daemon. visuals-commit only
-      // validates already-staged templates locally, so it doesn't.
-      if (body.mode !== "visuals-commit") {
+      // Everything that does vision work needs the daemon. visuals-commit and
+      // commit-all only validate/publish already-staged files locally, so they
+      // don't.
+      if (body.mode !== "visuals-commit" && body.mode !== "commit-all") {
         const alive = await daemonAlive();
         if (!alive) return sendJson(res, 503, {
           error: "MCP daemon at http://127.0.0.1:9223 is offline. Start it: cd pursue-vision-mcp && npm start",
@@ -749,6 +764,56 @@ const server = http.createServer(async (req, res) => {
         }
       } catch { /* no staging dir yet */ }
       return sendJson(res, 200, { total, committable, incomplete: total - committable });
+    }
+
+    // Per-source pending counts feed the unified COMMIT button's sublabel:
+    // it reports OCR/review/visuals separately so the volunteer can see what
+    // they're about to publish before clicking. Walks contributions/<handle>/
+    // for OCR + review (any .txt/.json files), and the staging dir for visuals
+    // (committable ones only — incomplete templates aren't ready to PR).
+    if (req.method === "GET" && req.url === "/pending") {
+      const handle = state.handle || "Rizzleroc";
+      const counts = { ocr: 0, review: 0, visuals: 0 };
+      // OCR + Review: count contribution output files on disk.
+      for (const [key, dir] of [["ocr", "gpt-vision"], ["review", "gpt-vision-review"]]) {
+        const root = path.resolve(SCRIPTS_ROOT, "contributions", handle, dir);
+        if (!existsSync(root)) continue;
+        try {
+          for (const eid of await readdir(root)) {
+            let files; try { files = await readdir(path.join(root, eid)); } catch { continue; }
+            for (const f of files) {
+              if (/^p0*\d+\.(txt|json)$/i.test(f)) counts[key]++;
+            }
+          }
+        } catch {}
+      }
+      // Visuals: only count templates that are actually committable (image +
+      // title ≥ 4 + context ≥ 20). Half-filled drafts shouldn't inflate the
+      // "ready to commit" badge.
+      const base = path.join(HELPER_DIR, "media-staging", handle);
+      const sectionText = (t, name) => {
+        const m = t.match(new RegExp(`^#\\s+${name}\\s*$`, "m"));
+        if (!m) return "";
+        const rest = t.slice(m.index + m[0].length);
+        const nx = rest.search(/^#\s+/m);
+        return (nx >= 0 ? rest.slice(0, nx) : rest).replace(/<!--[\s\S]*?-->/g, "").trim();
+      };
+      try {
+        for (const eid of await readdir(base)) {
+          let files; try { files = await readdir(path.join(base, eid)); } catch { continue; }
+          for (const f of files) {
+            if (!/^p\d+\.md$/i.test(f)) continue;
+            try {
+              const t = await readFile(path.join(base, eid, f), "utf8");
+              const img = existsSync(path.join(base, eid, f.replace(/\.md$/i, ".png")))
+                       || existsSync(path.join(base, eid, f.replace(/\.md$/i, ".jpg")));
+              if (img && sectionText(t, "Title").length >= 4 && sectionText(t, "Context").length >= 20) counts.visuals++;
+            } catch {}
+          }
+        }
+      } catch {}
+      const total = counts.ocr + counts.review + counts.visuals;
+      return sendJson(res, 200, { total, ...counts });
     }
 
     // Delete TRULY-empty stub contributions (0-byte / whitespace-only) so

--- a/scripts/commit-all.mjs
+++ b/scripts/commit-all.mjs
@@ -1,0 +1,211 @@
+// Unified commit script — commits whatever's pending across OCR, review,
+// and visuals into their own PRs. One COMMIT button in the dashboard drives
+// this regardless of which job the volunteer just ran.
+//
+// Why per-source instead of one big PR: the three sources have different
+// reviewer expectations (OCR judged by JUDGE-STANDARD, review pages are
+// human-typed canonical, visuals carry images). Mixing them in one PR
+// makes review awkward and CI status confusing. Per-source PRs let
+// each get the right treatment.
+//
+// Why temp-index instead of `git checkout -b`: the working tree is shared
+// with the user's editor and other tooling (monitor cockpit, sparse-checkout).
+// Branching with checkout flooded the runner log with sparse-checkout "M …"
+// warnings, occasionally left the tree stranded on an orphan contrib branch
+// when push failed, and could include unrelated build artifacts. Building
+// the commit off `origin/main` via GIT_INDEX_FILE + read-tree + commit-tree
+// produces a clean diff with zero working-tree side effects.
+//
+// Visuals still shell out to volunteer-media.mjs --commit because that path
+// already does template validation, image normalization, and staging cleanup
+// — duplicating that here would drift.
+//
+// Usage:
+//   node scripts/commit-all.mjs --my-handle=YOU              # commit everything pending
+//   node scripts/commit-all.mjs --my-handle=YOU --sources=ocr,review  # subset
+//   node scripts/commit-all.mjs --my-handle=YOU --dry-run    # show what would happen
+
+import { readdir, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const m = a.match(/^--([^=]+)(?:=(.*))?$/);
+  return m ? [m[1], m[2] ?? true] : [a, true];
+}));
+
+const HANDLE = args["my-handle"] || process.env.GITHUB_USER || "";
+if (!HANDLE) {
+  console.error("[commit-all] --my-handle=<github-handle> required");
+  process.exit(1);
+}
+const DRY = !!args["dry-run"];
+const REQUESTED_SOURCES = String(args.sources || "ocr,review,visuals").split(",").map(s => s.trim()).filter(Boolean);
+
+function run(cmd, argv, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const c = spawn(cmd, argv, { cwd: ROOT, stdio: "inherit", shell: process.platform === "win32", ...opts });
+    c.on("error", reject);
+    c.on("exit", code => code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`)));
+  });
+}
+function capture(cmd, argv, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const c = spawn(cmd, argv, { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"], shell: process.platform === "win32", ...opts });
+    let out = "", err = "";
+    c.stdout.on("data", d => out += d);
+    c.stderr.on("data", d => err += d);
+    c.on("error", reject);
+    c.on("exit", code => code === 0 ? resolve(out) : reject(new Error(`${cmd} ${code}: ${err.trim()}`)));
+  });
+}
+
+// Count files that look like contribution outputs in a source dir. Used to
+// decide whether to even attempt a commit (empty source = silent skip).
+async function pendingCount(sourceDir) {
+  if (!existsSync(sourceDir)) return 0;
+  let n = 0;
+  async function walk(d) {
+    for (const ent of await readdir(d, { withFileTypes: true })) {
+      const p = path.join(d, ent.name);
+      if (ent.isDirectory()) await walk(p);
+      else if (/\.(txt|json|md|jpg|jpeg|png|webp)$/i.test(ent.name)) n++;
+    }
+  }
+  await walk(sourceDir);
+  return n;
+}
+
+// Commit a single source via the temp-index pattern.
+//   - read-tree origin/main into a throwaway index
+//   - git add only that source's dir into the throwaway index
+//   - if no diff vs main → nothing new, silent skip
+//   - write-tree + commit-tree + push → PR
+// The user's working tree is never touched.
+async function commitSource({ source, label, prTitle, prBody }) {
+  const srcDir = path.join(ROOT, "contributions", HANDLE, source);
+  const n = await pendingCount(srcDir);
+  if (n === 0) {
+    console.log(`[commit-all] ${label}: nothing on disk; skipping`);
+    return { source, status: "empty" };
+  }
+  console.log(`[commit-all] ${label}: ${n} file(s) on disk in contributions/${HANDLE}/${source}/`);
+  if (DRY) return { source, status: "dry" };
+
+  // Fetch latest main so the commit is built on top of it, not a stale ref.
+  try { await run("git", ["fetch", "origin", "main", "--quiet"], { stdio: "ignore" }); }
+  catch (e) { console.warn(`[commit-all] ${label}: git fetch failed (${e.message}); using cached origin/main`); }
+
+  const tmpIndex = path.join(os.tmpdir(), `pursue-idx-${source}-${Date.now().toString(36)}`);
+  const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
+  try {
+    await run("git", ["read-tree", "origin/main"], { env, stdio: "ignore" });
+    await run("git", ["add", "--", `contributions/${HANDLE}/${source}`], { env, stdio: "ignore" });
+
+    // diff-index --quiet: exit 0 = clean (no diff), exit 1 = differences exist.
+    // We want "differences exist" to mean go-ahead, so a clean exit means skip.
+    let hasChanges = false;
+    try { await run("git", ["diff-index", "--quiet", "--cached", "origin/main"], { env, stdio: "ignore" }); }
+    catch { hasChanges = true; }
+    if (!hasChanges) {
+      console.log(`[commit-all] ${label}: byte-identical to origin/main; nothing new to publish`);
+      return { source, status: "clean" };
+    }
+
+    const tree = (await capture("git", ["write-tree"], { env })).trim();
+    const parent = (await capture("git", ["rev-parse", "origin/main"])).trim();
+    const msg = `${label}: volunteer contributions from @${HANDLE}\n\nSubmitted via scripts/commit-all.mjs.`;
+    const commit = (await capture("git", ["commit-tree", tree, "-p", parent, "-m", msg], { env })).trim();
+
+    const branch = `contrib-${HANDLE}-${source}-${Date.now().toString(36)}`;
+    await run("git", ["push", "-q", "origin", `${commit}:refs/heads/${branch}`]);
+    await run("gh", ["pr", "create", "--head", branch, "--base", "main",
+      "--title", prTitle.replace("{HANDLE}", HANDLE),
+      "--body", prBody.replace("{HANDLE}", HANDLE)]);
+    console.log(`[commit-all] ✓ ${label}: PR opened on ${branch}`);
+    return { source, status: "pr", branch };
+  } finally {
+    try { await rm(tmpIndex); } catch {}
+  }
+}
+
+// Visuals: delegate to volunteer-media.mjs --commit. That script already
+// validates templates, normalizes images, and clears staging on success —
+// re-implementing here would drift. The downside is it still uses the
+// checkout-based commit path, but it works and changing it is out of scope
+// for this task.
+async function commitVisuals() {
+  const stagingRoot = process.env.PURSUE_STAGING ||
+    path.join(os.homedir(), ".pursue-helper", "media-staging", HANDLE);
+  if (!existsSync(stagingRoot)) {
+    console.log(`[commit-all] visuals: no staging dir; skipping`);
+    return { source: "media", status: "empty" };
+  }
+  // Quick check: any p<NNN>.md files at all?
+  let any = false;
+  try {
+    for (const eid of await readdir(stagingRoot)) {
+      const d = path.join(stagingRoot, eid);
+      try {
+        if ((await readdir(d)).some(f => /^p\d+\.md$/i.test(f))) { any = true; break; }
+      } catch {}
+    }
+  } catch {}
+  if (!any) {
+    console.log(`[commit-all] visuals: staging empty; skipping`);
+    return { source: "media", status: "empty" };
+  }
+  console.log(`[commit-all] visuals: delegating to volunteer-media.mjs --commit`);
+  if (DRY) return { source: "media", status: "dry" };
+  try {
+    await run("node", ["scripts/volunteer-media.mjs", `--my-handle=${HANDLE}`, "--commit"]);
+    return { source: "media", status: "ok" };
+  } catch (e) {
+    console.error(`[commit-all] visuals: failed — ${e.message}`);
+    return { source: "media", status: "error" };
+  }
+}
+
+const SOURCES = {
+  ocr: {
+    source: "gpt-vision",
+    label: "OCR",
+    prTitle: "Volunteer OCR contribution from @{HANDLE}",
+    prBody: `## Vision-OCR contribution\n\nVision-OCR'd pages submitted via \`scripts/commit-all.mjs\` by @{HANDLE}.\n\nCI validates against [JUDGE-STANDARD.md](../blob/main/JUDGE-STANDARD.md).`,
+  },
+  review: {
+    source: "gpt-vision-review",
+    label: "Review",
+    prTitle: "Volunteer review contribution from @{HANDLE}",
+    prBody: `## Human review contribution\n\nHuman-typed canonical text for pages where machine sources disagreed. Submitted via \`scripts/commit-all.mjs\` by @{HANDLE}.\n\nThese pages were flagged \`needs_review\` by \`scripts/compare-sources.mjs\` and represent higher-leverage corrections than additional OCR.`,
+  },
+};
+
+const results = [];
+for (const key of REQUESTED_SOURCES) {
+  if (key === "visuals" || key === "media") {
+    results.push(await commitVisuals());
+  } else if (SOURCES[key]) {
+    try { results.push(await commitSource(SOURCES[key])); }
+    catch (e) {
+      console.error(`[commit-all] ${SOURCES[key].label}: failed — ${e.message}`);
+      results.push({ source: SOURCES[key].source, status: "error", error: e.message });
+    }
+  } else {
+    console.warn(`[commit-all] unknown source "${key}" — skipping`);
+  }
+}
+
+const prs = results.filter(r => r.status === "pr" || r.status === "ok").length;
+const empty = results.filter(r => r.status === "empty" || r.status === "clean").length;
+const errors = results.filter(r => r.status === "error").length;
+console.log(`\n[commit-all] done. ${prs} action(s), ${empty} skipped, ${errors} error(s)`);
+if (errors > 0) process.exit(2);
+if (prs === 0) process.exit(0);  // nothing to do is still success
+process.exit(0);


### PR DESCRIPTION
## Summary
- New `scripts/commit-all.mjs` scans every contribution source for the handle and opens a separate PR per source (OCR, review, visuals)
- OCR + review use a clean **temp-index commit pattern** off `origin/main` (`GIT_INDEX_FILE` + `read-tree` + `commit-tree`) — never disturbs the shared sparse-checkout working tree, no orphan branches if push fails, no sparse-checkout \"M …\" flood in the runner log
- Visuals still delegates to `volunteer-media.mjs --commit` so template validation + staging cleanup don't drift
- Monitor gets a new `commit-all` mode and a `/pending` endpoint reporting per-source pending counts
- Dashboard button renamed from \"COMMIT VISUALS\" to a generic \"✓ COMMIT\" with a dynamic sublabel (\"90 OCR · 38 review · 5 visuals ready to publish\") so volunteers see what they are about to publish before clicking

## Why
The COMMIT button was hard-wired to `visuals-commit` only. After running OCR or review jobs, volunteers had no obvious way to publish — contributions piled up on disk and required knowing the per-script flags to PR manually.

## Test plan
- [x] `node --check` on changed files
- [x] `node scripts/commit-all.mjs --my-handle=Rizzleroc --dry-run` correctly reports 90 OCR + 38 review files pending plus the visuals delegate path
- [ ] Click the new COMMIT button in the cockpit after an OCR run — expect one OCR PR opened
- [ ] Click again after a review run — expect one review PR
- [ ] Click after a visuals run with filled templates — expect visuals PR (existing path)
- [ ] `/pending` returns `{ ocr, review, visuals, total }` and the dashboard sublabel reflects it within 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)