### PR TITLE
Restore DVIDS iframe embeds (MediaView modal + LaunchOverlay)

### DIFF
--- a/src/components/LaunchOverlay.jsx
+++ b/src/components/LaunchOverlay.jsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useT } from "../i18n/context.js";
 
-// One-time launch overlay for the 2.0 drop. Hypes the release and surfaces
-// the declassified DVIDS sensor footage as a clickable reticle poster that
-// links out to dvidshub.net (the embed iframe stopped playing — see #257
-// and MediaView's matching pattern). Once dismissed it never shows again
-// (localStorage gate lives in App — this component just calls onClose).
-// Motion follows Emil Kowalski's playbook: ease-out entrances, blur+scale
-// reveals, staggered transform/opacity.
+// One-time launch overlay for the 2.0 drop. Hypes the release and plays
+// the declassified DVIDS sensor footage inline via the DVIDS embed player.
+// Once dismissed it never shows again (localStorage gate lives in App —
+// this component just calls onClose). Motion follows Emil Kowalski's
+// playbook: ease-out entrances, blur+scale reveals, staggered
+// transform/opacity.
 
 const SEEN_KEY = "pursue:launch-2.0-seen";
 
@@ -220,38 +219,16 @@ export default function LaunchOverlay({ onClose }) {
           <div className="lo-rise mt-6 grid lg:grid-cols-[1.6fr_1fr] gap-5" style={{ animationDelay: "200ms" }}>
             <div>
               <div className="relative aspect-video w-full overflow-hidden rounded-sm border border-emerald-700/40 bg-black">
-                <a
+                <iframe
                   key={swapKey}
-                  href={`https://www.dvidshub.net/video/${clip.videoId}`}
-                  target="_blank" rel="noopener noreferrer"
-                  className="lo-swap absolute inset-0 group block"
-                  aria-label={`Watch on DVIDS: ${clip.code} — ${clip.tag}`}
-                >
-                  <div className="absolute inset-0" style={{
-                    backgroundImage:
-                      "radial-gradient(circle at 50% 46%, rgba(52,211,153,0.16), rgba(2,8,6,0) 62%)," +
-                      "repeating-linear-gradient(0deg, rgba(52,211,153,0.06) 0px, rgba(52,211,153,0.06) 1px, transparent 1px, transparent 3px)",
-                  }} />
-                  <svg className="absolute inset-0 w-full h-full text-emerald-400/25" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
-                    <line x1="50" y1="0" x2="50" y2="100" stroke="currentColor" strokeWidth="0.4" />
-                    <line x1="0" y1="50" x2="100" y2="50" stroke="currentColor" strokeWidth="0.4" />
-                    <circle cx="50" cy="50" r="22" fill="none" stroke="currentColor" strokeWidth="0.5" />
-                  </svg>
-                  <span className="absolute top-2 left-2 w-3 h-3 border-t border-l border-emerald-400/50" />
-                  <span className="absolute top-2 right-2 w-3 h-3 border-t border-r border-emerald-400/50" />
-                  <span className="absolute bottom-2 left-2 w-3 h-3 border-b border-l border-emerald-400/50" />
-                  <span className="absolute bottom-2 right-2 w-3 h-3 border-b border-r border-emerald-400/50" />
-                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
-                    <span className="flex items-center justify-center rounded-full border border-emerald-400/60 bg-emerald-950/40 w-20 h-20 transition-all group-hover:scale-110 group-hover:border-emerald-300">
-                      <svg width={26} height={28} viewBox="0 0 22 24" aria-hidden="true">
-                        <path d="M2 2 L20 12 L2 22 Z" fill="#6ee7b7" />
-                      </svg>
-                    </span>
-                    <span className="text-[10px] tracking-[0.3em] text-emerald-300 group-hover:text-emerald-100 transition-colors">
-                      WATCH ON DVIDS ↗
-                    </span>
-                  </div>
-                </a>
+                  className="lo-swap absolute inset-0 w-full h-full"
+                  src={`https://www.dvidshub.net/video/embed/${clip.videoId}`}
+                  title={`${clip.code} — ${clip.tag}`}
+                  allow="autoplay; fullscreen; picture-in-picture"
+                  allowFullScreen
+                  loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
+                />
               </div>
               <div key={`meta-${swapKey}`} className="lo-swap mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">
                 <span className={`text-[9px] tracking-[0.25em] px-1.5 py-0.5 border rounded-sm ${FLAG_COLOR[clip.flag]}`}>{t(`launch.flag.${clip.flag}`)}</span>

--- a/src/views/MediaView.jsx
+++ b/src/views/MediaView.jsx
@@ -75,9 +75,10 @@ const HEADER_TYPE_TO_KINDS = {
   Audio: new Set(),
 };
 
-// IR-scope poster for video tiles — reticle + scanlines + play affordance.
-// DVIDS clips can't be embedded, so this stands in for a thumbnail and the
-// whole tile/modal links out to dvidshub.net.
+// IR-scope poster for video tiles in the grid — reticle + scanlines + play
+// affordance. The full iframe player only mounts inside the modal (one at
+// a time); grid tiles stay as posters to keep scroll cheap and avoid
+// dozens of concurrent iframes.
 function VideoPoster({ label, big }) {
   // Caller provides the label so we don't need to thread `t` into a
   // purely-presentational SVG. Defaults to the English DVIDS CTA when
@@ -510,12 +511,17 @@ export default function MediaView({ onSelect, headerFilters }) {
             </div>
             <div className="flex-1 overflow-auto bg-black flex items-center justify-center p-6 min-h-[40vh]">
               {focused.kind === "video" ? (
-                <a href={focused.dvidsUrl || `https://www.dvidshub.net/video/${focused.videoId}`}
-                  target="_blank" rel="noopener noreferrer"
-                  className="group w-full max-w-3xl aspect-video rounded-sm border border-blue-700/40 overflow-hidden bg-black block"
-                  aria-label={`Watch on DVIDS: ${focused.title || "DVIDS video"}`}>
-                  <VideoPoster big label="PLAY ON DVIDS ↗" />
-                </a>
+                <div className="w-full max-w-3xl aspect-video rounded-sm border border-blue-700/40 overflow-hidden bg-black">
+                  <iframe
+                    className="w-full h-full"
+                    src={`https://www.dvidshub.net/video/embed/${focused.videoId}`}
+                    title={focused.title || "DVIDS video"}
+                    allow="autoplay; fullscreen; picture-in-picture"
+                    allowFullScreen
+                    loading="lazy"
+                    referrerPolicy="no-referrer-when-downgrade"
+                  />
+                </div>
               ) : focused.imagePath ? (
                 <img src={`${import.meta.env.BASE_URL}${focused.imagePath}`} alt={focused.title || focused.kind}
                   className="max-w-full max-h-[70vh] object-contain" />


### PR DESCRIPTION
## Summary

Restores inline DVIDS video playback in both the MediaView modal and the LaunchOverlay featured player. Reverts the May 29 swap (commits `3f6e2b26c` and `8dee2064a`) that replaced the embed iframe with a click-out reticle poster — the embeds in fact play fine in deployed browsers, and the earlier "iframe broken" attribution was speculative ("likely due to DVIDS tightening X-Frame-Options / referrer policy").

## Changes

| Location | Before | After |
|---|---|---|
| `MediaView.jsx` modal | Anchor-wrapped `VideoPoster` with "PLAY ON DVIDS ↗" | `<iframe src="https://www.dvidshub.net/video/embed/<id>">` with autoplay/fullscreen/pip allowed |
| `LaunchOverlay.jsx` featured player | Anchor-wrapped emerald reticle poster (38 lines of SVG decoration) | Same iframe pattern as MediaView (10 lines) |

Grid tiles in MediaView still use the static `VideoPoster` — dozens of concurrent DVIDS iframes would be heavy on scroll and a poster grid is the conventional thumbnail pattern. Only the modal mounts a live player.

Stale comments updated:
- `LaunchOverlay.jsx` header — removed the "embed iframe stopped playing — see #257" note, restored the original "plays the declassified DVIDS sensor footage inline" wording.
- `MediaView.jsx` `VideoPoster` doc — was "DVIDS clips can't be embedded, so this stands in for a thumbnail and the whole tile/modal links out", now correctly explains why the grid stays as posters even though the modal embeds.

## Test plan

Note: this container's egress allowlist blocks `*.dvidshub.net`, so a local `vite dev` here can't load the iframe — testing has to happen against the deployed site or the user's own browser.

- [ ] Open MediaView, click any video tile → modal mounts iframe → DVIDS player loads and plays inline
- [ ] Trigger LaunchOverlay (clear `localStorage["pursue:launch-2.0-seen"]`) → featured player iframe loads and plays
- [ ] "Play on DVIDS" link in modal header still opens dvidshub.net in a new tab (kept as a fallback)
- [ ] Grid tile thumbnails still render the static blue VideoPoster (unchanged)

## If DVIDS does block iframes for some users

Should playback fail in a specific browser/region/extension, the modal header still carries the explicit "Play on DVIDS" link-out (`MediaView.jsx:484-488`), so the click-out path isn't lost — just demoted from "the only option" back to "the fallback."

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_