### PR TITLE
docs(readme): refresh corpus-stats table from 2026-05-26 db-rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,10 @@ When new Release tranches drop, that's where new event records come from.
 | | |
 |---|---|
 | **Records inventoried** | 162 Release 01 + 6 of 64 Release 02 files mirrored (all 6 Release 02 PDFs; 7 audio + 51 video pending). 128 events catalogued total (121 Release 01 + 7 Release 02) |
-| **Pages transcribed** | 3,394 across 65 events |
+| **Pages transcribed** | 3,475 across 71 events |
 | **First-pull backlog** | 52 catalogued docs · 754 pages awaiting download + transcription |
-| **Per source** | 3,370 Gemini · 446 GPT-vision · 0 Claude · 693 OCR transcripts (4 pages OCR-only · 689 cross-checked against vision) · 55 contributor-submitted |
-| **Multi-source pages** | 426 (cross-checked for agreement) |
+| **Per source** | 3,370 Gemini · 470 GPT-vision · 0 Claude · 774 OCR transcripts (81 pages OCR-only · 693 cross-checked against vision) · 80 contributor-submitted |
+| **Multi-source pages** | 438 (cross-checked for agreement) |
 | **Review queue** | 0 pages flagged — corpus is essentially fully vision-covered (22 reevaluated, 3 settled by standardized prompt) |
 
 </details>


### PR DESCRIPTION
## Summary

Round 3 of the rolling README upkeep loop. The corpus-stats.json was regenerated yesterday (2026-05-26) after R02 PDF ingestion (c8f158dc6) and a wave of volunteer contributions, but the README's stats table was still quoting the 2026-05-24 numbers. The table is annotated "live from `public/corpus-stats.json`" — so leaving it stale breaks that contract.

### This round

Refreshed five numbers in the **Corpus stats** collapsible:

| Field | Before | After | Why moved |
| --- | --- | --- | --- |
| Pages transcribed | 3,394 across 65 events | 3,475 across 71 events | R02 PDFs ingested |
| GPT-vision pages | 446 | 470 | Volunteer fanout runs |
| OCR transcripts | 693 (4 OCR-only · 689 cross-checked) | 774 (81 OCR-only · 693 cross-checked) | R02 PDFs are text-only → 77 new OCR-only pages |
| Contributions | 55 | 80 | Volunteer PRs #61–#71 et al. |
| Multi-source pages | 426 | 438 | Same fanout activity |

The Release 02 inventory line is unchanged — still 6 PDFs mirrored, 7 audio + 51 video pending. The review queue is still 0.

### Deferred

- CHANGELOG entry for the R02 PDF ingestion (PR #60 series). Not strictly a README job, leaving to the maintainer's release cadence.
- DVIDS view-count + sort-by-popular feature (#72 / 42cdd78b5) is a real UI addition — could merit a bullet in "What you can do here", but the rewritten README intentionally keeps that list short and tiebreaker-focused, so adding it deserves a separate conversation rather than a drive-by edit.

## Test plan

- [x] All five new numbers cross-referenced against `public/corpus-stats.json` (`generatedAt: 2026-05-26T23:41:31Z`).
- [x] `git diff` is exactly the five lines above — no structural changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y45sZnRH48KyVXqoqD4EKn)_