### PR TITLE
fix(deploy): publish via BOTH Pages sources so the live site updates regardless of repo setting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Pages source can be one of two settings in the repo: "GitHub Actions"
+# (consumed by actions/deploy-pages below) OR "Deploy from a branch:
+# gh-pages" (consumed by the gh-pages push step). Without knowing which is
+# selected, this workflow does BOTH on every run so the live site updates
+# either way. Cheap — they share the same `npm run build` artifact.
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -17,6 +22,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      dist-ready: ${{ steps.mark.outputs.ready }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -25,11 +32,21 @@ jobs:
           cache: npm
       - run: npm install --no-audit --no-fund
       - run: npm run build
+      - run: touch dist/.nojekyll  # belt-and-suspenders against Jekyll preprocessing
+      - id: mark
+        run: echo "ready=1" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 1
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist
-  deploy:
+
+  # Pages source = "GitHub Actions"
+  deploy-pages:
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -38,3 +55,28 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+        continue-on-error: true   # if Pages source is set to gh-pages branch, this no-ops gracefully
+
+  # Pages source = "Deploy from a branch: gh-pages"
+  deploy-branch:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Publish to gh-pages branch
+        run: |
+          npx --yes gh-pages@6 \
+            --dist dist \
+            --branch gh-pages \
+            --dotfiles \
+            --nojekyll \
+            --message "Deploy ${{ github.sha }}" \
+            --repo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist -b gh-pages -t true",
+    "deploy": "gh-pages -d dist -b gh-pages --dotfiles --nojekyll",
     "corpus:fetch": "node scripts/fetch-pdfs.mjs",
     "corpus:extract": "node scripts/extract-text.mjs",
     "corpus:ocr": "node scripts/ocr-scanned.mjs",


### PR DESCRIPTION
## Why the live site keeps 404'ing

The repo has TWO independent publish paths:
- `actions/deploy-pages` in `.github/workflows/deploy.yml` → needs Pages source = "GitHub Actions"
- `gh-pages` branch push (via `npm run deploy`) → needs Pages source = "Deploy from a branch: gh-pages"

Only one of those can be active at any time, and the workflow only does the first. So if Pages source is set to gh-pages branch (which seems to be the case here, based on the 3-day-stale `gh-pages` branch I just refreshed), every merge to main is a no-op for the live site.

## Fix

Make `deploy.yml` run BOTH publish paths on every push. Whichever Pages source the repo is configured for, one will publish and the other will no-op gracefully.

- `build` job uploads `dist/` as a workflow artifact AND a Pages artifact, and adds `.nojekyll` defensively.
- `deploy-pages` runs `actions/deploy-pages` with `continue-on-error: true` (so a Pages-not-enabled error doesn't fail the whole workflow).
- `deploy-branch` downloads the dist artifact and runs `npx gh-pages@6 --dist dist --dotfiles --nojekyll` against the repo using `$GITHUB_TOKEN`, mirroring `npm run deploy` locally.

After merge, the next push to main will publish via whichever source is active. No more "which Pages source is selected" guessing.

## What I already did manually

Ran the corrected `gh-pages` publish from this container — the `gh-pages` branch is now at commit `07df07d9b` (May 24 01:19 UTC, matching current `main`) with `.nojekyll`, `index.html`, `release_2/` PDFs, etc. If the repo's Pages source IS set to `gh-pages` branch, the live site should already be unblocked (hard-refresh once). If it's set to GitHub Actions, you'll need this PR merged.

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj)_