### PR TITLE
chore(ask): hide ASK tab from nav until hosted RAG backend ships

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,7 +14,13 @@ const PRIMARY = [
   { id: "live",     label: "LIVE",     glyph: "●" },
   { id: "search",   label: "SEARCH",   glyph: "⌕" },
   { id: "semantic", label: "SEMANTIC", glyph: "∿" },
-  { id: "ask",      label: "ASK",      glyph: "?" },
+  // ASK is temporarily pulled from the nav while the hosted RAG backend
+  // is being deployed (PR #56 — pursue-rag-server on Railway). The view
+  // code still lives at src/views/AskView.jsx and the route case in
+  // App.jsx still handles `view === "ask"`, so flipping the tab back
+  // on is a one-line uncomment once the Railway URL is set in
+  // src/lib/askSettings.js → DEFAULT_HOSTED_URL.
+  // { id: "ask",      label: "ASK",      glyph: "?" },
   { id: "review",   label: "REVIEW",   glyph: "⚖" },
   { id: "media",    label: "MEDIA",    glyph: "▦" },
   { id: "dossier",  label: "DOSSIER",  glyph: "❒" },


### PR DESCRIPTION
## Summary

Pulls the ASK tab from the nav while the hosted RAG backend is being deployed.

ASK lands in two pieces:
- **PR #55 (merged)**: PATTERN mode — local intent classifier. Already on main.
- **PR #56 (open)**: SMART mode — full RAG via FAISS + LLM. Needs either `pursue-vision-mcp` running locally or `pursue-rag-server` deployed to Railway. Neither is wired up for the deployed site yet (Railway proxy is being built this week).

Until the hosted backend is up, the deployed ASK tab only shows PATTERN mode, which competes for shelf space with SEARCH and SEMANTIC without delivering the "ask anything" experience.

## What this does

One-line change: comment out the ASK entry in `Header.jsx`'s `PRIMARY` array. The view + engine code stays in the tree (`src/views/AskView.jsx`, `src/lib/askEngine.js`) and `App.jsx` still handles `view === "ask"`, so re-enabling is a one-line uncomment once `src/lib/askSettings.js` → `DEFAULT_HOSTED_URL` points at the live Railway service.

## Files

- `src/components/Header.jsx` — comment out the ASK entry with a note pointing at PR #56 + the re-enable steps.

## Test plan

- [x] `vite build` clean
- [ ] After merge + deploy, verify ASK no longer appears between SEMANTIC and REVIEW in the deployed nav

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmp9EEH4mmgrCttcegUdog)_