### PR TITLE
scripts: add fetch-uap-csv.mjs for canonical war.gov CSV ingestion

### DIFF
--- a/scripts/fetch-uap-csv.mjs
+++ b/scripts/fetch-uap-csv.mjs
@@ -1,0 +1,81 @@
+// Fetch the canonical war.gov UAP CSV via an in-page fetch from a
+// real Chromium tab on the war.gov origin. Akamai's TLS fingerprinting
+// rejects every Node-side HTTP client; the only way through is to run
+// the fetch INSIDE a page already loaded on www.war.gov.
+//
+// Prereq: a Chromium instance with CDP open on 127.0.0.1:9222 (the
+// pursue-vision-mcp daemon's start.mjs sets this up, or launch any
+// Chromium with --remote-debugging-port=9222).
+//
+// Writes data-raw/uap-data.csv. Prints row count + first few IDs so
+// the caller can sanity-check.
+
+import { createRequire } from "node:module";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const require = createRequire(path.join(ROOT, "pursue-vision-mcp", "package.json"));
+const { chromium } = require("playwright");
+const CDP_URL = process.env.PURSUE_CDP_URL || "http://127.0.0.1:9222";
+const CSV_URL = process.env.UAP_CSV_URL
+  || "https://www.war.gov/Portals/1/Interactive/2026/UFO/uap-data.csv";
+const LANDING = "https://www.war.gov/UFO/";
+const OUT_PATH = path.join(ROOT, "data-raw", "uap-data.csv");
+
+console.log(`[fetch-uap-csv] cdp=${CDP_URL}`);
+console.log(`[fetch-uap-csv] csv=${CSV_URL}`);
+
+const browser = await chromium.connectOverCDP(CDP_URL);
+
+let page = null;
+for (const ctx of browser.contexts()) {
+  for (const p of ctx.pages()) {
+    if (/^https?:\/\/(www\.)?war\.gov\//i.test(p.url())) { page = p; break; }
+  }
+  if (page) break;
+}
+if (!page) {
+  const ctx = browser.contexts()[0];
+  if (!ctx) throw new Error("no Chrome context found over CDP");
+  page = await ctx.newPage();
+  console.log(`[fetch-uap-csv] opening ${LANDING}`);
+  await page.goto(LANDING, { waitUntil: "domcontentloaded", timeout: 30_000 });
+} else {
+  console.log(`[fetch-uap-csv] reusing existing war.gov tab: ${page.url()}`);
+  if (!/war\.gov\/UFO\b/i.test(page.url())) {
+    await page.goto(LANDING, { waitUntil: "domcontentloaded", timeout: 30_000 });
+  }
+}
+
+const res = await page.evaluate(async (u) => {
+  const r = await fetch(u, { credentials: "include" });
+  return {
+    ok: r.ok,
+    status: r.status,
+    contentType: r.headers.get("content-type") || "",
+    body: await r.text(),
+  };
+}, CSV_URL);
+
+if (!res.ok) {
+  console.error(`[fetch-uap-csv] HTTP ${res.status} (${res.contentType})`);
+  console.error(`[fetch-uap-csv] body preview: ${res.body.slice(0, 400)}`);
+  await browser.close().catch(() => {});
+  process.exit(1);
+}
+
+await mkdir(path.dirname(OUT_PATH), { recursive: true });
+await writeFile(OUT_PATH, res.body, "utf8");
+
+const lines = res.body.split(/\r?\n/).filter(Boolean);
+const head = lines[0] || "";
+const sampleIds = lines.slice(1, 12).map(l => l.split(",")[0]?.replace(/^"|"$/g, "") || "");
+console.log(`[fetch-uap-csv] saved ${res.body.length} bytes → ${OUT_PATH}`);
+console.log(`[fetch-uap-csv] rows: ${lines.length - 1} (excluding header)`);
+console.log(`[fetch-uap-csv] header: ${head}`);
+console.log(`[fetch-uap-csv] first IDs:\n  ${sampleIds.join("\n  ")}`);
+
+await browser.close().catch(() => {});


### PR DESCRIPTION
## Summary

- Adds `scripts/fetch-uap-csv.mjs`: standalone Playwright-CDP path that pulls the canonical `uap-data.csv` (`/Portals/1/Interactive/2026/UFO/uap-data.csv`) via an in-page `fetch` from a real Chromium tab on `www.war.gov` — the only TLS fingerprint Akamai accepts.
- Doesn't go through `/war-gov/index` so the existing driver's `INDEX_CANDIDATE_PATHS` (which doesn't list the canonical CSV) isn't a blocker.

## Context — why this isn't enough to ingest yet

The goal of this branch was the full 222-record ingestion. Both whip paths are currently blocked outside the container:

| Path | Blocker |
|---|---|
| whipgen MCP (Windows host) | Daemon (`commit 622b751`) was healthy at session start but now hangs at 60s on every call — matches the regression flagged in the handoff. Even when responsive, all stateful endpoints return `401 unauthorized — set WHIPGEN_TOKEN`; this container's MCP server lacks the bearer token. |
| in-container `pursue-vision-mcp` + this new script | Container egress proxy rejects every war.gov host with `HTTP 403 x-deny-reason: host_not_allowed` — `*.war.gov` is missing from the env's network allowlist (see `docs/war-gov-setup.md`). |

Verified end-to-end in-container: launched bundled Chromium on CDP 9222, started the local daemon, ran the script — Chromium reaches `https://www.war.gov/UFO/` but the in-page `fetch` of the CSV returns the egress proxy's allowlist-block.

The script is the missing piece for path #2: once `*.war.gov` lands in the allowlist, `node scripts/fetch-uap-csv.mjs` writes `data-raw/uap-data.csv` end-to-end.

## Test plan

- [ ] On a session with `*.war.gov` in egress allowlist: `node scripts/fetch-uap-csv.mjs` writes `data-raw/uap-data.csv` and reports ~222 rows
- [ ] Sanity-check first IDs match the 10 known-good rows from the handoff (DOW-UAP-PR050, DOW-UAP-PR051, DOW-UAP-D017, CIA-UAP-D001, ODNI-UAP-D001, NASA-UAP-D008, DOE-UAP-D001, plus three R01 ids)
- [ ] Confirm script reuses an existing war.gov tab when one is open (skips reopen)

https://claude.ai/code/session_01LpJBRk2ahmUnt6JV9PSVLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpJBRk2ahmUnt6JV9PSVLB)_