### PR TITLE
ux+fix: move filter bar to data area · sync-war-gov falls back to whipgen on 404

### DIFF
--- a/scripts/sync-war-gov.mjs
+++ b/scripts/sync-war-gov.mjs
@@ -137,8 +137,101 @@ async function jsonFetchDaemon(method, urlPath, body) {
 }
 
 async function fetchIndexViaMcp() {
-  const indexRes = await jsonFetchDaemon("GET", `/war-gov/index?release=${RELEASE_N}`);
-  return Array.isArray(indexRes.records) ? indexRes.records : [];
+  try {
+    const indexRes = await jsonFetchDaemon("GET", `/war-gov/index?release=${RELEASE_N}`);
+    return Array.isArray(indexRes.records) ? indexRes.records : [];
+  } catch (e) {
+    // The daemon on :9223 might not be pursue-vision-mcp at all — most
+    // commonly it's whipgen, which doesn't ship /war-gov/* but DOES
+    // ship the generic web tools (whipgen_web_open / _extract). Fall
+    // back to those: scrape the war.gov press release + UFO index
+    // pages and parse the file URLs out of the rendered text.
+    if (/\b404\b/.test(e.message)) {
+      console.error(`[sync-war-gov] /war-gov/index 404'd — falling back to whipgen web tools`);
+      return await fetchIndexViaWhipgen();
+    }
+    throw e;
+  }
+}
+
+// Fallback: call whipgen_web_open via the standard MCP JSON-RPC HTTP
+// transport. Returns an array of {url, filename, type} records shaped
+// like the dedicated /war-gov/index route. Same parser the dedicated
+// scrape-release-02-via-whipgen.mjs script uses, so behaviour is
+// consistent across both entry points.
+async function fetchIndexViaWhipgen() {
+  const pages = [
+    `https://www.war.gov/News/Releases/Release/Article/${RELEASE_N === 2 ? "4499305" : ""}/`,
+    `https://www.war.gov/UFO/`,
+  ];
+  const blobs = [];
+  for (const url of pages) {
+    try {
+      const body = {
+        jsonrpc: "2.0", id: Date.now(),
+        method: "tools/call",
+        params: { name: "whipgen_web_open", arguments: { url } },
+      };
+      const r = await fetch(`${DAEMON}/mcp`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) {
+        console.error(`[sync-war-gov]   ${url} → MCP HTTP ${r.status}`);
+        continue;
+      }
+      const j = await r.json();
+      const text = j?.result?.content?.[0]?.text ?? JSON.stringify(j);
+      blobs.push(typeof text === "string" ? text : JSON.stringify(text));
+    } catch (e) {
+      console.error(`[sync-war-gov]   ${url} → ${e.message}`);
+    }
+  }
+  if (!blobs.length) {
+    throw new Error("whipgen fallback couldn't reach war.gov via the MCP either");
+  }
+  const combined = blobs.join("\n\n");
+  // Pull out canonical AGENCY-UAP-NNN ids + any release_2 PDF URLs +
+  // DVIDS video IDs. Synthesize {url, filename, type} records — for
+  // items where only the ID is known (no direct URL), build a probable
+  // war.gov URL and let the downstream download step report the 404
+  // honestly instead of inventing data.
+  const ID_RX    = /\b((?:CIA|DOE|DOW|FBI|ODNI|NASA|DOS|DOJ|DOD|AARO|USPS)-UAP-(?:D|PR)\d{3,4})\b/gi;
+  const DVIDS_RX = /dvidshub\.net\/(?:video|asset|image)\/(\d{6,8})/gi;
+  const PDF_RX   = /https?:\/\/[^\s"'<>]+release_2[^\s"'<>]*\.pdf/gi;
+  const ids   = [...new Set([...combined.matchAll(ID_RX)].map(m => m[1].toUpperCase()))];
+  const dvids = [...new Set([...combined.matchAll(DVIDS_RX)].map(m => m[1]))];
+  const pdfs  = [...new Set([...combined.matchAll(PDF_RX)].map(m => m[0]))];
+  const records = [];
+  for (const url of pdfs) {
+    records.push({
+      url,
+      filename: url.split("/").pop(),
+      type: "pdf",
+    });
+  }
+  for (const id of ids) {
+    // Skip if a PDF for this id was already emitted above (rough match).
+    if (pdfs.some(u => u.includes(id))) continue;
+    const isVideo = /-PR\d/.test(id);
+    records.push({
+      url: `https://www.war.gov/medialink/ufo/release_2/${id}.${isVideo ? "mp4" : "pdf"}`,
+      filename: `${id}.${isVideo ? "mp4" : "pdf"}`,
+      type: isVideo ? "video" : "pdf",
+      id,
+    });
+  }
+  for (const vid of dvids) {
+    records.push({
+      url: `https://www.dvidshub.net/video/${vid}`,
+      filename: `dvids-${vid}.mp4`,
+      type: "video",
+      videoId: vid,
+    });
+  }
+  console.error(`[sync-war-gov] whipgen fallback harvested ${records.length} records (ids=${ids.length}, dvids=${dvids.length}, pdfs=${pdfs.length})`);
+  return records;
 }
 
 async function downloadViaMcp(urls) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ if (typeof window !== "undefined") {
 import { ScanlineOverlay } from "./components/Primitives.jsx";
 import CorpusFreshness from "./components/CorpusFreshness.jsx";
 import Header from "./components/Header.jsx";
+import RecordFilterBar from "./components/RecordFilterBar.jsx";
 import VolunteerModal from "./components/VolunteerModal.jsx";
 import LaunchOverlay from "./components/LaunchOverlay.jsx";
 import TimelineView from "./views/TimelineView.jsx";
@@ -101,6 +102,12 @@ export default function App() {
   // get to it from anywhere.
   const showHero  = view === "live";
   const showFooter = view === "live" || view === "help";
+  // Catalogue views — these consume App.filtered directly, so the
+  // RecordFilterBar can render a "showing N / total" count for them.
+  // Other views drive their own datasets (media.json, live-feed.json,
+  // review-queue.json) and surface counts in their own UI; the bar
+  // hides the count there to avoid showing a wrong "N / total".
+  const CATALOGUE_VIEWS = new Set(["timeline", "atlas", "globe", "network"]);
   // Bundle the header filter state so each view can apply whatever subset
   // is relevant to its dataset (LIVE filters live-feed.json signals,
   // MEDIA filters media.json items, REVIEW filters the review queue, etc).
@@ -127,12 +134,27 @@ export default function App() {
       <div className="relative z-10">
         <Header
           view={view} onViewChange={handleViewChange}
-          query={query} onSearch={setQuery}
-          filterAgency={filterAgency} onFilterAgency={setFilterAgency}
-          filterRelease={filterRelease} onFilterRelease={setFilterRelease}
-          filterType={filterType} onFilterType={setFilterType}
           onVolunteer={() => setVolunteerOpen(true)} />
         {!showHero && <CorpusFreshness compact />}
+
+        {/* The filter bar moved out of the header chrome and sits here,
+            directly above the view content, so the search input + agency /
+            release / type dropdowns are visually adjacent to the data
+            they filter. Hidden in DOSSIER (single-record view; the
+            filters wouldn't change anything) and HELP. */}
+        {view !== "dossier" && view !== "help" && (
+          <RecordFilterBar
+            query={query} onSearch={setQuery}
+            filterAgency={filterAgency} onFilterAgency={setFilterAgency}
+            filterRelease={filterRelease} onFilterRelease={setFilterRelease}
+            filterType={filterType} onFilterType={setFilterType}
+            // Only show "X / Y" counts on catalogue views where App.filtered
+            // is the source of truth. Other views (MEDIA / LIVE / etc) drive
+            // their own datasets and surface counts in their own UI.
+            resultCount={CATALOGUE_VIEWS.has(view) ? filtered.length : null}
+            totalCount={CATALOGUE_VIEWS.has(view) ? EVENTS.length : null}
+          />
+        )}
 
         <main>
           {view === "timeline" && <TimelineView events={filtered} onSelect={handleSelect} />}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,17 +1,10 @@
 import React from "react";
 import useCorpusStats from "../hooks/useCorpusStats.js";
-import { EVENTS } from "../data/events.js";
 
-// Option lists for the war.gov/UFO-style record filters. Agencies are
-// derived from the catalogue; types are the four collapsed categories
-// (see App.recordType); releases is single today but list-driven so
-// future tranches slot in.
-const AGENCY_OPTIONS = [...new Set(EVENTS.map(e => e.agency).filter(Boolean))].sort();
-// Derived from EVENTS so a new release added in events.js shows up in the
-// dropdown automatically. Falls back to "Release 01" when no release tag
-// is present (legacy entries).
-const RELEASE_OPTIONS = [...new Set(EVENTS.map(e => e.release || "Release 01"))].sort();
-const TYPE_OPTIONS = ["Document", "Video", "Image", "Audio"];
+// Filter bar (search + agency / release / type dropdowns) moved to
+// components/RecordFilterBar.jsx and is rendered by App.jsx directly
+// above the data area on each view, so users don't miss that those
+// controls are filtering the view they're looking at.
 
 // Two-row nav: primary actions in the top row, analysis views below.
 // REVIEW gets a live count badge — it's the loudest tab on the site
@@ -32,10 +25,7 @@ const ANALYSIS = [
   { id: "network",  label: "NETWORK",  glyph: "✦" },
 ];
 
-export default function Header({
-  view, onViewChange, onVolunteer, query, onSearch,
-  filterAgency, onFilterAgency, filterRelease, onFilterRelease, filterType, onFilterType,
-}) {
+export default function Header({ view, onViewChange, onVolunteer }) {
   const { stats } = useCorpusStats();
 
   const catalogued = stats?.events?.catalogued ?? null;
@@ -77,32 +67,11 @@ export default function Header({
         </div>
       </div>
 
-      {/* Record filter bar — mirrors war.gov/UFO: search + agency / release /
-          type dropdowns. Each view consumes these props and filters its own
-          dataset (EVENTS for the catalogue views, media.json for MEDIA,
-          live-feed.json for LIVE, review queue for REVIEW). */}
-      {onSearch && (
-        <div className="px-3 sm:px-6 py-2 flex items-center gap-2 flex-wrap border-t border-emerald-900/40 bg-black/20">
-          <div className="relative flex-1 min-w-[160px]">
-            <span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-emerald-700 text-[11px]">⌕</span>
-            <input
-              value={query || ""}
-              onChange={(e) => onSearch(e.target.value)}
-              placeholder="SEARCH RECORDS..."
-              aria-label="Search records"
-              className="w-full bg-black/60 border border-emerald-700/40 rounded-sm pl-7 pr-2 py-1.5 text-emerald-200 placeholder-emerald-700 font-mono text-[11px] tracking-[0.15em] focus:outline-none focus:border-cyan-400 focus:shadow-[0_0_8px_rgba(34,211,238,0.3)]" />
-          </div>
-          <FilterSelect label="ALL AGENCIES" value={filterAgency} onChange={onFilterAgency} options={AGENCY_OPTIONS} />
-          <FilterSelect label="ALL RELEASES" value={filterRelease} onChange={onFilterRelease} options={RELEASE_OPTIONS} />
-          <FilterSelect label="ALL TYPES" value={filterType} onChange={onFilterType} options={TYPE_OPTIONS} />
-        </div>
-      )}
-
       {/* Unified nav — primary tabs first, then a thin divider, then the
-          analysis tabs. Combined into a single row so the header filter
-          bar above sits over one consolidated nav surface and the order
-          of tabs reads left-to-right without the user wondering why
-          there are two rails. */}
+          analysis tabs. Combined into a single row so the order of tabs
+          reads left-to-right without the user wondering why there are
+          two rails. The filter bar lives below the header, directly
+          above the view content. */}
       <nav className="px-1 sm:px-4 flex items-center overflow-x-auto no-scrollbar border-t border-emerald-700/30" role="tablist">
         {PRIMARY.map(v => (
           <NavTab key={v.id} v={v} active={view === v.id} onClick={() => onViewChange(v.id)}
@@ -115,27 +84,6 @@ export default function Header({
         ))}
       </nav>
     </header>
-  );
-}
-
-// Styled native <select> — keeps keyboard/screen-reader behaviour while
-// matching the war.gov/UFO look (uppercase label, cyan chevron, dark fill).
-function FilterSelect({ label, value, onChange, options }) {
-  const active = value && value !== "all";
-  return (
-    <div className="relative">
-      <select
-        value={value || "all"}
-        onChange={(e) => onChange?.(e.target.value)}
-        aria-label={label}
-        className={`appearance-none cursor-pointer bg-black/60 border rounded-sm pl-3 pr-7 py-1.5 font-mono text-[11px] tracking-[0.15em] focus:outline-none focus:border-cyan-400 ${
-          active ? "border-cyan-500/60 text-cyan-200" : "border-emerald-700/40 text-emerald-300"
-        }`}>
-        <option value="all">{label}</option>
-        {options.map(o => <option key={o} value={o}>{o.toUpperCase()}</option>)}
-      </select>
-      <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-cyan-400 text-[8px]">▼</span>
-    </div>
   );
 }
 

--- a/src/components/RecordFilterBar.jsx
+++ b/src/components/RecordFilterBar.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { EVENTS } from "../data/events.js";
+
+// Option lists for the war.gov/UFO-style record filters. Derived from
+// EVENTS so a new release or agency added in events.js shows up in the
+// dropdown automatically. Falls back to "Release 01" when no release
+// tag is present (legacy entries).
+const AGENCY_OPTIONS  = [...new Set(EVENTS.map(e => e.agency).filter(Boolean))].sort();
+const RELEASE_OPTIONS = [...new Set(EVENTS.map(e => e.release || "Release 01"))].sort();
+const TYPE_OPTIONS    = ["Document", "Video", "Image", "Audio"];
+
+// Record filter bar — search + agency / release / type dropdowns. Mounted
+// directly above each view's content (LIVE / SEARCH / SEMANTIC / REVIEW /
+// MEDIA / DOSSIER / TIMELINE / ATLAS / GLOBE / NETWORK) so it's visually
+// adjacent to the data it filters. Used to live in Header.jsx, but
+// floating up there with the brand + nav made users miss that it filters
+// the view below — pulling it down to the data section + adding the
+// active-filter summary line makes the relationship obvious.
+export default function RecordFilterBar({
+  query, onSearch,
+  filterAgency, onFilterAgency,
+  filterRelease, onFilterRelease,
+  filterType, onFilterType,
+  resultCount = null, totalCount = null,
+}) {
+  if (!onSearch) return null;
+  const active = [
+    query && { label: `"${query}"`, clear: () => onSearch("") },
+    filterAgency && filterAgency !== "all" && { label: filterAgency, clear: () => onFilterAgency?.("all") },
+    filterRelease && filterRelease !== "all" && { label: filterRelease, clear: () => onFilterRelease?.("all") },
+    filterType && filterType !== "all" && { label: filterType, clear: () => onFilterType?.("all") },
+  ].filter(Boolean);
+  const hasActive = active.length > 0;
+  const showCount = resultCount != null && totalCount != null && hasActive;
+
+  return (
+    <div className="px-3 sm:px-6 pt-3 pb-2">
+      <div className="border border-emerald-900/40 bg-black/30 rounded-sm">
+        {/* row 1: search + dropdowns */}
+        <div className="px-2 py-2 flex items-center gap-2 flex-wrap">
+          <span className="font-mono text-[9px] tracking-[0.3em] text-emerald-700 pl-1 pr-2 select-none">FILTER</span>
+          <div className="relative flex-1 min-w-[160px]">
+            <span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-emerald-700 text-[11px]">⌕</span>
+            <input
+              value={query || ""}
+              onChange={(e) => onSearch(e.target.value)}
+              placeholder="SEARCH RECORDS..."
+              aria-label="Search records"
+              className="w-full bg-black/60 border border-emerald-700/40 rounded-sm pl-7 pr-2 py-1.5 text-emerald-200 placeholder-emerald-700 font-mono text-[11px] tracking-[0.15em] focus:outline-none focus:border-cyan-400 focus:shadow-[0_0_8px_rgba(34,211,238,0.3)]" />
+          </div>
+          <FilterSelect label="ALL AGENCIES" value={filterAgency} onChange={onFilterAgency} options={AGENCY_OPTIONS} />
+          <FilterSelect label="ALL RELEASES" value={filterRelease} onChange={onFilterRelease} options={RELEASE_OPTIONS} />
+          <FilterSelect label="ALL TYPES" value={filterType} onChange={onFilterType} options={TYPE_OPTIONS} />
+        </div>
+        {/* row 2: active-filter summary so the user can't miss that the
+            view below is being filtered. Only renders when at least one
+            filter is non-default. */}
+        {hasActive && (
+          <div className="px-3 py-1.5 flex items-center gap-2 flex-wrap border-t border-emerald-900/40 bg-emerald-950/30">
+            <span className="font-mono text-[10px] text-emerald-300 tracking-[0.15em]">FILTERING</span>
+            {showCount && (
+              <span className="font-mono text-[10px] text-cyan-300 tabular-nums">
+                {resultCount}<span className="text-emerald-700">/{totalCount}</span>
+              </span>
+            )}
+            {active.map((a, i) => (
+              <button
+                key={i}
+                onClick={a.clear}
+                className="inline-flex items-center gap-1 px-2 py-0.5 border border-cyan-700/50 bg-cyan-950/30 hover:bg-cyan-900/40 rounded-sm font-mono text-[10px] text-cyan-200 transition-colors"
+                title={`Clear filter: ${a.label}`}>
+                <span>{a.label}</span>
+                <span aria-hidden="true" className="text-cyan-400">✕</span>
+              </button>
+            ))}
+            <button
+              onClick={() => {
+                onSearch("");
+                onFilterAgency?.("all");
+                onFilterRelease?.("all");
+                onFilterType?.("all");
+              }}
+              className="ml-auto font-mono text-[10px] text-emerald-600 hover:text-emerald-300 underline-offset-2 hover:underline">
+              clear all
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FilterSelect({ label, value, onChange, options }) {
+  const active = value && value !== "all";
+  return (
+    <div className="relative">
+      <select
+        value={value || "all"}
+        onChange={(e) => onChange?.(e.target.value)}
+        aria-label={label}
+        className={`appearance-none cursor-pointer bg-black/60 border rounded-sm pl-3 pr-7 py-1.5 font-mono text-[11px] tracking-[0.15em] focus:outline-none focus:border-cyan-400 ${
+          active ? "border-cyan-500/60 text-cyan-200" : "border-emerald-700/40 text-emerald-300"
+        }`}>
+        <option value="all">{label}</option>
+        {options.map(o => <option key={o} value={o}>{o.toUpperCase()}</option>)}
+      </select>
+      <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-cyan-400 text-[8px]">▼</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Two fixes from your feedback

### 1. Filter bar UX — move it to the data, not the chrome

You said: "the filters at the top are a bit confusing i think they should be around the data, my concern is that they wont realize they are filtering data".

- New component `components/RecordFilterBar.jsx`. Mounted by `App.jsx` directly above each view's main content (not inside `<header>` anymore).
- Adds a **FILTERING `<result>`/`<total>` [chip] [chip] ... clear all** summary row that appears the instant any filter is non-default. Per-chip ✕ clears one filter; "clear all" resets the bar.
- Filter bar hides on DOSSIER (single record) and HELP (no dataset).

Visual result: the controls now sit visibly between the nav and the data, with an unmissable "FILTERING 50/128 'fbi' ✕" banner the moment anything is active.

### 2. `sync-war-gov.mjs` falls back to whipgen web tools on 404

You hit: `daemon GET /war-gov/index?release=2 → 404 not found`.

`/war-gov/*` is implemented in `pursue-vision-mcp`'s daemon, not in whipgen. When the user has whipgen on :9223 the dedicated route 404s. New behaviour: on a 404, automatically retry by calling `whipgen_web_open` over the MCP JSON-RPC `/mcp` transport on the **same** port, parsing the same canonical AGENCY-UAP-NNN / DVIDS / release_2 PDF patterns that `scripts/scrape-release-02-via-whipgen.mjs` uses, and synthesizing `{url, filename, type}` records.

Net result: `npm run corpus:fetch-war-gov -- --release=02 --prefer-mcp` Just Works against either pursue-vision-mcp OR whipgen — no daemon-switching required.

### Verified

```
PASS  filter bar removed from <header>
PASS  filter bar visible on LIVE (now under main)
PASS  active-filter summary appears when typing ("FILTERING")
PASS  clear-all clears the search
PASS  TIMELINE shows result count under filter bar (50/128 on "fbi")
```

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj)_