### PR TITLE
fix(volunteer): resolve site-relative pdfUrl + count any render-fail

### DIFF
--- a/pursue-vision-mcp/monitor.mjs
+++ b/pursue-vision-mcp/monitor.mjs
@@ -226,7 +226,11 @@ function summarizeLog(allLines, exitCode) {
   const econnRefused = /ECONNREFUSED.*9223|ECONNREFUSED 127\.0\.0\.1:9223|OCR daemon at .* (?:is unreachable|stopped responding)/.test(text);
   const cdpTimeout   = /connectOverCDP.*Timeout|CDP.*timeout/i.test(text);
   const tokenError   = /unauthorized.*bearer|HTTP 401/i.test(text);
-  const pdfRenderFails = (text.match(/render failed \(Value is none of these types/g) || []).length;
+  // Count ANY pdfjs render failure, not just the old napi-canvas "Value is none
+  // of these types" string. A relative pdfUrl that fetch() rejects produces
+  // "Failed to parse URL from ..." which used to slip past this regex and let
+  // the classifier headline a doomed claim as STAGED.
+  const pdfRenderFails = (text.match(/render failed \(/g) || []).length;
   const claimedFromMedia = /\[claim\]/.test(text);
   // Visuals claim phase: "[claim] claiming N page(s)" then "templates written to".
   const mediaClaimMatch = text.match(/\[claim\] claiming (\d+) page/);

--- a/scripts/volunteer-media.mjs
+++ b/scripts/volunteer-media.mjs
@@ -339,8 +339,12 @@ async function claimPhase() {
     // Fall back to downloading from war.gov into the volunteer scratch dir.
     const filename = path.join(PDF_ROOT, `${eid}.pdf`);
     if (!existsSync(filename)) {
-      console.log(`    ↓ downloading ${url}`);
-      const r = await fetch(url);
+      // Release-02 PDFs ship as site-relative paths (e.g. "release_2/X.pdf")
+      // because they're mirrored under public/release_2/ — resolve against the
+      // deployed site so Node's fetch() (which rejects relative URLs) works.
+      const absUrl = /^https?:\/\//i.test(url) ? url : new URL(url, "https://rizzleroc.github.io/pursue-console/").href;
+      console.log(`    ↓ downloading ${absUrl}`);
+      const r = await fetch(absUrl);
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const buf = Buffer.from(await r.arrayBuffer());
       await writeFile(filename, buf);

--- a/scripts/volunteer.mjs
+++ b/scripts/volunteer.mjs
@@ -277,8 +277,12 @@ await mkdir(PDF_ROOT, { recursive: true });
 for (const c of claims) {
   const dest = path.join(PDF_ROOT, `${c.eid}.pdf`);
   if (existsSync(dest)) { console.log(`  ⊖ ${c.eid}.pdf already present`); continue; }
-  console.log(`  ↓ ${c.eid}.pdf  ${c.doc.pdfUrl}`);
-  const r = await fetch(c.doc.pdfUrl);
+  // Release-02 PDFs ship as site-relative paths (e.g. "release_2/X.pdf")
+  // because they're mirrored under public/release_2/ — resolve against the
+  // deployed site so Node's fetch() (which rejects relative URLs) works.
+  const absUrl = /^https?:\/\//i.test(c.doc.pdfUrl) ? c.doc.pdfUrl : new URL(c.doc.pdfUrl, "https://rizzleroc.github.io/pursue-console/").href;
+  console.log(`  ↓ ${c.eid}.pdf  ${absUrl}`);
+  const r = await fetch(absUrl);
   if (!r.ok) { console.error(`    HTTP ${r.status} — skipping doc`); c.skip = true; continue; }
   await writeFile(dest, Buffer.from(await r.arrayBuffer()));
 }


### PR DESCRIPTION
## Summary

- Resolve site-relative `pdfUrl` strings (Release-02 mirrors at `public/release_2/`) against `https://rizzleroc.github.io/pursue-console/` before calling Node's `fetch()` — fixes the silent `Failed to parse URL from release_2/...` failure in both `volunteer.mjs` (OCR phase) and `volunteer-media.mjs` (visuals claim phase).
- Broaden `monitor.mjs`'s `pdfRenderFails` regex so the new URL-parse failure is counted — the existing `RENDER FAILED` / partial-`STAGED` branches now trigger correctly instead of headlining a doomed claim as `STAGED · N page(s) rendered`.

Closes #254.

## How it was caught

`:9224` monitor watchdog — runnerLog tail for handle `Rizzleroc` showed `[claim] claiming 2 page(s)` followed by `! DOE-UAP-D001 p0001: render failed (Failed to parse URL from release_2/DOE-UAP-D001_PANTEX_Image.pdf)` for every page, exit code 0, headline `STAGED · 2 page(s) rendered`. Verified the absolute URL at `https://rizzleroc.github.io/pursue-console/release_2/DOE-UAP-D001_PANTEX_Image.pdf` returns 200 OK (164 KB).

## Test plan

- [ ] `node scripts/volunteer-media.mjs --my-handle=Rizzleroc --slice=2` against a Release-02 doc — expect PNGs in `~/.pursue-helper/media-staging/Rizzleroc/<eid>/p*.png` next to the staged templates, no `Failed to parse URL` in the runnerLog.
- [ ] Same run, but force a render failure (e.g. point at a missing PDF) — expect monitor cockpit headline `RENDER FAILED · N page(s)` instead of `STAGED`.
- [ ] Existing Release-01 absolute URLs (`https://www.war.gov/medialink/ufo/release_1/...`) still download fine — the absolute-URL branch returns them unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)