### PR TITLE
fix(deploy): repair `npm run deploy` (gh-pages v6+ flag mismatch) — live site was 404'ing because Pages source is gh-pages branch + the publish script was broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist -b gh-pages -t true",
+    "deploy": "gh-pages -d dist -b gh-pages --dotfiles --nojekyll",
     "corpus:fetch": "node scripts/fetch-pdfs.mjs",
     "corpus:extract": "node scripts/extract-text.mjs",
     "corpus:ocr": "node scripts/ocr-scanned.mjs",


### PR DESCRIPTION
## Summary — fixes the live-site 404

You hit a 404 on https://rizzleroc.github.io/pursue-console/. Root cause has two layers:

1. **Repo Pages source = "branch: gh-pages"**, not "GitHub Actions". So `.github/workflows/deploy.yml` (which uses `actions/deploy-pages`) has been a no-op for live publishing. Every merge to main has been "successfully" running deploy.yml's `build` job and uploading an artifact that GitHub Pages doesn't consume.

2. **`npm run deploy` (the actual publish path) was broken.** Script was `gh-pages -d dist -b gh-pages -t true`. In `gh-pages` v6+, `-t` is the bare `--dotfiles` flag — `true` is parsed as a stray positional arg and the CLI errors with "too many arguments. Expected 0 arguments but got 1". Nobody could run a manual publish either, so the `gh-pages` branch was stuck at the 2026-05-21 build — three days behind `main`. New URLs like `release_2/DOW-UAP-D017_*.pdf` 404'd because they didn't exist in the stale snapshot.

### Change

```diff
-    "deploy": "gh-pages -d dist -b gh-pages -t true",
+    "deploy": "gh-pages -d dist -b gh-pages --dotfiles --nojekyll",
```

`--nojekyll` adds the `.nojekyll` marker so GitHub doesn't try to Jekyll-process the site (which would otherwise hide directories starting with `_`).

### Already done (live site unblocked now)

I ran the corrected `gh-pages` command directly while diagnosing — the `gh-pages` branch now reflects current main (336 files including `release_2/`), so the live site should resolve. Try a hard-refresh.

### Recommended follow-up (Settings access required)

Switch the repo's Pages source from "Deploy from a branch: gh-pages" → "GitHub Actions" so `deploy.yml` actually publishes on merge. Once that's done, `npm run deploy` becomes a fallback and the gh-pages branch can be retired.

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj)_