### PR TITLE
fix(release-02): surface Release 02 in chrome + dynamic labels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, Suspense, lazy } from "react";
-import { EVENTS } from "./data/events.js";
+import { EVENTS, RELEASES_LABEL } from "./data/events.js";
 
 // Global handle for cross-view event lookups (MediaView, ReviewView use
 // this when their deep-link buttons only have eid + title, but the
@@ -199,7 +199,7 @@ export default function App() {
         {showFooter ? (
           <footer className="border-t border-emerald-700/30 mt-10 px-3 sm:px-8 py-6">
             <div className="font-mono text-[9px] text-emerald-700 tracking-widest space-y-1">
-              <div>▌ SOURCE: WAR.GOV/UFO RELEASE 01 // CLEARED MAY 8, 2026</div>
+              <div>▌ SOURCE: WAR.GOV/UFO {RELEASES_LABEL.toUpperCase()} // CLEARED MAY 8 + MAY 22, 2026</div>
               <div>▌ ALL CASES UNRESOLVED — GOVERNMENT UNABLE TO MAKE DEFINITIVE DETERMINATION</div>
               <div>▌ INTERAGENCY: WHITE HOUSE / ODNI / DOE / AARO / NASA / FBI / DOW</div>
             </div>
@@ -207,7 +207,7 @@ export default function App() {
         ) : (
           <footer className="border-t border-emerald-900/30 mt-6 px-3 sm:px-8 py-3 text-center">
             <span className="font-mono text-[9px] text-emerald-800 tracking-widest">
-              ▌ war.gov/UFO · release 02 incoming · release 01 catalogued
+              ▌ war.gov/UFO · {RELEASES_LABEL.toLowerCase()} catalogued
             </span>
           </footer>
         )}

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -137,3 +137,15 @@ export const AGENCY_COLORS = {
 };
 
 export const FLAG_LABEL = { anchor: "PRIORITY", high: "ELEVATED", med: "ROUTINE", low: "TRIVIAL" };
+
+// Derived release metadata — used by the LIVE / SEARCH / SEMANTIC headers
+// and the App footer so "what releases are catalogued?" doesn't have to be
+// hand-updated every time a tranche lands. Just add release-tagged entries
+// to RAW (or RELEASE_FOR above) and these update.
+export const RELEASES = [...new Set(EVENTS.map(e => e.release))].sort();
+export const LATEST_RELEASE = RELEASES[RELEASES.length - 1] || "Release 01";
+// "RELEASE 01–02" style label, en-dash between bookends. Single release →
+// just that release's name. Used in chrome / banner copy.
+export const RELEASES_LABEL = RELEASES.length > 1
+  ? `${RELEASES[0]}–${RELEASES[RELEASES.length - 1].replace(/^Release\s+/, "")}`
+  : RELEASES[0];

--- a/src/views/LiveFeedView.jsx
+++ b/src/views/LiveFeedView.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
-import { EVENTS, AGENCY_COLORS } from "../data/events.js";
+import { EVENTS, AGENCY_COLORS, RELEASES_LABEL } from "../data/events.js";
 import useCorpusStats from "../hooks/useCorpusStats.js";
 
 // LIVE WATCH — immersive Phosphor Vigil dashboard.
@@ -421,7 +421,7 @@ export default function LiveFeedView({ onSelect, headerFilters }) {
             </h1>
           </div>
           <div className="font-mono text-[11px] text-emerald-500 tracking-[0.2em]">
-            <UtcClock /> <span className="text-emerald-800 mx-2">·</span> WAR.GOV / UFO / RELEASE 01
+            <UtcClock /> <span className="text-emerald-800 mx-2">·</span> WAR.GOV / UFO / {RELEASES_LABEL.toUpperCase()}
           </div>
         </div>
         <div className="font-mono text-[11px] text-emerald-700 max-w-2xl leading-relaxed mb-6">
@@ -469,7 +469,7 @@ export default function LiveFeedView({ onSelect, headerFilters }) {
               <div className="flex items-baseline justify-between flex-wrap gap-3 mb-3">
                 <div className="font-mono text-[10px] tracking-[0.3em] text-emerald-300">
                   ▌ D O C U M E N T &nbsp; P R O G R E S S
-                  <span className="ml-3 text-emerald-700 text-[9px] tracking-widest">RELEASE 01 · {dp.totalInventory} INVENTORY</span>
+                  <span className="ml-3 text-emerald-700 text-[9px] tracking-widest">{RELEASES_LABEL.toUpperCase()} · {dp.totalInventory} INVENTORY</span>
                 </div>
                 <div className="flex items-center gap-4 font-mono text-[10px] tracking-widest text-emerald-700">
                   {/* ACTIVE indicator — pulses when something is being worked on */}

--- a/src/views/SemanticSearchView.jsx
+++ b/src/views/SemanticSearchView.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { pipeline, env } from "@huggingface/transformers";
-import { EVENTS, AGENCY_COLORS } from "../data/events.js";
+import { EVENTS, AGENCY_COLORS, RELEASES_LABEL } from "../data/events.js";
 import { GlitchText, DocTypeBadge, flagBg } from "../components/Primitives.jsx";
 import { ingestFile, listDocs, deleteDoc, clearAll, loadAllChunks } from "../lib/dropCorpus.js";
 import { highlightQuery } from "../lib/highlightQuery.jsx";
@@ -455,7 +455,7 @@ export default function SemanticSearchView({ onSelect, headerFilters }) {
         {/* REPO SCOPE */}
         <div className="border border-emerald-700/40 bg-black/40 rounded-sm p-3 font-mono text-[11px]">
           <div className="flex items-center justify-between flex-wrap gap-3 mb-2">
-            <div className="text-emerald-700 tracking-widest text-[9px]">▌ REPOSITORY SCOPE — RELEASE 01</div>
+            <div className="text-emerald-700 tracking-widest text-[9px]">▌ REPOSITORY SCOPE — {RELEASES_LABEL.toUpperCase()}</div>
             {coverage.droppedDocs > 0 && (
               <button onClick={onClearAllDropped} className="text-[9px] text-rose-400 hover:text-rose-200 tracking-widest">CLEAR DROPPED ({coverage.droppedDocs})</button>
             )}


### PR DESCRIPTION
## Summary

LIVE front page still said "RELEASE 01" everywhere even though 7 Release 02 records have been in the catalogue since #51. The filter dropdown is actually fine — Playwright confirms its options are `["ALL RELEASES", "RELEASE 01", "RELEASE 02"]` — but the surrounding labels all said RELEASE 01, so the existence of the filter (and the second release) wasn't apparent.

Fix: add derived release metadata to `events.js` and use it everywhere the label is rendered.

## What changed

`src/data/events.js` — new exports:
- `RELEASES` — distinct release tags from EVENTS, sorted
- `LATEST_RELEASE` — most recent (currently "Release 02")
- `RELEASES_LABEL` — `"Release 01–02"` style label. Single release → that release's name. Auto-updates when events.js gains a Release 03 entry.

Consumers:
- `src/views/LiveFeedView.jsx` — LIVE header + document-progress block
- `src/App.jsx` — both footers (LIVE/help long footer + thin non-LIVE footer)
- `src/views/SemanticSearchView.jsx` — repository-scope label

## Test plan

- [x] `vite build` clean
- [x] Playwright screenshot of LIVE shows `WAR.GOV / UFO / RELEASE 01–02`
- [x] Playwright confirms the filter dropdown options are `["ALL RELEASES", "RELEASE 01", "RELEASE 02"]` (was already working, just visually hidden)

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kmp9EEH4mmgrCttcegUdog)_