### PR TITLE
chore(media): hourly media-library loop + skip no-op writes

### DIFF
--- a/docs/war-gov-scrape-state.json
+++ b/docs/war-gov-scrape-state.json
@@ -1,0 +1,46 @@
+{
+  "_kind": "war-gov-scrape-state",
+  "_note": "Partial scrape of https://www.war.gov/UFO/ via whipgen MCP web tools. The page renders only 10 records per pagination step in the DOM; the underlying CSV is Akamai-gated against direct navigation. Full ingest requires either a whipgen JS-eval tool (see docs/whipgen-web-eval-request.md) or an out-of-band CSV drop by the operator.",
+  "scrapedAt": "2026-05-25T22:00:00.000Z",
+  "scrapedVia": "whipgen-mcp web_open + web_extract",
+  "totalRecordsOnPage": 222,
+  "filterCategories": {
+    "agencies": ["Central Intelligence Agency", "Department of Energy", "Department of State", "Department of War", "FBI", "NASA", "Office of the Director of National Intelligence"],
+    "releases": ["Release 01", "Release 02"],
+    "fileTypes": [".aud", ".img", ".pdf", ".vid"]
+  },
+  "bulkDownloads": {
+    "release01Videos": { "url": "https://d34w7g4gy10iej.cloudfront.net/uapvideos.zip", "sizeGB": 1.3 },
+    "release02Videos": { "url": "https://d34w7g4gy10iej.cloudfront.net/uap052226.zip", "sizeGB": 5.6 }
+  },
+  "dataSource": {
+    "csvUrl": "https://www.war.gov/Portals/1/Interactive/2026/UFO/uap-data.csv",
+    "loadedBy": "in-page JS fetch on /UFO/",
+    "directNavigationStatus": "net::ERR_ABORTED (Akamai rejects non-XHR access)"
+  },
+  "recordsFromPage1": [
+    { "id": "DOW-UAP-PR050", "title": "4 UAP Formation Iran 26 Aug 2022 over water [CALLSIGN]", "agency": "Department of War", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": "2022", "location": "CENTCOM", "type": ".vid" },
+    { "id": "DOW-UAP-PR051", "title": "Syrian UAP instant acceleration", "agency": "Department of War", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": "2021", "location": "CENTCOM", "type": ".vid" },
+    { "id": "DOW-UAP-D017", "title": "UAP Reported at Sandia Base, 1948-1950", "agency": "Department of War", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": "1948-1950", "location": "New Mexico", "type": ".pdf" },
+    { "id": "CIA-UAP-D001", "title": "Intelligence Information Report, USSR, 1973", "agency": "Central Intelligence Agency", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": "1973-12-20", "location": "USSR", "type": ".pdf" },
+    { "id": "ODNI-UAP-D001", "title": "USPER Narrative, Senior USIC Official", "agency": "Office of the Director of National Intelligence", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": "2025", "location": "Western United States", "type": ".pdf" },
+    { "id": "NASA-UAP-D008", "title": "Apollo 12 Medical Debriefing - Tape 12, 1969", "agency": "NASA", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": "1969", "location": "Texas", "type": ".aud" },
+    { "id": "DOE-UAP-D001", "title": "Enhanced PANTEX Imagery", "agency": "Department of Energy", "release": "Release 02", "releaseDate": "2026-05-22", "incidentDate": null, "location": "N/A", "type": ".pdf" },
+    { "id": "DOW-R01-001", "title": "18_100754_ General 1946-7_Vol_2", "agency": "Department of War", "release": "Release 01", "releaseDate": "2026-05-08", "incidentDate": "1947-12-30", "location": "N/A", "type": ".pdf" },
+    { "id": "DOW-R01-002", "title": "18_6369445_General_1948_Vol_1", "agency": "Department of War", "release": "Release 01", "releaseDate": "2026-05-08", "incidentDate": "1948-06-15", "location": "N/A", "type": ".pdf" },
+    { "id": "NASA-R01-001", "title": "255_413270_UFO's_and_Defense_What_Should_we_Prepare_For", "agency": "NASA", "release": "Release 01", "releaseDate": "2026-05-08", "incidentDate": null, "location": "N/A", "type": ".pdf" }
+  ],
+  "additionalIdsFromSlideshow": [
+    { "id": "DOW-UAP-PR052", "thumb": "https://www.war.gov/portals/1/Interactive/2026/UFO/Slideshow-2/DOW-UAP-PR052.jpg", "type": ".vid" },
+    { "id": "DOW-UAP-PR071", "thumb": "https://www.war.gov/portals/1/Interactive/2026/UFO/Slideshow-2/DOW-UAP-PR071_USAF-ANG%20F-16C_callsign_CALLSIGN_Shoots_Down_UAP.jpg", "type": ".vid", "title": "USAF-ANG F-16C [CALLSIGN] Shoots Down UAP" },
+    { "id": "DOW-UAP-PR086", "thumb": "https://www.war.gov/portals/1/Interactive/2026/UFO/Slideshow-2/DOW-UAP-PR086-UAP_from_Dec_2019_East_Coast.jpg", "type": ".vid", "title": "UAP from Dec 2019 East Coast" }
+  ],
+  "knownRange": {
+    "videoIds": "DOW-UAP-PR050 through at least DOW-UAP-PR086 (37+ videos in Release 02, contiguous range likely)",
+    "documentIds": "varies by agency (D017 for DOW, D001 for CIA/ODNI/DOE, D008 for NASA, etc.)"
+  },
+  "missingFromRepo": {
+    "totalGap": "222 records on war.gov vs 16 video tiles + 6 PDFs currently catalogued",
+    "criticalGap": "~35-40 Release 02 videos (PR050-PR086 range) with no events.js entry"
+  }
+}

--- a/docs/whipgen-web-eval-request.md
+++ b/docs/whipgen-web-eval-request.md
@@ -1,0 +1,114 @@
+# Feature request — `whipgen_web_eval`
+
+**Target:** [whipgen-mcp](https://github.com/your-org/whipgen-mcp) (paste this into a new issue there)
+
+**Filed by:** pursue-console / war.gov UFO ingest pipeline · 2026-05-25
+
+---
+
+## Summary
+
+Add a `whipgen_web_eval` tool that runs an arbitrary JavaScript expression inside the currently loaded page's context (Playwright `page.evaluate`) and returns the serialised result. This unlocks scraping for any site that hides its real data behind in-page XHRs or JS-state pagination — which is most modern .gov / SPA sites.
+
+## Concrete blocker that prompted this
+
+`pursue-console`'s media-library ingest needs the file index from `https://www.war.gov/UFO/` (the Presidential Unsealing and Reporting System / PURSUE archive). The page renders **222 records** across two releases, but:
+
+| Approach | Result |
+| --- | --- |
+| `whipgen_web_open(https://www.war.gov/UFO/)` | Renders the page; only the first **10** records land in the DOM (`<button class="record-row">`). Pagination is pure JS state (Vue) — clicking "next" mutates an in-memory array, never the URL. |
+| `whipgen_web_open(.../UFO/?page=2)` | Ignored — site has no URL-based paging. |
+| `whipgen_web_open(.../UFO/uap-data.csv)` (the data source the page itself reads) | `net::ERR_ABORTED` — Akamai rejects direct navigation; the CSV only responds to same-origin in-page `fetch()`. |
+| Search-engine scrape (Google, DuckDuckGo) for the record IDs | Zero hits — page is new (May 22, 2026) and crawlers haven't indexed individual records. |
+| `whipgen_web_extract` with every plausible selector | Caps at 10 visible rows. No `[v-for]`, no `data-*` attribute, no inline JSON contains the full list. |
+
+There is no path from the existing toolset to the other 212 records without page-context JS execution.
+
+## Proposed API
+
+```jsonc
+// whipgen_web_eval
+{
+  "expression": "await fetch('/Portals/1/Interactive/2026/UFO/uap-data.csv').then(r => r.text())",
+  "url": "https://www.war.gov/UFO/",      // optional — like web_extract, navigates first if set
+  "returnType": "text",                    // 'text' | 'json' | 'base64'  (default: auto)
+  "awaitPromise": true,                    // default true — `expression` may be async
+  "timeoutMs": 30000,                      // default 30000
+  "saveTo": "/abs/path/inside/allowed"     // optional — write result to disk instead of returning inline
+}
+```
+
+**Returns:**
+```jsonc
+{
+  "value": "Agency,Title,Release,...\nDOW-UAP-PR050,...,\n...",   // present unless saveTo set
+  "valueSize": 87642,
+  "savedTo": "/abs/path/...",                                      // present if saveTo set
+  "durationMs": 1430,
+  "jobId": "..."
+}
+```
+
+## Reference implementation sketch
+
+Roughly 30 lines on the daemon side; reuses the existing browser pool:
+
+```ts
+// pseudocode — slot into the same router as web_open / web_extract
+async function webEval({ expression, url, returnType, awaitPromise, timeoutMs, saveTo, sessionId }) {
+  const page = await pool.checkout(sessionId);
+  try {
+    if (url) await page.goto(url, { waitUntil: 'load', timeout: timeoutMs });
+    const wrapped = awaitPromise
+      ? `(async () => { return (${expression}); })()`
+      : `(() => { return (${expression}); })()`;
+    const value = await page.evaluate(`(${timeoutMs} && Promise.race([${wrapped}, new Promise((_,r) => setTimeout(() => r(new Error('eval-timeout')), ${timeoutMs}))]))`);
+    const serialized = serialize(value, returnType);  // string|JSON|base64
+    if (saveTo) {
+      assertWriteRootOk(saveTo);                       // existing helper
+      await fs.writeFile(saveTo, serialized);
+      return { savedTo: saveTo, valueSize: serialized.length };
+    }
+    return { value: serialized, valueSize: serialized.length };
+  } finally {
+    pool.checkin(sessionId, page);
+  }
+}
+```
+
+## Security / abuse considerations
+
+- The expression runs **inside the loaded site's origin**, so anything it can read is already accessible to the operator with devtools open. No new auth boundary is crossed.
+- Same `mutates-session` side-effect class as `web_open` — opt-in by callers.
+- Log every invocation to the existing `~/.whipgen-history.ndjson` (the operator can audit retroactively).
+- Cap `expression` length (e.g. 64 KB) and result size (e.g. 8 MB) to prevent runaway returns.
+- Capture page errors via `page.on('pageerror')` during the eval window and bubble them up so the caller can distinguish "syntax error in expression" from "expression triggered a site-side failure".
+
+## Alternatives considered
+
+| Alternative | Why it's strictly weaker |
+| --- | --- |
+| `whipgen_web_click({selector})` + `whipgen_web_fill({selector, value})` | Solves pagination, but not the same-origin-fetch case (`uap-data.csv` and similar Akamai-gated endpoints). |
+| Headless `curl` via daemon | Loses the WAF-bypass that the logged-in Chrome provides — Akamai is the whole reason to use the browser. |
+| Make the caller poll `__doPostBack` form posts | Requires reconstructing ASP.NET viewstate each request — fragile and site-specific. |
+
+`web_eval` subsumes both `web_click` and `web_fill` (they're 2-line eval expressions) and handles the Akamai-protected XHR case for free.
+
+## Use cases this unblocks (beyond war.gov)
+
+- Any DataTables / DataTable-AJAX site (most US gov agency directories).
+- Vue / React / Angular SPAs whose data is in component state.
+- Sites whose `/api/...` endpoints require same-origin fetches due to WAF / CSP / SameSite cookies.
+- Programmatic search/filter against any UI-only search box.
+
+---
+
+## Workaround until this lands
+
+For the war.gov ingest specifically, the operator can do this in their existing logged-in browser:
+
+1. Open `https://www.war.gov/UFO/` in Chrome.
+2. DevTools → Network tab → filter `uap-data.csv` → right-click → Save as → `data-raw/war-gov-uap-data.csv`.
+3. Commit the CSV; the repo's parser can ingest it directly into `events.js` entries.
+
+This is a one-time manual step per release, but it's the only path that works today.

--- a/scripts/build-media-index.mjs
+++ b/scripts/build-media-index.mjs
@@ -291,12 +291,26 @@ const byKind = items.reduce((acc, it) => { acc[it.kind] = (acc[it.kind] || 0) + 
 const byEvent = items.reduce((acc, it) => { acc[it.eventId] = (acc[it.eventId] || 0) + 1; return acc; }, {});
 const byAgency = items.reduce((acc, it) => { acc[it.agency || "—"] = (acc[it.agency || "—"] || 0) + 1; return acc; }, {});
 
-await writeFile(OUT, JSON.stringify({
+const nextBody = {
   generatedAt: new Date().toISOString(),
   total: items.length,
   byKind, byAgency, eventCount: Object.keys(byEvent).length,
   items,
-}, null, 2) + "\n", "utf8");
+};
+
+// Skip rewriting media.json if only generatedAt would change. The
+// hourly loop re-runs this every pass; without this guard, every pass
+// produces a no-op diff that pollutes git history.
+let skipWrite = false;
+try {
+  const prev = JSON.parse(await readFile(OUT, "utf8"));
+  const { generatedAt: _a, ...prevRest } = prev;
+  const { generatedAt: _b, ...nextRest } = nextBody;
+  skipWrite = JSON.stringify(prevRest) === JSON.stringify(nextRest);
+} catch {}
+if (!skipWrite) {
+  await writeFile(OUT, JSON.stringify(nextBody, null, 2) + "\n", "utf8");
+}
 
 const missingRenderCount = items.filter(it => it.missingRender).length;
 console.log(`[media-index] ${items.length} media items across ${Object.keys(byEvent).length} events`);

--- a/scripts/extract-media-from-gemini.mjs
+++ b/scripts/extract-media-from-gemini.mjs
@@ -161,9 +161,24 @@ for (const eid of await listDirs(VIS)) {
       classifier: "gemini-text-extract",
       classifiedAt: new Date().toISOString(),
     };
-    await mkdir(path.dirname(sidecarPath), { recursive: true });
-    await writeFile(sidecarPath, JSON.stringify(sidecar, null, 2) + "\n", "utf8");
-    stats.written++;
+
+    // Skip the write if only classifiedAt would change — re-stamping a
+    // timestamp on every run produces noisy diffs and pointless commits
+    // when the hourly loop re-ingests with no real change.
+    let unchanged = false;
+    if (existsSync(sidecarPath)) {
+      try {
+        const prev = JSON.parse(await readFile(sidecarPath, "utf8"));
+        const { classifiedAt: _a, ...prevRest } = prev;
+        const { classifiedAt: _b, ...nextRest } = sidecar;
+        unchanged = JSON.stringify(prevRest) === JSON.stringify(nextRest);
+      } catch {}
+    }
+    if (!unchanged) {
+      await mkdir(path.dirname(sidecarPath), { recursive: true });
+      await writeFile(sidecarPath, JSON.stringify(sidecar, null, 2) + "\n", "utf8");
+      stats.written++;
+    }
     stats.by_kind[primary.kind] = (stats.by_kind[primary.kind] || 0) + 1;
 
     // If we have a local PDF, render the page so MEDIA has an image


### PR DESCRIPTION
## Summary

Working branch for an hourly media-library maintenance loop. First commit makes the ingest pipeline idempotent across repeat runs so the loop produces clean diffs (only real content changes, not timestamp churn).

- `scripts/extract-media-from-gemini.mjs` — skip sidecar write when only `classifiedAt` would change.
- `scripts/build-media-index.mjs` — skip `public/media.json` write when only `generatedAt` would change.

Without these guards, every loop pass rewrites 150+ sidecars and `media.json` even when no real ingest happened.

## What the loop does (each pass, hourly)

1. `git pull --ff-only` on the working branch.
2. Run extract → backfill → build-media-index (cheap, all local).
3. Use whipgen MCP web tools to peek at the war.gov UFO release index for any file links not already in `src/data/events.js`; report findings only — no auto-edits to events.js.
4. Commit + push only if there are real changes (script guards above ensure this is meaningful).

## Test plan

- [x] Re-run extract twice; second run reports `0 sidecars written`.
- [x] Re-run build-media-index twice; second run leaves `public/media.json` mtime unchanged.
- [ ] Loop pass with no upstream change produces no commit.
- [ ] Loop pass with a new Gemini transcript surfaces it in `media.json`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_