### PR TITLE
feat(ask): natural-language query over the dataset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import HelpView from "./views/HelpView.jsx";
 import DossierView from "./views/DossierView.jsx";
 import ReviewView from "./views/ReviewView.jsx";
 import MediaView from "./views/MediaView.jsx";
+import AskView from "./views/AskView.jsx";
 
 // Semantic search pulls in transformers.js (~25MB INT8 model + ORT wasm) —
 // lazy-load it so first paint isn't gated on that bundle.
@@ -165,6 +166,7 @@ export default function App() {
           {view === "live"     && <LiveFeedView onSelect={handleSelect} headerFilters={headerFilters} />}
           {view === "review"   && <ReviewView   onSelect={handleSelect} headerFilters={headerFilters} />}
           {view === "media"    && <MediaView    onSelect={handleSelect} headerFilters={headerFilters} />}
+          {view === "ask"      && <AskView      onSelect={handleSelect} headerFilters={headerFilters} />}
           {view === "help"     && <HelpView onViewChange={handleViewChange} />}
           {view === "semantic" && (
             <Suspense fallback={

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,6 +14,7 @@ const PRIMARY = [
   { id: "live",     label: "LIVE",     glyph: "●" },
   { id: "search",   label: "SEARCH",   glyph: "⌕" },
   { id: "semantic", label: "SEMANTIC", glyph: "∿" },
+  { id: "ask",      label: "ASK",      glyph: "?" },
   { id: "review",   label: "REVIEW",   glyph: "⚖" },
   { id: "media",    label: "MEDIA",    glyph: "▦" },
   { id: "dossier",  label: "DOSSIER",  glyph: "❒" },

--- a/src/lib/askEngine.js
+++ b/src/lib/askEngine.js
@@ -1,0 +1,417 @@
+// =====================================================================
+// ASK — a tiny natural-language processor for the corpus.
+//
+// Not an LLM. Pattern-matches a question against a fixed set of intents
+// (changes / classified / agency-distinctives / where / when / count /
+// keyword) and runs the matching query against EVENTS. Returns a
+// structured answer the AskView renders.
+//
+// Why pattern-match instead of a model? Two reasons. (1) The questions
+// we want to answer — "what's new", "what was classified before",
+// "what's different about NASA" — are about *the shape of the dataset*,
+// not about the documents' contents (SEMANTIC search already covers
+// that). (2) Browser-side LLMs aren't free. A 25 MB transformer is
+// already pulled in for SEMANTIC; bolting a second one on for chat
+// would double the cold-load cost for a feature that boils down to
+// "filter EVENTS by a couple of fields."
+// =====================================================================
+import { EVENTS, AGENCY_COLORS } from "../data/events.js";
+
+// Agency aliases → canonical record.agency string. "war" matches DoW,
+// "intelligence" matches ODNI (the only agency with "intelligence" in
+// the full name; CIA is matched by the "cia" alias).
+const AGENCY_ALIASES = [
+  ["nasa",         "NASA"],
+  ["fbi",          "FBI"],
+  ["dow",          "Department of War"],
+  ["dod",          "Department of War"],
+  ["defense",      "Department of War"],
+  ["war",          "Department of War"],
+  ["state",        "Department of State"],
+  ["dos",          "Department of State"],
+  ["cia",          "Central Intelligence Agency"],
+  ["doe",          "Department of Energy"],
+  ["energy",       "Department of Energy"],
+  ["odni",         "Office of the Director of National Intelligence"],
+  ["intelligence", "Office of the Director of National Intelligence"],
+];
+
+const STOPWORDS = new Set([
+  "the","a","an","what","was","is","are","were","does","did","do","about",
+  "data","on","of","in","to","from","for","by","or","and","that","which",
+  "whats","this","these","those","with","like","just","get","back","you",
+  "so","can","be","been","has","have","had","there","its","any","i","me",
+  "tell","show","find","list","all","into","across","records","record",
+  "documents","document","docs","doc","files","file","reports","report",
+  "anything","everything","things","stuff","please","me","us"
+]);
+
+function lc(q) { return (q || "").toLowerCase().trim(); }
+
+function tokens(q) {
+  return lc(q).replace(/[^a-z0-9' ]+/g, " ").split(/\s+/).filter(Boolean);
+}
+
+function detectAgency(qLower) {
+  for (const [alias, canonical] of AGENCY_ALIASES) {
+    if (new RegExp(`\\b${alias}\\b`).test(qLower)) return canonical;
+  }
+  return null;
+}
+
+function detectRelease(qLower) {
+  if (/\brelease[\s-]*(?:0?2|two|ii)\b|\br[\s-]*02\b|\brel[\s-]*2\b/.test(qLower)) return "Release 02";
+  if (/\brelease[\s-]*(?:0?1|one|i)\b|\br[\s-]*01\b|\brel[\s-]*1\b/.test(qLower))  return "Release 01";
+  return null;
+}
+
+function detectEra(qLower) {
+  // "60s", "1960s", "the sixties"
+  const m = qLower.match(/\b(?:19|20)?(\d0)s\b/);
+  if (m) return m[1] + "s";
+  const decades = { sixties:"60s", seventies:"70s", eighties:"80s", nineties:"90s", forties:"40s", fifties:"50s" };
+  for (const [w, era] of Object.entries(decades)) if (qLower.includes(w)) return era;
+  return null;
+}
+
+function detectYear(qLower) {
+  const m = qLower.match(/\b(19|20)\d{2}\b/);
+  return m ? m[0] : null;
+}
+
+function detectMedia(qLower) {
+  if (/\bvideos?\b|\bfootage\b|\bflir\b|\bir video\b/.test(qLower)) return "video";
+  if (/\baudios?\b|\brecordings?\b|\btranscripts?\b/.test(qLower))   return "audio";
+  if (/\bphotos?\b|\bimagery?\b|\bimages?\b|\bsketch(?:es)?\b/.test(qLower)) return "image";
+  return null;
+}
+
+// Pull "content words" out of the question for keyword fallback / topic
+// matching against title + summary + tags.
+function topicTerms(qLower) {
+  return tokens(qLower).filter(t => !STOPWORDS.has(t) && t.length > 2);
+}
+
+// ---- Intent triggers -------------------------------------------------
+
+// Stem-match prefixes (no trailing \b) so "changed", "changing", "updated",
+// "newest" all hit. The leading \b keeps "ranch" from matching "chang".
+function isChanges(q) {
+  return /\b(chang|new|added|since|latest|recently|update|fresh|just dropped|incoming|release 02|release 2|release ii|r02|rel 2)/.test(q);
+}
+function isClassifiedBefore(q) {
+  return /\b(classified before|classified beforehand|previously classified|was classified|still classified|still redacted|still secret|redacted|secret|withheld|blacked out|black bars|censored)\b/.test(q);
+}
+function isUnclassified(q) {
+  return /\b(unclassified|unredacted|not redacted|fully released|fully declassified|public|no redactions|clean)\b/.test(q);
+}
+function isDifferent(q) {
+  return /\b(differ|distinct|unique|stand[- ]?out|odd|unusual|special|peculiar|notable)/.test(q);
+}
+function isCount(q) {
+  return /\b(how many|count|total|number of)\b/.test(q);
+}
+// ---- Helpers ---------------------------------------------------------
+
+const FLAG_RANK = { anchor: 3, high: 2, med: 1, low: 0 };
+
+function sortByPriority(arr) {
+  return [...arr].sort((a, b) => {
+    const fa = FLAG_RANK[a.flag] ?? 0, fb = FLAG_RANK[b.flag] ?? 0;
+    if (fa !== fb) return fb - fa;
+    return (b.sort || 0) - (a.sort || 0);
+  });
+}
+
+function byAgency(events) {
+  const m = new Map();
+  for (const e of events) {
+    const a = e.agency || "Unknown";
+    if (!m.has(a)) m.set(a, []);
+    m.get(a).push(e);
+  }
+  return Array.from(m.entries())
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([agency, list]) => ({ label: `${agency} (${list.length})`, agency, events: sortByPriority(list) }));
+}
+
+function pct(n, total) {
+  if (!total) return "0%";
+  return Math.round((n / total) * 100) + "%";
+}
+
+// ---- Intent handlers -------------------------------------------------
+
+function answerChanges({ events }) {
+  const r02 = events.filter(e => e.release === "Release 02");
+  const r01 = events.filter(e => (e.release || "Release 01") === "Release 01");
+  const r02Agencies = new Set(r02.map(e => e.agency));
+  const r01Agencies = new Set(r01.map(e => e.agency));
+  const newAgencies = [...r02Agencies].filter(a => !r01Agencies.has(a));
+
+  const r02Redacted = r02.filter(e => e.redacted).length;
+  const r02Videos = r02.filter(e => e.videoId).length;
+
+  return {
+    intent: "changes",
+    headline: `Release 02 added ${r02.length} records to the catalogue (Release 01: ${r01.length}).`,
+    notes: [
+      newAgencies.length
+        ? `New agencies in Release 02: ${newAgencies.join(", ")} — first appearance in the public corpus.`
+        : `No new agencies in Release 02.`,
+      `${r02Redacted} of ${r02.length} Release 02 records still bear redactions; ${r02Videos} are video.`,
+      `Release 02 PDFs are mirrored locally under /release_2/ — the war.gov WAF rejects automated fetches.`,
+    ],
+    stats: [
+      { label: "RELEASE 02", value: r02.length },
+      { label: "RELEASE 01", value: r01.length },
+      { label: "NEW AGENCIES", value: newAgencies.length },
+      { label: "STILL REDACTED", value: r02Redacted },
+    ],
+    groups: byAgency(r02),
+    hint: "Try also: \"what was classified before\" · \"different about NASA\" · \"records from the 70s\"",
+  };
+}
+
+function answerClassifiedBefore({ events }) {
+  const redacted = events.filter(e => e.redacted);
+  const total = events.length;
+  return {
+    intent: "classified-before",
+    headline: `${redacted.length} of ${total} records (${pct(redacted.length, total)}) were declassified for this release but still carry visible redactions.`,
+    notes: [
+      `These are the documents that were classified beforehand. Black bars, withheld names, sanitized locations — the unredacted material is what war.gov decided to release.`,
+      `Use SEARCH to find specific redacted passages; the search index includes everything the OCR could read around the bars.`,
+    ],
+    stats: [
+      { label: "STILL REDACTED", value: redacted.length },
+      { label: "FULLY RELEASED", value: total - redacted.length },
+      { label: "TOTAL", value: total },
+    ],
+    groups: byAgency(redacted),
+    hint: "Compare: \"what is unredacted\" · \"different about NASA\"",
+  };
+}
+
+function answerUnclassified({ events }) {
+  const clean = events.filter(e => !e.redacted);
+  const total = events.length;
+  return {
+    intent: "unclassified",
+    headline: `${clean.length} of ${total} records (${pct(clean.length, total)}) released without visible redactions — fully declassified.`,
+    notes: [
+      `These records carry no black bars in the released copy. Historical material (40s–60s) dominates: anything sensitive about Cold War sources has aged out.`,
+      `Modern fully-clean records are rare — most post-2000 mission reports still redact unit identifiers and personnel names.`,
+    ],
+    stats: [
+      { label: "FULLY RELEASED", value: clean.length },
+      { label: "STILL REDACTED", value: total - clean.length },
+      { label: "TOTAL", value: total },
+    ],
+    groups: byAgency(clean),
+    hint: "Compare: \"what was classified before\" · \"records from the 40s\"",
+  };
+}
+
+// "Different about X" — surface the facts that distinguish a slice from
+// the rest of the catalogue. For agencies that becomes: where do these
+// docs live (region, era, flag), and what types are over-represented?
+function answerDifferent({ events, agency }) {
+  const slice = agency ? events.filter(e => e.agency === agency) : null;
+  if (!slice || slice.length === 0) {
+    return {
+      intent: "different",
+      headline: "I need an agency or topic to compare against the rest of the catalogue.",
+      notes: ["Try: \"what's different about NASA\" or \"what's different about FBI\"."],
+      stats: [],
+      events: [],
+    };
+  }
+  const others = events.filter(e => e.agency !== agency);
+  const total = events.length;
+
+  const sliceAnchor = slice.filter(e => e.flag === "anchor").length;
+  const otherAnchor = others.filter(e => e.flag === "anchor").length;
+
+  const sliceSpace = slice.filter(e => e.region === "Space" || /space|orbit|lunar|moon|cislunar/i.test(e.loc || "")).length;
+  const otherSpace = others.filter(e => e.region === "Space" || /space|orbit|lunar|moon|cislunar/i.test(e.loc || "")).length;
+
+  const sliceVideo = slice.filter(e => e.videoId).length;
+  const sliceRedacted = slice.filter(e => e.redacted).length;
+
+  // Spread of eras for this slice
+  const eras = {};
+  for (const e of slice) if (e.era) eras[e.era] = (eras[e.era] || 0) + 1;
+  const eraList = Object.entries(eras).sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([k, v]) => `${k}:${v}`).join(" · ");
+
+  const notes = [];
+  notes.push(
+    `${pct(sliceAnchor, slice.length)} of ${agency} records are PRIORITY-flagged (anchor), versus ${pct(otherAnchor, others.length)} of the rest of the corpus.`
+  );
+  if (sliceSpace > 0) {
+    notes.push(
+      `${sliceSpace} of ${slice.length} ${agency} records are set in space / orbit / on the moon — the rest of the catalogue has ${otherSpace} space-set records combined.`
+    );
+  }
+  if (sliceVideo > 0) {
+    notes.push(`${sliceVideo} ${agency} record${sliceVideo === 1 ? "" : "s"} include${sliceVideo === 1 ? "s" : ""} declassified DVIDS video / audio.`);
+  }
+  if (sliceRedacted > 0) {
+    notes.push(`${sliceRedacted} of ${slice.length} ${agency} records still carry redactions; ${slice.length - sliceRedacted} are released fully clean.`);
+  }
+  if (eraList) {
+    notes.push(`Era spread: ${eraList}.`);
+  }
+  // Highlight any single-record outliers (e.g. COMETA under NASA)
+  if (agency === "NASA") {
+    const cometa = slice.find(e => e.id === "cometa");
+    if (cometa) notes.push(`Outlier: COMETA is filed under NASA but contains French intelligence material hand-delivered to Washington. The filing choice is itself revealing.`);
+  }
+
+  return {
+    intent: "different",
+    headline: `What's distinctive about the ${agency} slice (${slice.length} of ${total} records).`,
+    notes,
+    stats: [
+      { label: agency.toUpperCase().replace(/DEPARTMENT OF /, "DEPT/"), value: slice.length },
+      { label: "PRIORITY", value: sliceAnchor },
+      { label: "VIDEO", value: sliceVideo },
+      { label: "REDACTED", value: sliceRedacted },
+    ],
+    groups: null,
+    events: sortByPriority(slice),
+    hint: `Try also: "${agency} records from the 70s" · "NASA video footage"`,
+  };
+}
+
+function answerCount({ events, agency, release, era, media }) {
+  let slice = events;
+  const filters = [];
+  if (agency)  { slice = slice.filter(e => e.agency === agency); filters.push(agency); }
+  if (release) { slice = slice.filter(e => (e.release || "Release 01") === release); filters.push(release); }
+  if (era)     { slice = slice.filter(e => e.era === era); filters.push(era); }
+  if (media === "video") { slice = slice.filter(e => e.videoId); filters.push("video"); }
+  if (media === "audio") { slice = slice.filter(e => /audio|transcript|debrief/i.test(e.type || "")); filters.push("audio"); }
+  if (media === "image") { slice = slice.filter(e => /image|imagery|photo|sketch/i.test(e.type || "")); filters.push("image"); }
+  return {
+    intent: "count",
+    headline: filters.length
+      ? `${slice.length} record${slice.length === 1 ? "" : "s"} match: ${filters.join(" · ")}.`
+      : `${events.length} records total in the catalogue.`,
+    notes: [
+      `Each record is a single declassified PDF, video, or audio file from war.gov/UFO.`,
+    ],
+    stats: [{ label: "MATCHED", value: slice.length }, { label: "TOTAL", value: events.length }],
+    groups: agency ? null : byAgency(slice),
+    events: agency ? sortByPriority(slice) : null,
+  };
+}
+
+// Filter-only (agency / release / era / media / topic) — no aggregation,
+// just "show me these records."
+function answerFilter({ events, agency, release, era, media, terms }) {
+  let slice = events;
+  const filters = [];
+  if (agency)  { slice = slice.filter(e => e.agency === agency); filters.push(agency); }
+  if (release) { slice = slice.filter(e => (e.release || "Release 01") === release); filters.push(release); }
+  if (era)     { slice = slice.filter(e => e.era === era); filters.push(`${era}`); }
+  if (media === "video") { slice = slice.filter(e => e.videoId); filters.push("video"); }
+  if (media === "audio") { slice = slice.filter(e => /audio|transcript|debrief/i.test(e.type || "")); filters.push("audio"); }
+  if (media === "image") { slice = slice.filter(e => /image|imagery|photo|sketch/i.test(e.type || "")); filters.push("image"); }
+  if (terms && terms.length) {
+    slice = slice.filter(e => {
+      const hay = (e.title + " " + (e.summary || "") + " " + (e.tags || []).join(" ") + " " + (e.loc || "")).toLowerCase();
+      return terms.every(t => hay.includes(t));
+    });
+    filters.push(`matching "${terms.join(" ")}"`);
+  }
+  return {
+    intent: "filter",
+    headline: slice.length
+      ? `${slice.length} record${slice.length === 1 ? "" : "s"} — ${filters.join(" · ") || "all records"}.`
+      : `No records match: ${filters.join(" · ")}.`,
+    notes: slice.length === 0
+      ? [`Nothing matched. Try broader terms — or check SEARCH for full-text hits.`]
+      : [],
+    stats: [{ label: "MATCHED", value: slice.length }],
+    events: sortByPriority(slice).slice(0, 60),
+    hint: filters.length ? null : "Try: \"NASA records from the 70s\" · \"redacted Iraq reports\"",
+  };
+}
+
+// ---- Top-level dispatch ----------------------------------------------
+
+export function ask(question, opts = {}) {
+  const allEvents = opts.events || EVENTS;
+  // Drop the auto-imported FBI section stubs from quantitative answers
+  // unless the question is explicitly about them — they're not really
+  // "records" in the curatorial sense, they're the unprocessed long tail.
+  const events = allEvents.filter(e => !e.auto);
+
+  const original = (question || "").trim();
+  if (!original) {
+    return {
+      intent: "empty",
+      headline: "Ask the dataset a question.",
+      notes: [
+        "I parse questions like \"what changed in Release 02\", \"what was classified before\", \"what's different about NASA\", or \"FBI records from the 50s\" and run them against the local catalogue.",
+        "I don't read inside the documents — for that, use SEARCH (full-text) or SEMANTIC (meaning-based).",
+      ],
+      stats: [],
+      events: [],
+    };
+  }
+  const q = lc(original);
+
+  const agency  = detectAgency(q);
+  const release = detectRelease(q);
+  const era     = detectEra(q);
+  const year    = detectYear(q);
+  const media   = detectMedia(q);
+
+  let answer;
+  if (isClassifiedBefore(q))     answer = answerClassifiedBefore({ events });
+  else if (isUnclassified(q))    answer = answerUnclassified({ events });
+  else if (isChanges(q))         answer = answerChanges({ events });
+  else if (isDifferent(q))       answer = answerDifferent({ events, agency });
+  else if (isCount(q))           answer = answerCount({ events, agency, release, era, media });
+  else if (agency || release || era || media || year) {
+    const terms = year ? [year] : [];
+    answer = answerFilter({ events, agency, release, era, media, terms });
+  } else {
+    // Fallback: keyword search over title / summary / tags / location.
+    const terms = topicTerms(q);
+    if (terms.length === 0) {
+      answer = {
+        intent: "unknown",
+        headline: "I didn't recognize that question.",
+        notes: [
+          "Try one of: \"what's new in Release 02\" · \"what was classified beforehand\" · \"what's different about the NASA document\" · \"how many videos\" · \"FBI records from the 50s\".",
+        ],
+        stats: [], events: [],
+      };
+    } else {
+      answer = answerFilter({ events, agency: null, release: null, era: null, media: null, terms });
+      // Mark intent as keyword so the UI can label it
+      answer.intent = "keyword";
+    }
+  }
+
+  answer.query = { original, normalized: q, agency, release, era, year, media };
+  return answer;
+}
+
+// Example questions for the UI's quick-start chips.
+export const ASK_EXAMPLES = [
+  "what changed in Release 02",
+  "what was classified beforehand",
+  "what is unredacted",
+  "what's different about the NASA documents",
+  "how many videos",
+  "FBI records from the 50s",
+  "Syria 2024",
+  "anything from the 60s",
+];
+
+export { AGENCY_COLORS };

--- a/src/views/AskView.jsx
+++ b/src/views/AskView.jsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { ask, ASK_EXAMPLES } from "../lib/askEngine.js";
+import { AGENCY_COLORS } from "../data/events.js";
+import { GlitchText, DocTypeBadge, flagBg } from "../components/Primitives.jsx";
+
+// =====================================================================
+// ASK — natural-language interface over the catalogue.
+//
+// The engine in lib/askEngine.js does the parsing; this view is just the
+// terminal-styled shell. Mirrors the look-and-feel of SearchView /
+// SemanticSearchView so it slots in alongside them in the nav.
+// =====================================================================
+export default function AskView({ onSelect, headerFilters }) {
+  const [query, setQuery] = useState(headerFilters?.query || "");
+  // Honor a question pushed in from the header search box — typing
+  // "what's new" up there and switching to ASK should land on the answer.
+  useEffect(() => {
+    if ((headerFilters?.query ?? "") !== query) setQuery(headerFilters?.query || "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerFilters?.query]);
+
+  // The engine is pure + synchronous; recompute on every keystroke is fine.
+  const answer = useMemo(() => ask(query), [query]);
+
+  return (
+    <div className="px-3 sm:px-8 py-6">
+      <div className="flex items-baseline justify-between mb-4 flex-wrap gap-2">
+        <h2 className="font-mono text-emerald-300 text-lg sm:text-2xl tracking-[0.2em]">
+          <GlitchText>┃ ASK</GlitchText>
+        </h2>
+        <div className="font-mono text-[10px] text-emerald-700 tracking-widest">
+          NATURAL-LANGUAGE QUERY · DATASET-LEVEL · LOCAL
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <input
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          autoFocus
+          placeholder="› ask the dataset — e.g. what's different about the NASA documents"
+          className="w-full bg-black/60 border border-emerald-700/50 rounded-sm px-3 py-2 text-emerald-200 placeholder-emerald-700 font-mono text-sm focus:outline-none focus:border-amber-400 focus:shadow-[0_0_8px_rgba(255,217,61,0.4)]"
+        />
+      </div>
+
+      {!query && (
+        <div className="mb-4">
+          <div className="font-mono text-[9px] text-emerald-700 tracking-widest mb-2">▌ TRY</div>
+          <div className="flex flex-wrap gap-1.5">
+            {ASK_EXAMPLES.map(q => (
+              <button
+                key={q} onClick={() => setQuery(q)}
+                className="px-2 py-0.5 rounded-sm font-mono text-[11px] bg-emerald-950/60 text-emerald-300 hover:bg-emerald-900/80 border border-emerald-700/40">
+                {q}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Headline + parsed-intent badge */}
+      <div className="border border-emerald-700/40 bg-black/40 rounded-sm p-3 sm:p-4 mb-4">
+        <div className="flex items-baseline gap-2 flex-wrap mb-2">
+          <span className="font-mono text-[9px] tracking-widest text-amber-400">▌ ANSWER</span>
+          {answer.intent && answer.intent !== "empty" && (
+            <span className="font-mono text-[9px] tracking-widest text-emerald-700">
+              · INTENT: {answer.intent.toUpperCase()}
+            </span>
+          )}
+          {answer.query?.agency && (
+            <span className="font-mono text-[9px] tracking-widest" style={{ color: AGENCY_COLORS[answer.query.agency] || "#7CFFB2" }}>
+              · {answer.query.agency.replace("Department of ", "DEPT/")}
+            </span>
+          )}
+          {answer.query?.release && (
+            <span className="font-mono text-[9px] tracking-widest text-emerald-500">· {answer.query.release.toUpperCase()}</span>
+          )}
+          {answer.query?.era && (
+            <span className="font-mono text-[9px] tracking-widest text-emerald-500">· {answer.query.era}</span>
+          )}
+        </div>
+        <div className="font-mono text-emerald-100 text-[14px] leading-snug">
+          {answer.headline}
+        </div>
+        {answer.notes && answer.notes.length > 0 && (
+          <ul className="mt-3 space-y-1.5">
+            {answer.notes.map((n, i) => (
+              <li key={i} className="font-mono text-[12px] text-emerald-300/90 leading-relaxed pl-3 border-l border-emerald-700/30">
+                {n}
+              </li>
+            ))}
+          </ul>
+        )}
+        {answer.stats && answer.stats.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-3">
+            {answer.stats.map((s, i) => (
+              <div key={i} className="border border-emerald-700/40 bg-emerald-950/30 rounded-sm px-2.5 py-1.5">
+                <div className="font-mono text-[9px] tracking-widest text-emerald-600">{s.label}</div>
+                <div className="font-mono text-emerald-200 text-base">{s.value}</div>
+              </div>
+            ))}
+          </div>
+        )}
+        {answer.hint && (
+          <div className="mt-3 font-mono text-[10px] text-emerald-700 tracking-wider">
+            ▌ {answer.hint}
+          </div>
+        )}
+      </div>
+
+      {/* Groups (e.g. "by agency") or flat event list */}
+      {answer.groups && answer.groups.length > 0 && (
+        <div className="space-y-4">
+          {answer.groups.map((g, i) => (
+            <Group key={i} group={g} onSelect={onSelect} />
+          ))}
+        </div>
+      )}
+      {answer.events && answer.events.length > 0 && (
+        <div className="space-y-2">
+          {answer.events.map(e => <EventRow key={e.id} event={e} onSelect={onSelect} />)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Group({ group, onSelect }) {
+  const color = AGENCY_COLORS[group.agency] || "#7CFFB2";
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1.5">
+        <span className="h-px flex-1 bg-emerald-900/50" />
+        <span className="font-mono text-[10px] tracking-widest" style={{ color }}>
+          {group.label.replace("Department of ", "DEPT/")}
+        </span>
+        <span className="h-px flex-1 bg-emerald-900/50" />
+      </div>
+      <div className="space-y-2">
+        {group.events.map(e => <EventRow key={e.id} event={e} onSelect={onSelect} />)}
+      </div>
+    </div>
+  );
+}
+
+function EventRow({ event, onSelect }) {
+  const color = AGENCY_COLORS[event.agency] || "#7CFFB2";
+  return (
+    <button
+      onClick={() => onSelect(event)}
+      className={`text-left w-full rounded-sm border-l-2 ${flagBg(event.flag)} border p-2.5 hover:bg-emerald-950/40`}
+      style={{ borderLeftColor: color }}>
+      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-mono text-[10px] tracking-wider shrink-0" style={{ color }}>
+            {event.agency.replace("Department of ", "DEPT/")}
+          </span>
+          <DocTypeBadge docType={event.docType} />
+          {event.flag === "anchor" && <span className="text-amber-400 text-[10px] shrink-0">▲</span>}
+          {event.redacted && <span className="font-mono text-[9px] tracking-widest text-rose-400 shrink-0">REDACTED</span>}
+          {event.videoId && <span className="font-mono text-[9px] tracking-widest text-blue-300 shrink-0">VIDEO</span>}
+          {event.release === "Release 02" && <span className="font-mono text-[9px] tracking-widest text-amber-300 shrink-0">R02</span>}
+        </div>
+        <span className="font-mono text-[10px] text-amber-300 shrink-0">{event.date || "—"}</span>
+      </div>
+      <div className="font-mono text-emerald-100 text-[13px] mt-1 leading-snug">{event.title}</div>
+      {event.summary && (
+        <div className="font-mono text-[11px] text-emerald-400/80 mt-1 leading-snug line-clamp-2">
+          {event.summary}
+        </div>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an **ASK** tab — a natural-language query interface over the catalogue. Users can ask the dataset questions like "what changed", "what was classified beforehand", "what's unredacted", "what's different about the NASA documents" without learning the SEARCH/SEMANTIC distinction or the agency/release/era dropdowns.

Engine (`src/lib/askEngine.js`) is a small pattern-matching NLP — **not** an LLM. It classifies questions into a fixed set of intents (changes, classified-before, unclassified, different, count, filter, keyword fallback), extracts entities (agency aliases NASA / FBI / DOW / CIA / DOE / ODNI / State, release tag, era, year, media kind), and runs the matching query against `EVENTS`. Returns a structured answer with a headline, narrative notes, stat tiles, and either grouped or flat event rows.

**Why not a model?** The questions are about the *shape* of the dataset (diffs between releases, redaction status, agency distinctives) — not document contents, which SEMANTIC already covers. A second 25 MB transformer would double cold-load cost for a feature that's fundamentally `EVENTS.filter(...)`.

### What each question type answers

| Question | Intent | Output |
|---|---|---|
| *what changed in Release 02* | `changes` | Diff r02 vs r01 by agency · flags new agencies (CIA, DOE, ODNI) · redaction / video counts |
| *what was classified beforehand* | `classified-before` | 35/59 records (59%) still carry redactions — these are the previously-classified ones |
| *what is unredacted* | `unclassified` | 24/59 records (41%) released fully clean |
| *what's different about NASA* | `different` | 83% PRIORITY-flagged vs 26% of rest · 5/6 set in space · COMETA outlier called out |
| *how many videos* | `count` | Count + grouping by agency |
| *FBI records from the 50s* / *Syria 2024* | `filter` | Agency / era / year / media / topic filter |
| anything else | `keyword` fallback | Title / summary / tags / location match |

Auto-imported FBI section stubs (`events-auto.js`, `auto: true`) are excluded from quantitative answers — they're the unprocessed long tail, not curated records.

## Files

- `src/lib/askEngine.js` (new) — intent dispatcher + entity extractor, pure functions
- `src/views/AskView.jsx` (new) — terminal-styled UI, reuses `DocTypeBadge` / `flagBg`
- `src/components/Header.jsx` — adds the **ASK** tab between SEMANTIC and REVIEW
- `src/App.jsx` — mounts `AskView`, passes through `headerFilters` and `onSelect`

## Test plan

- [x] Engine smoke-test: 9 sample questions classify to correct intents (Node script against `askEngine.js`)
- [x] `npx vite build` clean
- [x] Lint: only inherited project-wide patterns remain (React-unused-import, setState-in-effect — same as SearchView)
- [x] Playwright screenshots verify ASK tab renders for all three example questions ("NASA differences", "Release 02 changes", "classified beforehand")
- [ ] Click-through: rows open the correct DOSSIER record (manual)
- [ ] Pre-seed from header search box works (manual)

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmp9EEH4mmgrCttcegUdog)_