### PR TITLE
fix(import): drop MIN_CHARS 40 → 1 so short OCR isn't silently lost

### DIFF
--- a/scripts/import-contributions.mjs
+++ b/scripts/import-contributions.mjs
@@ -21,7 +21,16 @@ const CONTRIB = path.join(ROOT, "contributions");
 const VIS_CACHE = path.join(ROOT, "data-raw", ".vision-cache");
 const MANIFEST = path.join(ROOT, "data-raw", ".contributions-manifest.json");
 
-const MIN_CHARS = 40;  // anything shorter we treat as effectively empty
+// Minimum non-whitespace chars to count a contribution as a real OCR result.
+// Was 40 — but that silently dropped legitimate short pages ("BOTTOM VIEW",
+// "(blank)", page numbers, classification stamps, "1.4(a)") so they never
+// reached .vision-cache, and build-work-available.mjs kept asking volunteers
+// to re-OCR them. Every "stuck" page in the dashboard's OCR queue turned out
+// to be a real contribution shorter than 40 chars. Matches the convention in
+// monitor.mjs isStub(): 0-byte/whitespace-only = empty, anything else = real.
+// The canonical-merge guard ("longer wins, human always wins") still prevents
+// a 1-byte garbage commit from clobbering a real canonical further down.
+const MIN_CHARS = 1;
 
 async function exists(p) { try { await stat(p); return true; } catch { return false; } }
 


### PR DESCRIPTION
## Summary
- One-line constant change in `scripts/import-contributions.mjs`: `MIN_CHARS: 40 → 1`.
- Comment explains the failure mode so the threshold doesn't get bumped back.

## Why
`import-contributions.mjs` was silently skipping any contribution under 40 chars as "empty". But many legitimate OCR results are short — they live in `contributions/<handle>/gpt-vision/` on `main` but never reached `data-raw/.vision-cache/`, so `build-work-available.mjs` kept asking volunteers to re-OCR them. The dashboard's fresh-work filter then correctly saw them in `published` and disabled the OCR button with *"queue empty for you — all listed pages already submitted/merged."*

10 pages were stuck in this loop right now. Every single one is a real, committed OCR result:

| Page | Bytes | Contents |
|---|---|---|
| fbi-62hq83894 p0091 | 11 | `BOTTOM VIEW` |
| africa-2025 p0001 / p0006 | 6 | `1.4(a)` |
| §62hq-section-10 p0048 | 7 | `(blank)` |
| §62hq-section-10 p0120 | 12 | `62-83894-466` |
| §62hq-section-3 p0126 | 7 | `(blank)` |
| §62hq-section-4 p0055 | 19 | `EMPTY 11/29/64 #(?)` |
| §62hq-section-4 p0093 | 7 | `(blank)` |
| §62hq-section-9 p0018 | 30 | `called 3:15 9/27  (?) file (?)` |
| §62hq-section-9 p0270 | 7 | `(blank)` |

## Safety
Matches the convention already in `monitor.mjs:540` (`isStub()`): 0-byte / whitespace-only counts as missing, anything else is real. The canonical-merge guard further down the script (`human always wins; otherwise longer wins`) still prevents a 1-char garbage commit from clobbering a real canonical.

## Test plan
- [ ] Merge.
- [ ] `refresh-work-queue.yml` runs automatically; import-contributions imports the 10 short pages into `.vision-cache`.
- [ ] `build-work-available.mjs` excludes them from the new queue.
- [ ] Dashboard's OCR button lights up only for genuinely-needed pages (or stays off if the queue is truly drained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)