### PR TITLE
verdict(fbi-photos-2025/p0001): promote gemini as canonical (judge: 0.95)

### DIFF
--- a/data-raw/.vision-cache/fbi-photos-2025/p0001.sources.json
+++ b/data-raw/.vision-cache/fbi-photos-2025/p0001.sources.json
@@ -26,6 +26,14 @@
           "via": "volunteer-review"
         }
       }
+    },
+    "judge": {
+      "verdict": "gemini",
+      "text": "**Document title:** FBI Photo B1\n**Source file:** FBI Photo B1.pdf\n**Page:** 1 of 1\n**Agency:** FBI\n**Release date:** 5/8/26\n**Dataset description:** Incident date: Late 2025; Incident location: Western United States\n\n\n[redacted]\n\n[Sensor overlay with central crosshair and horizontal scale markings: 15 | 10 | 5 | 0 | 5 | 10 | 15]\n\n[redacted]\n",
+      "confidence": 0.95,
+      "reasoning": "Heavily redacted FBI photo page. Gemini correctly identified the document metadata header (title, source file, page, agency, release date, dataset description), the central [redacted] regions, and the sensor overlay's horizontal scale markings (15|10|5|0|5|10|15). The two gpt-vision attempts only captured the visible scale and an unrelated viewer timestamp ('12/31/99 18:11:19'), marking everything else as (?). Promoted gemini as canonical; this is page-intrinsic redaction, not OCR variance.",
+      "judged_at": "2026-05-27T00:35:37.432Z",
+      "judge": "human:Rizzleroc"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Writes a `sidecar.comparison.judge` verdict (confidence 0.95) for the single page sitting in the review queue.
- After merge, `compare-sources.mjs`'s priorJudge round-trip block honors the verdict on every rebuild, locks canonical to gemini's text, and clears `needs_review`.

## Why gemini wins on this page

Heavily-redacted FBI photo. Three OCR attempts diverge dramatically:

| Source | Chars | Captured |
|---|---|---|
| **gemini** | 343 | Document metadata header (title / source / page / agency / release date / dataset description) + `[redacted]` markers + sensor overlay scale `15 \| 10 \| 5 \| 0 \| 5 \| 10 \| 15` |
| gpt-vision (v1) | 119 | Visible scale + viewer-chrome timestamp; everything else `(?)` |
| gpt-vision-review (v2) | 172 | Same; slightly more whitespace |

This is page-intrinsic redaction, not OCR variance — re-OCR cannot bridge the gap. Gemini's reading is correct and complete. The gpt-vision attempts weren't *wrong*, just more conservative.

## How it works

`compare-sources.mjs` checks `sidecar.comparison?.judge?.confidence >= 0.7` first; when present, it skips the re-evaluation branches and runs only the priorJudge round-trip block at the end, which sets:

- `cmp.dispute_kind = \"judged\"`
- `cmp.needs_review = false`
- `cmp.confidence = \"high\"`

The verdict block is preserved across rebuilds because import-contributions only writes to `sidecar.sources` / `sidecar.best`, never to `sidecar.comparison`.

## Test plan
- [ ] Merge.
- [ ] Trigger `refresh-work-queue.yml` + `deploy.yml` (or wait for them to fire on next push).
- [ ] Confirm gh-pages `work-available.json` shows `totalPagesNeedingReview: 0`.
- [ ] Dashboard's REVIEW QUEUE panel shows ✓ EMPTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)