### PR TITLE
feat(monitor): scheduled uptime probe for the live GitHub Pages site

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -1,0 +1,121 @@
+name: Uptime monitor
+
+# Every 5 minutes: probe the live GitHub Pages site and open/update a
+# tracking issue if it's down. Recovery comment + close on next healthy run.
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: uptime-monitor
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run healthcheck
+        id: check
+        continue-on-error: true
+        run: |
+          set +e
+          OUTPUT=$(node scripts/healthcheck-site.mjs)
+          EXIT_CODE=$?
+          echo "$OUTPUT"
+          REPORT=$(echo "$OUTPUT" | tail -n 1)
+          echo "report=$REPORT" >> "$GITHUB_OUTPUT"
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Find existing incident issue
+        id: incident
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUM=$(gh issue list --label uptime-incident --state open --json number --jq '.[0].number // empty' || echo "")
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update incident issue
+        if: steps.check.outputs.healthy == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT: ${{ steps.check.outputs.report }}
+          ISSUE_NUMBER: ${{ steps.incident.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SITE_URL: https://rizzleroc.github.io/pursue-console/
+        run: |
+          TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          BODY_FILE=$(mktemp)
+          if [ -n "$ISSUE_NUMBER" ]; then
+            {
+              echo "Still down at $TS."
+              echo ""
+              echo "Workflow run: $RUN_URL"
+              echo ""
+              echo '```json'
+              echo "$REPORT"
+              echo '```'
+            } > "$BODY_FILE"
+            gh issue comment "$ISSUE_NUMBER" --body-file "$BODY_FILE"
+          else
+            gh label create uptime-incident \
+              --description "Live site is failing the scheduled uptime probe" \
+              --color B60205 \
+              --force >/dev/null
+            {
+              echo "The live site is failing its uptime probe."
+              echo ""
+              echo "- URL: $SITE_URL"
+              echo "- Detected at: $TS"
+              echo "- Workflow run: $RUN_URL"
+              echo ""
+              echo "Latest report:"
+              echo ""
+              echo '```json'
+              echo "$REPORT"
+              echo '```'
+            } > "$BODY_FILE"
+            gh issue create \
+              --title "[uptime] pursue-console is down" \
+              --label uptime-incident \
+              --body-file "$BODY_FILE"
+          fi
+
+      - name: Close incident on recovery
+        if: steps.check.outputs.healthy == 'true' && steps.incident.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT: ${{ steps.check.outputs.report }}
+          ISSUE_NUMBER: ${{ steps.incident.outputs.number }}
+        run: |
+          TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          BODY_FILE=$(mktemp)
+          {
+            echo "Recovered at $TS."
+            echo ""
+            echo "Latest report:"
+            echo ""
+            echo '```json'
+            echo "$REPORT"
+            echo '```'
+          } > "$BODY_FILE"
+          gh issue close "$ISSUE_NUMBER" --comment "$(cat "$BODY_FILE")"
+
+      - name: Fail run if unhealthy
+        if: steps.check.outputs.healthy == 'false'
+        run: exit 1

--- a/scripts/healthcheck-site.mjs
+++ b/scripts/healthcheck-site.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+
+const DEFAULT_URL = 'https://rizzleroc.github.io/pursue-console/';
+const MARKER = 'PURSUE Console — Release 01';
+const RETRY_PAUSE_MS = 5000;
+
+const { values } = parseArgs({
+  options: {
+    url: { type: 'string', default: DEFAULT_URL },
+    timeout: { type: 'string', default: '15000' },
+    retries: { type: 'string', default: '2' },
+  },
+});
+
+const url = values.url;
+const timeoutMs = Number.parseInt(values.timeout, 10);
+const retries = Number.parseInt(values.retries, 10);
+const maxAttempts = retries + 1;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function attempt() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { 'user-agent': 'pursue-console-healthcheck/1.0' },
+    });
+    const status = res.status;
+    if (status < 200 || status >= 300) {
+      return { healthy: false, status, reason: `http_${status}`, elapsed: Date.now() - start };
+    }
+    const body = await res.text();
+    if (!body.includes(MARKER)) {
+      return { healthy: false, status, reason: 'missing_marker', elapsed: Date.now() - start };
+    }
+    return { healthy: true, status, reason: 'ok', elapsed: Date.now() - start };
+  } catch (err) {
+    const isAbort = err?.name === 'AbortError';
+    return {
+      healthy: false,
+      status: null,
+      reason: isAbort ? 'timeout' : 'fetch_error',
+      elapsed: Date.now() - start,
+      error: err?.message || String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const overallStart = Date.now();
+let result;
+let attempts = 0;
+for (let i = 0; i < maxAttempts; i++) {
+  attempts = i + 1;
+  process.stderr.write(`[healthcheck] attempt ${attempts}/${maxAttempts} GET ${url}\n`);
+  result = await attempt();
+  if (result.healthy) {
+    process.stderr.write(`[healthcheck] attempt ${attempts} ok (${result.elapsed}ms)\n`);
+    break;
+  }
+  const detail = result.error ? ` (${result.error})` : '';
+  process.stderr.write(
+    `[healthcheck] attempt ${attempts} unhealthy: ${result.reason}${detail} (${result.elapsed}ms)\n`,
+  );
+  if (i < maxAttempts - 1) {
+    await sleep(RETRY_PAUSE_MS);
+  }
+}
+
+const payload = {
+  healthy: result.healthy,
+  url,
+  status: result.status,
+  elapsed_ms: Date.now() - overallStart,
+  reason: result.reason,
+  attempts,
+  checked_at: new Date().toISOString(),
+};
+
+process.stdout.write(JSON.stringify(payload) + '\n');
+process.exit(result.healthy ? 0 : 1);


### PR DESCRIPTION
## Summary

Adds a runtime uptime monitor for https://rizzleroc.github.io/pursue-console/. Built by two sub-agents working in parallel against a shared CLI contract (the healthcheck script + the workflow that calls it).

- **`.github/workflows/uptime-monitor.yml`** — cron `*/5 * * * *` + `workflow_dispatch`, `issues: write` permission. Calls the healthcheck script, then on unhealthy opens or comments on a tracking issue labelled `uptime-incident`; on recovery posts a closing comment and closes the issue. Idempotent — at most one open `uptime-incident` issue. Ensures the label exists via `gh label create --force` before the first incident. Final `exit 1` so unhealthy runs show red in the Actions UI.
- **`scripts/healthcheck-site.mjs`** — zero-deps Node 20 ESM. Probes the URL with a 15s timeout and 3 internal attempts (5s pause between retries) before deciding. Verifies HTTP 2xx **and** that the response body contains the stable `<title>` marker `PURSUE Console — Release 01` (proves Pages is serving the app, not a 404 or blank). Emits a single-line JSON report to stdout (`{healthy, url, status, elapsed_ms, reason, attempts, checked_at}`); per-attempt diagnostics go to stderr. Exit 0 healthy, 1 unhealthy. Flags: `--url`, `--timeout`, `--retries`.

## Test plan

- [ ] Merge to main, then trigger the workflow manually from the Actions tab (`Uptime monitor` → Run workflow). Confirm the run is green and no issue is created.
- [ ] Temporarily run the workflow with `--url https://httpbin.org/status/503` (or edit the cron step in a throwaway branch) to confirm an issue is opened with label `uptime-incident`.
- [ ] On the next healthy run, confirm the issue is closed with a recovery comment.
- [ ] After two failing runs in a row, confirm the second one **comments on** the existing issue rather than opening a duplicate.

> Note: this container's egress sandbox blocks `rizzleroc.github.io` (returns 403 `Host not in allowlist`), so the script was only smoke-tested locally — it correctly reports `http_403`, exits 1, and emits well-formed JSON. The real probe will run from GitHub-hosted runners which have open egress.

https://claude.ai/code/session_01XzWMN5obQSjH8Fu7dUtpBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWMN5obQSjH8Fu7dUtpBh)_