### PR TITLE
Mission Control 3.0 — 11 surface mockups, deployable at /mc/

### DIFF
--- a/public/mc/ask.html
+++ b/public/mc/ask.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Ask</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .ask-shell { padding: 0 56px 64px; display: grid; grid-template-columns: minmax(0,1fr) 340px; gap: 24px; position: relative; z-index: 3; }
+    .ask-card { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; backdrop-filter: blur(10px); }
+    .mode-pill-row { display: flex; gap: 10px; margin-bottom: 22px; }
+    .mp { padding: 10px 16px; border: 1px solid var(--border); background: var(--surface-2); cursor: pointer; font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; }
+    .mp.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.08); box-shadow: 0 0 14px rgba(242,166,35,0.18); }
+    .mp .badge { background: rgba(74,222,128,0.10); border: 1px solid rgba(74,222,128,0.4); color: var(--emerald); padding: 1px 6px; margin-left: 8px; font-size: 9px; }
+    .ask-input { display: flex; flex-direction: column; gap: 12px; background: var(--surface-3); border: 1px solid var(--border-strong); padding: 22px; }
+    .ask-input textarea { background: transparent; border: none; outline: none; color: var(--text); font-family: 'Inter', sans-serif; font-size: 16px; line-height: 1.5; resize: vertical; min-height: 88px; }
+    .ask-input textarea::placeholder { color: var(--text-4); }
+    .ask-input-row { display: flex; align-items: center; gap: 12px; padding-top: 12px; border-top: 1px solid var(--hairline); }
+    .ask-input-row .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.18em; flex: 1; }
+    .ask-input-row .meta .v { color: var(--amber); }
+    .ask-input-row .send { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.18em; color: var(--void); background: linear-gradient(180deg, var(--amber-bright), var(--gold)); border: 1px solid var(--amber); padding: 10px 22px; cursor: pointer; }
+    .qa { margin-top: 32px; }
+    .q { display: flex; align-items: flex-start; gap: 14px; padding: 22px 0 16px; border-bottom: 1px solid var(--hairline); }
+    .q .avatar { width: 32px; height: 32px; border: 1px solid var(--border-strong); display: flex; align-items: center; justify-content: center; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.12em; color: var(--text-2); flex-shrink: 0; }
+    .q .avatar.user { background: rgba(97,215,240,0.10); border-color: rgba(97,215,240,0.4); color: var(--cyan); }
+    .q .avatar.ai { background: rgba(242,166,35,0.10); border-color: var(--border-strong); color: var(--amber); }
+    .q .body { flex: 1; }
+    .q .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.14em; margin-bottom: 8px; }
+    .q .body p { font-size: 15px; line-height: 1.65; color: var(--text-2); margin: 0 0 12px; }
+    .q .body p strong { color: var(--text); font-weight: 600; }
+    .q .body p em { color: var(--text); font-style: normal; font-weight: 500; background: rgba(242,166,35,0.06); padding: 0 4px; }
+    .cite { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--cyan); background: rgba(97,215,240,0.10); border: 1px solid rgba(97,215,240,0.30); padding: 1px 6px; margin: 0 3px; vertical-align: super; }
+    .src-list { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; padding-top: 14px; border-top: 1px solid var(--hairline); }
+    .src { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: baseline; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); }
+    .src .n { color: var(--cyan); font-weight: 600; }
+    .src .title { color: var(--text-2); }
+    .src .pg { color: var(--text-4); }
+    .suggest { padding: 0; }
+    .suggest h4 { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; margin: 0 0 14px; }
+    .suggest .sg { display: block; padding: 12px 0; border-bottom: 1px solid var(--hairline); cursor: pointer; transition: color .15s; color: var(--text-2); text-decoration: none; }
+    .suggest .sg:hover { color: var(--text); }
+    .suggest .sg:last-child { border-bottom: none; }
+    .suggest .sg .q-text { font-size: 13px; line-height: 1.45; }
+    .suggest .sg .q-meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.08em; margin-top: 4px; }
+  </style>
+</head>
+<body data-view="ask">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 04 — natural-language Q&A</div>
+    <h1>Ask the corpus a question, <em>get a cited answer.</em></h1>
+    <p class="sub">SMART mode runs a RAG pipeline against the 5,665-chunk semantic index and a frontier LLM. PATTERN mode falls back to a local classifier when the LLM backend is offline.</p>
+  </section>
+
+  <section class="ask-shell">
+    <div class="ask-card">
+
+      <div class="mode-pill-row">
+        <span class="mp active">∿ SMART <span class="badge">RAG + LLM</span></span>
+        <span class="mp">▣ PATTERN <span style="background:rgba(184,168,135,0.10);border:1px solid var(--border);color:var(--text-3);padding:1px 6px;margin-left:8px;font-size:9px">LOCAL</span></span>
+      </div>
+
+      <div class="ask-input">
+        <textarea placeholder="Ask anything about the corpus — events, entities, sources, dates, patterns…">What does the corpus suggest about helicopter encounters with orbs at low altitude?</textarea>
+        <div class="ask-input-row">
+          <span class="meta">SOURCE · <span class="v">3,530 pages · 5,665 chunks · 220 events</span></span>
+          <button class="send">▶ INVESTIGATE</button>
+        </div>
+      </div>
+
+      <div class="qa">
+        <div class="q">
+          <div class="avatar user">YOU</div>
+          <div class="body">
+            <div class="meta">02·06 · 17:21 UTC · SMART · WEB</div>
+            <p>What does the corpus suggest about helicopter encounters with orbs at low altitude?</p>
+          </div>
+        </div>
+
+        <div class="q">
+          <div class="avatar ai">▣</div>
+          <div class="body">
+            <div class="meta">02·06 · 17:21:14 UTC · SMART · CLAUDE-3.7 · 4 SOURCES</div>
+            <p>The corpus contains one anchor event matching this profile: a late-2025 FBI 302 statement from a senior US intelligence official aboard a search helicopter at a US military facility <span class="cite">[1]</span>. The narrative describes an <em>LP/OP-tracked orb</em> that "gained elevation, came within ten feet of [the helicopter]" before separating into a swarm of orbs in triangle formation that "moved in all directions" <span class="cite">[2]</span>.</p>
+            <p>Adjacent DoW mission reports show similar low-altitude small-object encounters but in fixed-wing contexts: <strong>UAE June 2024</strong> records an object flying straight at 140 knots over water at the same general altitude band as a returning aircraft <span class="cite">[3]</span>. The <strong>Western US 2023</strong> dossier provides a complementary ground-witness account of a "Large, Fiery Orb" at ~500–600m observed by federal law-enforcement agents <span class="cite">[4]</span>.</p>
+            <p>The corpus does not contain a second helicopter-vs-orb event matching the USPER profile. <span style="color:var(--text-3)">Confidence: 0.86 · Caveat: 46% of catalogued events lack body text.</span></p>
+
+            <div class="src-list">
+              <div class="src"><span class="n">[1]</span><span class="title">USPER Statement · Senior USIC Official · helicopter encounter, US military facility</span><span class="pg">FBI · p1</span></div>
+              <div class="src"><span class="n">[2]</span><span class="title">USPER Statement · "swarm of lights in triangle formation"</span><span class="pg">FBI · p3</span></div>
+              <div class="src"><span class="n">[3]</span><span class="title">UAE June 2024 mission report · 140kt at low altitude over water</span><span class="pg">DoW · p6</span></div>
+              <div class="src"><span class="n">[4]</span><span class="title">Western US 2023 · "Large, Fiery Orb" at 500–600m, dusk</span><span class="pg">DoW · p2</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-head"><span><span class="icon-sq"></span>Suggested queries</span><span class="right">community curated</span></div>
+      <div class="suggest">
+        <a class="sg"><div class="q-text">Which events involve multiple USIC witnesses?</div><div class="q-meta">3 hits in corpus</div></a>
+        <a class="sg"><div class="q-text">Sightings classified as "orb" near military facilities, 2020–2025?</div><div class="q-meta">7 hits</div></a>
+        <a class="sg"><div class="q-text">List USCENTCOM events with FLIR sensor readouts</div><div class="q-meta">12 hits</div></a>
+        <a class="sg"><div class="q-text">Which 1947 documents mention "Roswell"?</div><div class="q-meta">FBI 62HQ section 2 + 5</div></a>
+        <a class="sg"><div class="q-text">Compare Gemini VII bogey vs Apollo 17 debrief language</div><div class="q-meta">cross-event analysis</div></a>
+        <a class="sg"><div class="q-text">What patterns dominate the 2020s cohort?</div><div class="q-meta">light / hover / vertical</div></a>
+        <a class="sg"><div class="q-text">List events that have signature "split" or "swarm"</div><div class="q-meta">3 hits</div></a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+<script>
+  document.querySelectorAll('.mp').forEach(m => m.addEventListener('click', () => {
+    document.querySelectorAll('.mp').forEach(x => x.classList.remove('active'));
+    m.classList.add('active');
+  }));
+</script>
+</body>
+</html>

--- a/public/mc/atlas.html
+++ b/public/mc/atlas.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Atlas</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .at-shell { padding: 0 56px 64px; position: relative; z-index: 3; }
+    .at-card { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; backdrop-filter: blur(10px); }
+    .at-grid { display: grid; grid-template-columns: 160px repeat(8, 1fr); gap: 4px; }
+    .at-grid .corner-cell, .at-grid .col-h, .at-grid .row-h, .at-grid .cell { padding: 14px 10px; }
+    .at-grid .col-h { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; text-align: center; padding-bottom: 8px; }
+    .at-grid .row-h { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-2); letter-spacing: 0.14em; text-transform: uppercase; padding-right: 14px; text-align: right; align-self: center; }
+    .at-grid .cell { aspect-ratio: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; transition: all .15s; cursor: pointer; position: relative; border: 1px solid #1A2638; }
+    .at-grid .cell:hover { transform: scale(1.05); z-index: 2; border-color: var(--amber); }
+    .at-grid .cell .v { font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px; color: var(--text); line-height: 1; }
+    .at-grid .cell .pct { font-family: 'JetBrains Mono', monospace; font-size: 8px; color: var(--text-4); letter-spacing: 0.08em; }
+    .at-grid .cell.h0 { background: #0A1018; }
+    .at-grid .cell.h1 { background: rgba(242,166,35,0.08); border-color: rgba(242,166,35,0.18); }
+    .at-grid .cell.h2 { background: rgba(242,166,35,0.18); border-color: rgba(242,166,35,0.30); }
+    .at-grid .cell.h3 { background: rgba(242,166,35,0.35); border-color: rgba(242,166,35,0.55); }
+    .at-grid .cell.h4 { background: rgba(242,166,35,0.55); border-color: var(--amber); box-shadow: 0 0 16px rgba(242,166,35,0.4); }
+    .at-grid .cell.h5 { background: rgba(242,166,35,0.75); border-color: var(--amber-bright); box-shadow: 0 0 22px rgba(242,166,35,0.55); }
+    .at-grid .cell.h5 .v { color: var(--void); }
+    .at-grid .cell.h4 .v { color: var(--void); }
+    .at-grid .cell .v.zero { color: var(--text-4); }
+    .at-summary { margin-top: 26px; padding-top: 22px; border-top: 1px solid var(--hairline); display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+    .at-summary .s { padding-left: 18px; border-left: 1px solid var(--hairline); }
+    .at-summary .s:first-child { padding-left: 0; border-left: none; }
+    .at-summary .k { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; }
+    .at-summary .v { font-family: 'Space Grotesk', sans-serif; font-size: 32px; font-weight: 700; color: var(--text); margin: 6px 0 2px; letter-spacing: -0.025em; }
+    .at-summary .v.amber { color: var(--amber); text-shadow: 0 0 16px var(--amber-glow); }
+    .at-summary .sub { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.08em; }
+    .at-legend { display: flex; align-items: center; gap: 12px; padding: 16px 0; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.14em; text-transform: uppercase; }
+    .at-legend .swatch { width: 22px; height: 12px; display: inline-block; }
+  </style>
+</head>
+<body data-view="atlas">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 09 — agency × era heatmap</div>
+    <h1>Where the corpus lives. <em>And where it doesn't.</em></h1>
+    <p class="sub">Eight agencies, eight eras. The hot cells dominate the corpus story; the cold cells are where contributors are most needed. Click any cell to drill into the events that anchor that cohort.</p>
+  </section>
+
+  <section class="at-shell">
+    <div class="at-card">
+      <div class="at-legend">
+        <span>DENSITY</span>
+        <span class="swatch" style="background:#0A1018;border:1px solid #1A2638"></span><span>0</span>
+        <span class="swatch" style="background:rgba(242,166,35,0.08);border:1px solid rgba(242,166,35,0.18)"></span><span>1–2</span>
+        <span class="swatch" style="background:rgba(242,166,35,0.18)"></span><span>3–8</span>
+        <span class="swatch" style="background:rgba(242,166,35,0.35)"></span><span>9–20</span>
+        <span class="swatch" style="background:rgba(242,166,35,0.55)"></span><span>21–50</span>
+        <span class="swatch" style="background:rgba(242,166,35,0.75)"></span><span>51+</span>
+        <span style="margin-left:auto">220 EVENTS · 8 AGENCIES · 8 ERAS</span>
+      </div>
+
+      <div class="at-grid">
+        <div class="corner-cell"></div>
+        <div class="col-h">1940s</div>
+        <div class="col-h">1950s</div>
+        <div class="col-h">1960s</div>
+        <div class="col-h">1970s</div>
+        <div class="col-h">1980s</div>
+        <div class="col-h">1990s</div>
+        <div class="col-h">2000s</div>
+        <div class="col-h">2020s</div>
+
+        <div class="row-h">DEPT/WAR</div>
+        <div class="cell h2"><span class="v">3</span><span class="pct">14%</span></div>
+        <div class="cell h2"><span class="v">2</span><span class="pct">9%</span></div>
+        <div class="cell h2"><span class="v">4</span><span class="pct">18%</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h2"><span class="v">2</span><span class="pct">9%</span></div>
+        <div class="cell h2"><span class="v">3</span><span class="pct">14%</span></div>
+        <div class="cell h5"><span class="v">144</span><span class="pct">91%</span></div>
+
+        <div class="row-h">FBI</div>
+        <div class="cell h3"><span class="v">11</span><span class="pct">42%</span></div>
+        <div class="cell h2"><span class="v">5</span><span class="pct">19%</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h1"><span class="v">2</span><span class="pct">8%</span></div>
+        <div class="cell h2"><span class="v">8</span><span class="pct">31%</span></div>
+
+        <div class="row-h">NASA</div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h3"><span class="v">12</span><span class="pct">55%</span></div>
+        <div class="cell h2"><span class="v">8</span><span class="pct">36%</span></div>
+        <div class="cell h1"><span class="v">1</span><span class="pct">5%</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h1"><span class="v">1</span><span class="pct">5%</span></div>
+
+        <div class="row-h">STATE</div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h1"><span class="v">2</span><span class="pct">29%</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h1"><span class="v">2</span><span class="pct">29%</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h2"><span class="v">3</span><span class="pct">43%</span></div>
+
+        <div class="row-h">ENERGY</div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h2"><span class="v">3</span><span class="pct">100%</span></div>
+
+        <div class="row-h">CIA</div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h1"><span class="v">1</span><span class="pct">100%</span></div>
+
+        <div class="row-h">ODNI</div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h1"><span class="v">1</span><span class="pct">100%</span></div>
+
+        <div class="row-h">UNKNOWN</div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h0"><span class="v zero">·</span></div>
+        <div class="cell h2"><span class="v">12</span><span class="pct">100%</span></div>
+      </div>
+
+      <div class="at-summary">
+        <div class="s"><div class="k">Dominant cohort</div><div class="v amber">DoW · 2020s</div><div class="sub">144 events · 65% of corpus</div></div>
+        <div class="s"><div class="k">Secondary cluster</div><div class="v">FBI · 1940s</div><div class="sub">11 events · 5% of corpus</div></div>
+        <div class="s"><div class="k">Cold cells</div><div class="v">42</div><div class="sub">of 64 grid positions empty</div></div>
+        <div class="s"><div class="k">Cross-era agencies</div><div class="v">3</div><div class="sub">DoW · NASA · FBI</div></div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+</body>
+</html>

--- a/public/mc/chrome.js
+++ b/public/mc/chrome.js
@@ -1,0 +1,137 @@
+// Mission Control chrome injector.
+// Each page wraps its body content in <main>. This script inserts
+// the consistent header/nav before <main> and the footer after.
+
+(function () {
+  const VIEWS = [
+    { id: 'live',     label: 'Live' },
+    { id: 'coverage', label: 'Coverage' },
+    { id: 'search',   label: 'Search' },
+    { id: 'ask',      label: 'Ask' },
+    { id: 'review',   label: 'Review', badge: 3 },
+    { id: 'media',    label: 'Media' },
+    null,
+    { id: 'dossier',  label: 'Dossier' },
+    { id: 'timeline', label: 'Timeline' },
+    { id: 'atlas',    label: 'Atlas' },
+    { id: 'globe',    label: 'Globe' },
+    { id: 'network',  label: 'Network' },
+  ];
+
+  function el(tag, attrs = {}, children = []) {
+    const e = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (k === 'class') e.className = v;
+      else if (k === 'html') e.innerHTML = v;
+      else e.setAttribute(k, v);
+    }
+    for (const c of children) {
+      if (typeof c === 'string') e.appendChild(document.createTextNode(c));
+      else if (c) e.appendChild(c);
+    }
+    return e;
+  }
+
+  const view = document.body.dataset.view || 'live';
+  function stamp() {
+    const d = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    return `${d.getUTCFullYear()}·${pad(d.getUTCMonth() + 1)}·${pad(d.getUTCDate())}  ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
+  }
+
+  // Background overlays (fixed-position, order doesn't matter)
+  document.body.append(
+    el('div', { class: 'bg-void' }),
+    el('div', { class: 'bg-grid' }),
+    el('div', { class: 'bg-noise' }),
+    el('div', { class: 'vignette' }),
+    el('div', { class: 'scanline' }),
+    el('span', { class: 'corner tl' }),
+    el('span', { class: 'corner tr' }),
+    el('span', { class: 'corner bl' }),
+    el('span', { class: 'corner br' }),
+  );
+
+  // Find <main> — it's the anchor
+  const main = document.querySelector('main');
+  if (!main) {
+    console.error('Mission Control: page is missing <main>');
+    return;
+  }
+
+  // ─────────── Pre-main chrome ───────────
+  const classifiedTop = el('div', { class: 'classified' }, [
+    el('span', { class: 'stamp' }, ['// declassified · war.gov · open-source mirror']),
+    el('span', { class: 'dash' }, ['— — — — — — — — — — — — — — — — — — — — — — — — — — — — — — —']),
+    el('span', { class: 'stamp' }, ['community-run · not agency-affiliated']),
+  ]);
+  const topbar = el('header', { class: 'topbar' }, [
+    el('div', { class: 'brand' }, [
+      el('span', { class: 'brand-mark' }),
+      el('span', { class: 'brand-name' }, ['PURSUE  CONSOLE']),
+      el('span', { class: 'brand-sub' }, ['MISSION CONTROL · 3.0 · WAR.GOV/UAP']),
+    ]),
+    el('div', { class: 'center-strip' }, [
+      el('span', { class: 'badge' }, [el('span', { class: 'dot' }), 'OPERATIONAL']),
+      el('span', { class: 'badge', id: 'time-badge' }, [el('span', { class: 'v' }, [stamp()])]),
+      el('span', { class: 'badge amber' }, [el('span', { class: 'dot' }), 'LIVE WATCH']),
+    ]),
+    el('div', { class: 'topbar-actions' }, [
+      el('a', { class: 'ghost', href: 'index.html' }, ['LAUNCH ▾']),
+      el('a', { class: 'ops-btn', href: 'review.html' }, ['＋ ENLIST']),
+    ]),
+  ]);
+  const nav = el('nav', { class: 'tabs' });
+  for (const v of VIEWS) {
+    if (v === null) {
+      nav.appendChild(el('span', { class: 'nav-divider' }));
+      nav.appendChild(el('span', { class: 'nav-group' }, ['ANALYSIS']));
+      continue;
+    }
+    const tab = el('a', {
+      class: 'nav-tab' + (view === v.id ? ' active' : ''),
+      href: `${v.id}.html`,
+    }, [v.label]);
+    if (v.badge) tab.appendChild(el('span', { class: 'nav-badge' }, [String(v.badge)]));
+    nav.appendChild(tab);
+  }
+  main.parentNode.insertBefore(classifiedTop, main);
+  main.parentNode.insertBefore(topbar, main);
+  main.parentNode.insertBefore(nav, main);
+
+  // ─────────── Post-main chrome ───────────
+  const footer = el('footer', { class: 'fc' }, [
+    el('span', {}, ['watchkeeper · automated vigil · human-in-loop']),
+    el('span', {}, [`// ${stamp().toLowerCase()}`]),
+    el('span', {}, ['community-run · not agency-affiliated']),
+  ]);
+  const classifiedBot = el('div', { class: 'classified', style: 'margin-top: 12px;' }, [
+    el('span', { class: 'stamp' }, ['// end of transmission']),
+    el('span', { class: 'dash' }, ['— — — — — — — — — — — — — — — — — — — — — — — — — — — — — — —']),
+    el('span', { class: 'stamp' }, ['classification · open · public mirror']),
+  ]);
+  main.parentNode.appendChild(footer);
+  main.parentNode.appendChild(classifiedBot);
+
+  // Live UTC tick
+  setInterval(() => {
+    const t = document.querySelector('#time-badge .v');
+    if (t) t.textContent = stamp();
+  }, 1000);
+
+  // Count-up helper
+  function easeOut(t) { return 1 - Math.pow(1 - t, 3); }
+  document.querySelectorAll('[data-count]').forEach(elx => {
+    const target = parseFloat(elx.dataset.count);
+    const start = performance.now();
+    setTimeout(() => {
+      function frame(now) {
+        const t = Math.min(1, (now - start - 600) / 1500);
+        if (t < 0) { requestAnimationFrame(frame); return; }
+        elx.textContent = Math.round(target * easeOut(t)).toLocaleString();
+        if (t < 1) requestAnimationFrame(frame);
+      }
+      requestAnimationFrame(frame);
+    }, 600);
+  });
+})();

--- a/public/mc/coverage.html
+++ b/public/mc/coverage.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Coverage</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .body2 { padding: 0 56px 64px; display: grid; grid-template-columns: minmax(0,1fr) 380px; gap: 24px; position: relative; z-index: 3; }
+    .cov-card { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; backdrop-filter: blur(10px); }
+    .cov-grid { display: grid; grid-template-columns: repeat(11, 1fr); gap: 8px; max-width: 700px; margin: 22px auto; }
+    .cov-cell { aspect-ratio: 1; background: #0A1018; border: 1px solid #182232; opacity: 0; animation: cov-in 0.5s cubic-bezier(.2,.7,.2,1) forwards; transition: transform .15s; cursor: pointer; }
+    .cov-cell:hover { transform: scale(1.18); border-color: var(--amber); }
+    @keyframes cov-in { from { opacity: 0; transform: scale(.5); } to { opacity: 1; transform: scale(1); } }
+    .cov-cell.partial { background: rgba(242,166,35,0.18); border-color: rgba(242,166,35,0.55); }
+    .cov-cell.complete { background: rgba(74,222,128,0.25); border-color: var(--emerald); box-shadow: 0 0 14px rgba(74,222,128,0.55); animation: cov-in 0.5s cubic-bezier(.2,.7,.2,1) forwards, cp 2.6s ease-in-out 1.5s infinite; }
+    @keyframes cp { 0%,100%{box-shadow:0 0 14px rgba(74,222,128,0.55)} 50%{box-shadow:0 0 26px rgba(74,222,128,0.9)} }
+    .cov-summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; margin-top: 32px; padding-top: 24px; border-top: 1px solid var(--hairline); }
+    .cov-summary .s { padding: 6px 18px; border-left: 1px solid var(--hairline); }
+    .cov-summary .s:first-child { border-left: none; padding-left: 0; }
+    .cov-summary .k { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; }
+    .cov-summary .v { font-family: 'Space Grotesk', sans-serif; font-size: 38px; font-weight: 700; color: var(--text); margin: 8px 0 2px; letter-spacing: -0.025em; }
+    .cov-summary .v.emerald { color: var(--emerald); text-shadow: 0 0 14px rgba(74,222,128,0.4); }
+    .cov-summary .v.amber { color: var(--amber); text-shadow: 0 0 14px var(--amber-glow); }
+    .cov-summary .v.rose { color: var(--rose); }
+    .cov-summary .sub { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.08em; }
+    .queue-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; align-items: baseline; }
+    .queue-row:last-child { border-bottom: none; }
+    .queue-row .left { display: flex; flex-direction: column; gap: 3px; }
+    .queue-row .eid { font-size: 12px; color: var(--text); font-weight: 500; }
+    .queue-row .meta { font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; }
+    .queue-row .meta .anchor { color: var(--rose); font-weight: 600; }
+    .queue-row .meta .high { color: var(--amber); font-weight: 600; }
+    .queue-row .meta .med { color: var(--text-2); font-weight: 600; }
+    .queue-row .pri { font-family: 'Space Grotesk', sans-serif; font-size: 18px; font-weight: 600; color: var(--text); }
+    .queue-row .pri.amber { color: var(--amber); }
+    .legend-rail { display: flex; gap: 22px; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; }
+    .legend-rail .sw { width: 9px; height: 9px; display: inline-block; margin-right: 7px; vertical-align: middle; transform: translateY(-1px); }
+    .legend-rail .lbl { color: var(--text-3); }
+    .legend-rail .v { color: var(--text); margin-left: 5px; font-weight: 700; }
+  </style>
+</head>
+<body data-view="coverage">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 02 — corpus coverage</div>
+    <h1>121 events. <em>One complete.</em> The rest is the work.</h1>
+    <p class="sub">Each cell is one catalogued event coloured by <span class="mono" style="color:var(--amber)">coverage.json</span> status. Hover for the eid; click to open the dossier. Priority queue on the right ranks the highest-impact pages awaiting a transcriber.</p>
+  </section>
+
+  <section class="body2">
+    <div class="cov-card">
+      <div style="display:flex;align-items:baseline;justify-content:space-between;margin-bottom:18px">
+        <span class="mono" style="font-size:11px;letter-spacing:0.26em;color:var(--text-2);font-weight:700">▣ &nbsp; COVERAGE MATRIX · RELEASE 01</span>
+        <span class="mono" style="font-size:10px;color:var(--text-4);letter-spacing:0.2em">SORTED BY STATUS</span>
+      </div>
+      <div class="legend-rail" style="margin-bottom:10px">
+        <span><span class="sw" style="background:var(--emerald);box-shadow:0 0 8px rgba(74,222,128,0.6)"></span><span class="lbl">COMPLETE</span><span class="v">1</span></span>
+        <span><span class="sw" style="background:rgba(242,166,35,0.4);border:1px solid var(--amber)"></span><span class="lbl">PARTIAL</span><span class="v">63</span></span>
+        <span><span class="sw" style="background:#0A1018;border:1px solid #182232"></span><span class="lbl">EMPTY</span><span class="v">57</span></span>
+      </div>
+      <div class="cov-grid" id="cg"></div>
+      <div class="cov-summary">
+        <div class="s"><div class="k">Total catalogued</div><div class="v">121</div><div class="sub">of 162 R01 inventory</div></div>
+        <div class="s"><div class="k">Complete</div><div class="v emerald" data-count="1">0</div><div class="sub">all pages OCR'd · 0.8%</div></div>
+        <div class="s"><div class="k">Partial</div><div class="v amber" data-count="63">0</div><div class="sub">gap pages remain · 52%</div></div>
+        <div class="s"><div class="k">No data</div><div class="v rose" data-count="57">0</div><div class="sub">no body text · 47%</div></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-head"><span><span class="icon-sq"></span>Priority queue</span><span class="right">next-missing.json</span></div>
+      <p style="font-size:11px;color:var(--text-3);line-height:1.6;font-family:'JetBrains Mono',monospace;letter-spacing:0.04em;margin:0 0 16px">Scored: flag-weight × (1 + gapPages/10) × (1 + chars/10000). Top of this list is the deep-link target for the LIVE-view CTA "Open the next missing page →".</p>
+      <div class="queue-row"><div class="left"><span class="eid">indopacom-2024</span><span class="meta"><span class="anchor">ANCHOR</span> · 24pp · 0%</span></div><span class="pri amber">4.00</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">pursue-release-01</span><span class="meta"><span class="anchor">ANCHOR</span> · 12pp · 0%</span></div><span class="pri amber">4.00</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">pursue-release-02</span><span class="meta"><span class="anchor">ANCHOR</span> · 8pp · 0%</span></div><span class="pri amber">4.00</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">army-2026</span><span class="meta"><span class="high">HIGH</span> · 14pp · 0%</span></div><span class="pri">3.00</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">dow-uap-d62</span><span class="meta"><span class="med">MED</span> · 9pp · 0%</span></div><span class="pri">2.20</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">dow-uap-d65</span><span class="meta"><span class="med">MED</span> · 8pp · 0%</span></div><span class="pri">2.16</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">dow-uap-d63</span><span class="meta"><span class="med">MED</span> · 8pp · 0%</span></div><span class="pri">2.16</span></div>
+      <div class="queue-row"><div class="left"><span class="eid">dow-uap-d54</span><span class="meta"><span class="med">MED</span> · 7pp · 23%</span></div><span class="pri">2.14</span></div>
+      <a class="primary-cta" href="review.html" style="margin-top:24px;width:100%;justify-content:center">Open queue head <span>→</span></a>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+<script>
+  const cls = []; cls.push('complete'); for (let i=0;i<63;i++) cls.push('partial'); for (let i=0;i<57;i++) cls.push('');
+  let s = 17; const rng = () => (s = (s*1103515245+12345)&0x7fffffff)/0x7fffffff;
+  for (let i = cls.length-1; i>0; i--) { const j = Math.floor(rng()*(i+1)); [cls[i],cls[j]]=[cls[j],cls[i]]; }
+  const ci = cls.indexOf('complete'); cls.splice(ci,1); cls.splice(28,0,'complete');
+  const grid = document.getElementById('cg');
+  cls.forEach((c,i) => { const d=document.createElement('div'); d.className='cov-cell'+(c?' '+c:''); d.style.animationDelay=(300+i*5)+'ms'; grid.appendChild(d); });
+</script>
+</body>
+</html>

--- a/public/mc/dossier.html
+++ b/public/mc/dossier.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Dossier</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .ds-header { padding: 48px 56px 20px; position: relative; z-index: 4; }
+    .ds-header .meta-row { display: flex; align-items: center; gap: 14px; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); letter-spacing: 0.20em; margin-bottom: 20px; text-transform: uppercase; }
+    .ds-header .meta-row .anchor { color: var(--rose); padding: 3px 10px; border: 1px solid rgba(224,73,104,0.5); background: rgba(224,73,104,0.08); font-size: 9px; font-weight: 700; letter-spacing: 0.24em; }
+    .ds-header .meta-row .id { color: var(--cyan); }
+    .ds-header .meta-row .stamp { color: var(--amber); }
+    .ds-header h1 { font-family: 'Space Grotesk', sans-serif; font-size: 52px; font-weight: 700; line-height: 1.05; color: var(--text); letter-spacing: -0.028em; margin: 0; max-width: 1100px; }
+    .ds-body { padding: 0 56px 64px; display: grid; grid-template-columns: minmax(0, 1fr) 380px; gap: 32px; position: relative; z-index: 3; }
+    .ds-main { display: flex; flex-direction: column; gap: 26px; }
+    .ds-section { background: var(--surface); border: 1px solid var(--border); padding: 26px 30px; backdrop-filter: blur(10px); }
+    .ds-h { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 14px; margin-bottom: 18px; border-bottom: 1px solid var(--hairline); }
+    .ds-h .t { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.28em; color: var(--text-2); text-transform: uppercase; display: flex; align-items: center; gap: 10px; }
+    .ds-h .t .icon { width: 6px; height: 6px; background: var(--amber); transform: rotate(45deg); display: inline-block; box-shadow: 0 0 8px var(--amber-glow); }
+    .ds-h .r { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.16em; }
+    .ds-summary { font-family: 'Inter', sans-serif; font-size: 16px; line-height: 1.7; color: var(--text-2); }
+    .ds-summary em { color: var(--text); font-style: normal; font-weight: 500; background: rgba(242,166,35,0.08); padding: 0 4px; }
+    .sig-grid { display: grid; grid-template-columns: 100px 1fr; gap: 14px 20px; font-family: 'JetBrains Mono', monospace; }
+    .sig-grid .label { font-size: 10px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; padding-top: 6px; }
+    .sig-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+    .sig-chip { background: var(--surface-2); border: 1px solid var(--border); padding: 5px 11px; font-size: 11px; color: var(--text-2); }
+    .sig-chip .v { color: var(--text); font-weight: 600; margin-left: 6px; }
+    .sig-chip.shape { color: #B280FF; border-color: rgba(178,128,255,0.3); }
+    .sig-chip.behavior { color: #FFD93D; border-color: rgba(255,217,61,0.3); }
+    .sig-chip.sensor { color: var(--cyan); border-color: rgba(97,215,240,0.3); }
+    .ed-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; }
+    .ent-row { display: flex; align-items: baseline; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
+    .ent-row:last-child { border-bottom: none; }
+    .ent-row .name { color: var(--text-2); }
+    .ent-row .docs { color: var(--cyan); font-size: 9px; letter-spacing: 0.14em; }
+    .ent-row .ct { color: var(--amber); font-family: 'Space Grotesk', sans-serif; font-weight: 600; font-size: 14px; }
+    .date-scatter { height: 80px; position: relative; padding-bottom: 18px; border-bottom: 1px solid var(--hairline); }
+    .date-scatter .pt { position: absolute; width: 6px; height: 6px; border-radius: 50%; background: var(--cyan); bottom: 22px; box-shadow: 0 0 6px rgba(97,215,240,0.5); }
+    .date-scatter .self { width: 12px; height: 12px; background: var(--emerald); border-radius: 0; box-shadow: 0 0 10px rgba(74,222,128,0.65); }
+    .date-axis { display: flex; justify-content: space-between; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.16em; padding-top: 6px; }
+    .excerpt { padding: 18px 0; border-bottom: 1px solid var(--hairline); }
+    .excerpt:last-child { border-bottom: none; }
+    .excerpt .meta { display: flex; align-items: center; gap: 10px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; margin-bottom: 10px; }
+    .excerpt .pg { background: rgba(97,215,240,0.10); border: 1px solid rgba(97,215,240,0.30); color: var(--cyan); padding: 2px 8px; font-size: 9px; letter-spacing: 0.18em; font-weight: 600; }
+    .excerpt p { font-family: 'Inter', sans-serif; font-size: 14px; line-height: 1.7; color: var(--text-2); margin: 0; }
+    .nb-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--hairline); align-items: center; cursor: pointer; }
+    .nb-row:last-child { border-bottom: none; }
+    .nb-row .left { display: flex; align-items: center; gap: 10px; min-width: 0; }
+    .nb-row .dot { width: 7px; height: 7px; flex-shrink: 0; }
+    .nb-row .dot.r { background: var(--rose); } .nb-row .dot.a { background: var(--amber); } .nb-row .dot.c { background: var(--cyan); } .nb-row .dot.z { background: var(--text-3); }
+    .nb-row .t { font-family: 'Inter', sans-serif; font-size: 12px; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .nb-row .cos { font-family: 'Space Grotesk', sans-serif; font-size: 13px; font-weight: 600; color: var(--cyan); }
+    .vis-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+    .vis-tile { aspect-ratio: 1; border: 1px solid var(--border); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; }
+    .vis-tile .k { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.14em; color: var(--text-3); }
+    .vis-tile .p { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); }
+    .vis-tile.photo { background: radial-gradient(circle at center, rgba(110,231,183,0.16), rgba(8,14,22,0.7)); }
+    .vis-tile.photo .k { color: #6EE7B7; }
+    .vis-tile.diagram { background: linear-gradient(135deg, rgba(178,128,255,0.14), rgba(8,14,22,0.7)); }
+    .vis-tile.diagram .k { color: #B280FF; }
+    .vis-tile.map { background: linear-gradient(135deg, rgba(244,114,182,0.14), rgba(8,14,22,0.7)); }
+    .vis-tile.map .k { color: #F472B6; }
+  </style>
+</head>
+<body data-view="dossier">
+
+<main>
+  <section class="ds-header">
+    <div class="meta-row">
+      <span class="anchor">ANCHOR</span>
+      <span class="id">USPER-2025</span>
+      <span>·</span>
+      <span>FBI</span>
+      <span>·</span>
+      <span class="stamp">SECRET//NOFORN</span>
+      <span>·</span>
+      <span>2025-10</span>
+      <span>·</span>
+      <span style="color:var(--text-3)">helicopter encounter at US military facility</span>
+    </div>
+    <h1>USPER Statement — orb gained elevation, came within ten feet of [the helicopter].</h1>
+  </section>
+
+  <section class="ds-body">
+    <div class="ds-main">
+
+      <div class="ds-section">
+        <div class="ds-h"><span class="t"><span class="icon"></span>SUMMARY</span><span class="r">curated</span></div>
+        <p class="ds-summary">Late 2025, SECRET//NOFORN. An FBI 302 from a senior US intelligence official aboard a search helicopter at a US military facility logs the moment an <em>LP/OP-tracked orb</em> "gained elevation, came within ten feet of [the helicopter]" — then split, then a swarm nobody could count. Multiple LP/OP positions reported the formation independently. <em>USCENTCOM</em> directed continued tracking but the swarm dispersed beyond visibility within fourteen seconds.</p>
+      </div>
+
+      <div class="ds-section">
+        <div class="ds-h"><span class="t"><span class="icon"></span>SIGNATURES</span><span class="r">patterns.json</span></div>
+        <div class="sig-grid">
+          <div class="label">SHAPE</div>
+          <div class="sig-chips">
+            <span class="sig-chip shape">orb <span class="v">23</span></span>
+            <span class="sig-chip shape">light <span class="v">11</span></span>
+            <span class="sig-chip shape">sphere <span class="v">7</span></span>
+          </div>
+          <div class="label">BEHAVIOR</div>
+          <div class="sig-chips">
+            <span class="sig-chip behavior">hover <span class="v">14</span></span>
+            <span class="sig-chip behavior">vertical <span class="v">9</span></span>
+            <span class="sig-chip behavior">split <span class="v">6</span></span>
+            <span class="sig-chip behavior">elevation <span class="v">3</span></span>
+          </div>
+          <div class="label">SENSOR</div>
+          <div class="sig-chips">
+            <span class="sig-chip sensor">visual <span class="v">8</span></span>
+            <span class="sig-chip sensor">LP/OP <span class="v">3</span></span>
+            <span class="sig-chip sensor">NVG <span class="v">2</span></span>
+            <span class="sig-chip sensor">FLIR <span class="v">1</span></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="ds-section">
+        <div class="ds-h"><span class="t"><span class="icon"></span>ENTITIES &amp; DATES MENTIONED</span><span class="r">patterns.json · 199 ents · 67 dates</span></div>
+        <div class="ed-grid">
+          <div>
+            <div style="font-family:'JetBrains Mono',monospace;font-size:9px;color:var(--text-4);letter-spacing:0.18em;margin-bottom:10px;text-transform:uppercase">ENTITIES (8 in event)</div>
+            <div class="ent-row"><span class="name">USCENTCOM</span><span class="docs">→ 18 docs</span><span class="ct">7</span></div>
+            <div class="ent-row"><span class="name">Air Force</span><span class="docs">→ 23 docs</span><span class="ct">4</span></div>
+            <div class="ent-row"><span class="name">FBI</span><span class="docs">→ 26 docs</span><span class="ct">3</span></div>
+            <div class="ent-row"><span class="name">Chief of Staff</span><span class="docs">→ 12 docs</span><span class="ct">3</span></div>
+            <div class="ent-row"><span class="name">AARO</span><span class="docs">→ 9 docs</span><span class="ct">2</span></div>
+            <div class="ent-row"><span class="name">Operations Center</span><span class="docs">→ 7 docs</span><span class="ct">2</span></div>
+            <div class="ent-row"><span class="name">USPER 1</span><span class="docs">→ 4 docs</span><span class="ct">2</span></div>
+            <div class="ent-row"><span class="name">USPER 2</span><span class="docs">→ 4 docs</span><span class="ct">1</span></div>
+          </div>
+          <div>
+            <div style="font-family:'JetBrains Mono',monospace;font-size:9px;color:var(--text-4);letter-spacing:0.18em;margin-bottom:10px;text-transform:uppercase">DATES (12 in event · spanning 1948–2024)</div>
+            <div class="date-scatter">
+              <span class="pt" style="left:5%;bottom:18px"></span>
+              <span class="pt" style="left:11%;bottom:26px"></span>
+              <span class="pt" style="left:18%;bottom:20px"></span>
+              <span class="pt" style="left:24%;bottom:38px"></span>
+              <span class="pt" style="left:33%;bottom:22px"></span>
+              <span class="pt" style="left:41%;bottom:30px"></span>
+              <span class="pt" style="left:52%;bottom:24px"></span>
+              <span class="pt" style="left:63%;bottom:46px"></span>
+              <span class="pt" style="left:72%;bottom:24px"></span>
+              <span class="pt" style="left:80%;bottom:36px"></span>
+              <span class="pt" style="left:86%;bottom:20px"></span>
+              <span class="pt self" style="left:93%;bottom:30px" title="this event 2025-10"></span>
+            </div>
+            <div class="date-axis"><span>1940</span><span>1960</span><span>1980</span><span>2000</span><span>2020</span></div>
+            <div style="display:flex;gap:14px;margin-top:14px;font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.06em">
+              <span style="color:var(--cyan)">● mentioned</span>
+              <span style="color:var(--emerald)">■ this event</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="ds-section">
+        <div class="ds-h"><span class="t"><span class="icon"></span>EXCERPTS BY PAGE</span><span class="r">vision-cache · 12 pages</span></div>
+        <div class="excerpt">
+          <div class="meta"><span class="pg">PAGE 03</span><span>vision · q=0.94</span><span>·</span><span>LP/OP report</span></div>
+          <p>"…the orb gained elevation and came within ten feet of [the helicopter] before separating into multiple objects of indeterminate count. LP/OP-1 reported the formation continued moving westward; LP/OP-2 reported it was 'now multiple lights' approximately ten seconds later…"</p>
+        </div>
+        <div class="excerpt">
+          <div class="meta"><span class="pg">PAGE 07</span><span>vision · q=0.89</span><span>·</span><span>USCENTCOM tasking</span></div>
+          <p>"…USCENTCOM directed continued tracking but the swarm dispersed beyond LP/OP visibility within fourteen seconds. Returning aircrew reported no anomalies in radar return or onboard FLIR; the encounter was visually-confirmed only…"</p>
+        </div>
+        <div class="excerpt">
+          <div class="meta"><span class="pg">PAGE 11</span><span>vision · q=0.81</span><span>·</span><span>witness 1 statement</span></div>
+          <p>"…[WITNESS 1] reported that the lead orb was 'too close to look at directly through the canopy' and that he had 'never seen anything fly that way' in 28 years of service. The pilots concurred but declined to provide a written statement…"</p>
+        </div>
+      </div>
+    </div>
+
+    <aside class="ds-main">
+      <div class="ds-section">
+        <div class="ds-h"><span class="t"><span class="icon"></span>SEMANTIC NEIGHBORS</span><span class="r">10 · event-similarity.json</span></div>
+        <div class="nb-row"><div class="left"><span class="dot r"></span><span class="t">middle-east-may-2020 range fouler debrief</span></div><span class="cos">0.94</span></div>
+        <div class="nb-row"><div class="left"><span class="dot r"></span><span class="t">southern-us-2020 targeting pod track</span></div><span class="cos">0.92</span></div>
+        <div class="nb-row"><div class="left"><span class="dot a"></span><span class="t">fbi-62hq83894 section 2 (1947)</span></div><span class="cos">0.87</span></div>
+        <div class="nb-row"><div class="left"><span class="dot a"></span><span class="t">fbi-62hq83894 section 5</span></div><span class="cos">0.82</span></div>
+        <div class="nb-row"><div class="left"><span class="dot r"></span><span class="t">dow-uap-d44 range fouler form</span></div><span class="cos">0.79</span></div>
+        <div class="nb-row"><div class="left"><span class="dot a"></span><span class="t">uae-june-2024 mission report</span></div><span class="cos">0.76</span></div>
+        <div class="nb-row"><div class="left"><span class="dot a"></span><span class="t">dow-uap-d35 greece-oct-2023</span></div><span class="cos">0.71</span></div>
+        <div class="nb-row"><div class="left"><span class="dot z"></span><span class="t">gemini-7 bogey trillions particles</span></div><span class="cos">0.64</span></div>
+        <div class="nb-row"><div class="left"><span class="dot a"></span><span class="t">dow-uap-d48 air force report 1996</span></div><span class="cos">0.58</span></div>
+        <div class="nb-row"><div class="left"><span class="dot z"></span><span class="t">1949-discs radar scope</span></div><span class="cos">0.52</span></div>
+      </div>
+
+      <div class="ds-section">
+        <div class="ds-h"><span class="t"><span class="icon"></span>VISUALS</span><span class="r">6 tiles</span></div>
+        <div class="vis-grid">
+          <div class="vis-tile photo"><span class="k">[PHOTO]</span><span class="p">p03</span></div>
+          <div class="vis-tile diagram"><span class="k">[DIAGRAM]</span><span class="p">p05</span></div>
+          <div class="vis-tile map"><span class="k">[MAP]</span><span class="p">p06</span></div>
+          <div class="vis-tile photo"><span class="k">[PHOTO]</span><span class="p">p07</span></div>
+          <div class="vis-tile diagram"><span class="k">[DIAGRAM]</span><span class="p">p08</span></div>
+          <div class="vis-tile photo"><span class="k">[PHOTO]</span><span class="p">p09</span></div>
+        </div>
+      </div>
+    </aside>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+</body>
+</html>

--- a/public/mc/globe.html
+++ b/public/mc/globe.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Globe</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .gl-shell { padding: 0 56px 64px; display: grid; grid-template-columns: minmax(0,1fr) 360px; gap: 24px; position: relative; z-index: 3; align-items: start; }
+    .gl-card { background: var(--surface); border: 1px solid var(--border); padding: 28px; backdrop-filter: blur(10px); position: relative; overflow: hidden; }
+    .gl-card::before { content: ''; position: absolute; left: 0; right: 0; top: 0; height: 2px; background: linear-gradient(90deg, transparent, var(--amber), transparent); animation: glscan 8s linear infinite; box-shadow: 0 0 18px var(--amber-glow); }
+    @keyframes glscan { 0%{transform:translateY(0);opacity:0} 8%{opacity:1} 92%{opacity:1} 100%{transform:translateY(700px);opacity:0} }
+    .gl-h { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 18px; margin-bottom: 22px; border-bottom: 1px solid var(--hairline); }
+    .gl-h .t { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.30em; color: var(--text-2); text-transform: uppercase; display: flex; align-items: center; gap: 10px; }
+    .gl-h .t .icon { width: 14px; height: 14px; border: 1px solid var(--amber); transform: rotate(45deg); position: relative; }
+    .gl-h .t .icon::before { content: ''; position: absolute; inset: 3px; background: var(--amber); box-shadow: 0 0 8px var(--amber-glow); }
+    .gl-h .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.16em; }
+    .globe-svg { width: 100%; height: 600px; display: block; margin: 0 auto; }
+    .longitude, .latitude { fill: none; stroke: rgba(242,166,35,0.10); stroke-width: 0.5; }
+    .equator, .prime { stroke: rgba(242,166,35,0.20); stroke-width: 0.8; }
+    .land { fill: rgba(110, 138, 124, 0.10); stroke: rgba(110, 138, 124, 0.35); stroke-width: 0.6; }
+    .pin { animation: pin-pulse 2.6s ease-in-out infinite; transform-origin: center; }
+    .pin:nth-child(3n){animation-delay:0.4s}.pin:nth-child(3n+1){animation-delay:1.4s}
+    @keyframes pin-pulse { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    .gl-ctl { display: flex; align-items: center; gap: 10px; padding: 14px 0 0; margin-top: 16px; border-top: 1px solid var(--hairline); }
+    .gl-ctl .btn { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; color: var(--text-3); background: var(--surface-2); border: 1px solid var(--border); padding: 8px 14px; cursor: pointer; text-transform: uppercase; }
+    .gl-ctl .btn.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.08); }
+    .gl-ctl .meta { margin-left: auto; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.18em; }
+    .reg-row { display: flex; align-items: center; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
+    .reg-row:last-child { border-bottom: none; }
+    .reg-row .l { display: flex; align-items: center; gap: 10px; color: var(--text-2); letter-spacing: 0.06em; }
+    .reg-row .l .d { width: 9px; height: 9px; }
+    .reg-row .ct { font-family: 'Space Grotesk', sans-serif; font-weight: 600; font-size: 16px; color: var(--text); }
+    .reg-row .ct.cold { color: var(--rose); }
+  </style>
+</head>
+<body data-view="globe">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 10 — orbital projection</div>
+    <h1>220 events plotted by lat/lon. <em>The blank zones tell their own story.</em></h1>
+    <p class="sub">Pins encode region density: hot amber where multiple events cluster, cool cyan for single sightings. Africa and Oceania are nearly empty — archive gap, not data gap. Drag to spin · scroll to zoom · tap any pin to open its dossier.</p>
+  </section>
+
+  <section class="gl-shell">
+    <div class="gl-card">
+      <div class="gl-h">
+        <div class="t"><div class="icon"></div>WORLD VIEW · ORTHOGRAPHIC</div>
+        <div class="meta">LAT/LON · 220 EVENTS · projection equirectangular</div>
+      </div>
+
+      <svg class="globe-svg" viewBox="0 0 1100 580" xmlns="http://www.w3.org/2000/svg">
+        <!-- Latitude/longitude grid -->
+        <g>
+          <line class="longitude" x1="100"  y1="40" x2="100"  y2="540"/>
+          <line class="longitude" x1="225"  y1="40" x2="225"  y2="540"/>
+          <line class="longitude" x1="350"  y1="40" x2="350"  y2="540"/>
+          <line class="longitude prime" x1="475"  y1="40" x2="475"  y2="540"/>
+          <line class="longitude" x1="600"  y1="40" x2="600"  y2="540"/>
+          <line class="longitude" x1="725"  y1="40" x2="725"  y2="540"/>
+          <line class="longitude" x1="850"  y1="40" x2="850"  y2="540"/>
+          <line class="longitude" x1="975"  y1="40" x2="975"  y2="540"/>
+
+          <line class="latitude" x1="80" y1="100" x2="1020" y2="100"/>
+          <line class="latitude" x1="80" y1="180" x2="1020" y2="180"/>
+          <line class="latitude equator" x1="80" y1="290" x2="1020" y2="290"/>
+          <line class="latitude" x1="80" y1="400" x2="1020" y2="400"/>
+          <line class="latitude" x1="80" y1="480" x2="1020" y2="480"/>
+
+          <!-- coord labels -->
+          <text x="80" y="35" fill="rgba(184,168,135,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.14em">180°W</text>
+          <text x="475" y="35" fill="rgba(184,168,135,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.14em" text-anchor="middle">0°</text>
+          <text x="1020" y="35" fill="rgba(184,168,135,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.14em" text-anchor="end">180°E</text>
+          <text x="70" y="293" fill="rgba(184,168,135,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.14em" text-anchor="end">0° EQ</text>
+          <text x="70" y="103" fill="rgba(184,168,135,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.14em" text-anchor="end">60°N</text>
+          <text x="70" y="483" fill="rgba(184,168,135,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.14em" text-anchor="end">60°S</text>
+        </g>
+
+        <!-- Very abstract continent silhouettes (stylized blobs) -->
+        <g>
+          <!-- North America -->
+          <path class="land" d="M 130 150 Q 170 130 230 145 Q 280 160 290 200 Q 310 240 280 290 Q 250 310 210 305 Q 175 295 155 270 Q 135 240 130 200 Z"/>
+          <!-- South America -->
+          <path class="land" d="M 270 340 Q 290 330 305 350 Q 315 390 310 440 Q 300 480 285 480 Q 268 470 265 430 Q 263 380 270 340 Z"/>
+          <!-- Europe -->
+          <path class="land" d="M 470 165 Q 510 155 540 175 Q 555 195 545 215 Q 525 225 495 220 Q 470 210 465 190 Z"/>
+          <!-- Africa -->
+          <path class="land" d="M 490 240 Q 530 230 555 250 Q 575 290 570 340 Q 560 390 535 415 Q 510 425 490 405 Q 475 360 480 310 Q 485 270 490 240 Z"/>
+          <!-- Asia -->
+          <path class="land" d="M 580 145 Q 660 130 750 145 Q 820 160 850 200 Q 855 250 820 270 Q 750 285 680 280 Q 620 270 590 240 Q 575 200 580 145 Z"/>
+          <!-- Australia -->
+          <path class="land" d="M 800 370 Q 850 360 880 385 Q 885 415 860 425 Q 820 425 800 410 Q 790 390 800 370 Z"/>
+          <!-- Antarctica band -->
+          <path class="land" d="M 80 525 Q 300 510 500 525 Q 700 535 1020 520 L 1020 545 L 80 545 Z" opacity="0.5"/>
+        </g>
+
+        <!-- Event pins -->
+        <!-- North America cluster — 80 events -->
+        <g class="pin"><circle cx="200" cy="220" r="11" fill="none" stroke="rgba(242,166,35,0.55)" stroke-width="0.6"/><circle cx="200" cy="220" r="7" fill="rgba(242,166,35,0.85)" /><text x="218" y="218" fill="rgba(242,166,35,0.85)" font-family="JetBrains Mono" font-size="10" font-weight="600">NA · 80</text></g>
+        <g class="pin"><circle cx="240" cy="260" r="5" fill="#F2A623"/></g>
+        <g class="pin"><circle cx="180" cy="180" r="4" fill="#F2A623"/></g>
+        <g class="pin"><circle cx="260" cy="240" r="4" fill="#F2A623"/></g>
+
+        <!-- Middle East cluster — 77 events -->
+        <g class="pin"><circle cx="595" cy="245" r="11" fill="none" stroke="rgba(242,166,35,0.55)" stroke-width="0.6"/><circle cx="595" cy="245" r="7" fill="rgba(242,166,35,0.85)"/><text x="610" y="243" fill="rgba(242,166,35,0.85)" font-family="JetBrains Mono" font-size="10" font-weight="600">ME · 77</text></g>
+        <g class="pin"><circle cx="610" cy="265" r="4" fill="#F2A623"/></g>
+        <g class="pin"><circle cx="580" cy="225" r="4" fill="#F2A623"/></g>
+
+        <!-- Europe — 14 events -->
+        <g class="pin"><circle cx="510" cy="200" r="6" fill="rgba(97,215,240,0.85)"/><text x="525" y="200" fill="rgba(97,215,240,0.85)" font-family="JetBrains Mono" font-size="10">EU · 14</text></g>
+
+        <!-- Asia Pacific — 10 events -->
+        <g class="pin"><circle cx="740" cy="230" r="5" fill="rgba(97,215,240,0.85)"/><text x="755" y="230" fill="rgba(97,215,240,0.85)" font-family="JetBrains Mono" font-size="10">AP · 10</text></g>
+
+        <!-- Asia — 4 events -->
+        <g class="pin"><circle cx="680" cy="215" r="4" fill="rgba(97,215,240,0.7)"/></g>
+
+        <!-- Africa — 4 events (sparse) -->
+        <g class="pin"><circle cx="520" cy="350" r="3.5" fill="rgba(224,73,104,0.85)"/><text x="535" y="352" fill="rgba(224,73,104,0.85)" font-family="JetBrains Mono" font-size="9">AF · 4</text></g>
+
+        <!-- Oceania — 1 event (sparse) -->
+        <g class="pin"><circle cx="840" cy="400" r="3" fill="rgba(224,73,104,0.8)"/><text x="853" y="402" fill="rgba(224,73,104,0.7)" font-family="JetBrains Mono" font-size="9">OC · 1</text></g>
+
+        <!-- Space band -->
+        <g>
+          <text x="475" y="55" fill="rgba(74,222,128,0.6)" font-family="JetBrains Mono" font-size="9" text-anchor="middle" letter-spacing="0.18em">LEO + ORBIT · 18 EVENTS</text>
+          <g class="pin"><circle cx="475" cy="70" r="4" fill="rgba(74,222,128,0.85)"/></g>
+          <g class="pin"><circle cx="540" cy="74" r="3" fill="rgba(74,222,128,0.7)"/></g>
+          <g class="pin"><circle cx="410" cy="68" r="3" fill="rgba(74,222,128,0.7)"/></g>
+        </g>
+
+        <!-- Center crosshair -->
+        <line x1="475" y1="285" x2="475" y2="295" stroke="rgba(244,236,212,0.5)" stroke-width="1"/>
+        <line x1="470" y1="290" x2="480" y2="290" stroke="rgba(244,236,212,0.5)" stroke-width="1"/>
+      </svg>
+
+      <div class="gl-ctl">
+        <span class="btn active">EQUIRECTANGULAR</span>
+        <span class="btn">ORTHOGRAPHIC</span>
+        <span class="btn">MERCATOR</span>
+        <span class="meta">ROTATE · ZOOM · TAP A PIN</span>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-head"><span><span class="icon-sq"></span>Region totals</span><span class="right">EVENTS.json</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--amber);box-shadow:0 0 6px var(--amber-glow)"></span>North America</span><span class="ct">80</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--amber);box-shadow:0 0 6px var(--amber-glow)"></span>Middle East</span><span class="ct">77</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--emerald);box-shadow:0 0 6px rgba(74,222,128,0.6)"></span>Space / orbit</span><span class="ct">18</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--cyan);box-shadow:0 0 6px rgba(97,215,240,0.6)"></span>Europe</span><span class="ct">14</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--text-3)"></span>Unknown</span><span class="ct">12</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--cyan);box-shadow:0 0 6px rgba(97,215,240,0.6)"></span>Asia-Pacific</span><span class="ct">10</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--cyan)"></span>Asia</span><span class="ct">4</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--rose)"></span>Africa</span><span class="ct cold">4</span></div>
+      <div class="reg-row"><span class="l"><span class="d" style="background:var(--rose)"></span>Oceania</span><span class="ct cold">1</span></div>
+      <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;line-height:1.6;color:var(--text-3);letter-spacing:0.06em">Africa and Oceania are <span style="color:var(--rose)">near-empty</span> — likely an archive gap, not a data gap.</div>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+</body>
+</html>

--- a/public/mc/index.html
+++ b/public/mc/index.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · launch</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .launch-hero { padding: 80px 56px 28px; position: relative; z-index: 4; }
+    .launch-hero .eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--amber); letter-spacing: 0.32em; text-transform: uppercase; }
+    .launch-hero h1 {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 96px; font-weight: 700; line-height: 1.0;
+      color: var(--text); letter-spacing: -0.035em;
+      margin: 28px 0 22px; max-width: 1100px;
+    }
+    .launch-hero h1 em { font-style: normal; background: linear-gradient(95deg, var(--amber-bright), var(--amber), #B07816); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; text-shadow: 0 0 40px rgba(242, 166, 35, 0.3); }
+    .launch-hero p { font-size: 18px; line-height: 1.6; color: var(--text-2); max-width: 680px; }
+    .launch-grid {
+      padding: 32px 56px 64px;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 18px;
+      position: relative; z-index: 3;
+    }
+    .lc {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      padding: 24px 26px 22px;
+      backdrop-filter: blur(10px);
+      text-decoration: none;
+      color: inherit;
+      transition: all .25s;
+      position: relative;
+      display: flex; flex-direction: column;
+      min-height: 200px;
+      overflow: hidden;
+    }
+    .lc:hover { border-color: var(--border-strong); transform: translateY(-3px); box-shadow: 0 20px 40px -16px rgba(0,0,0,0.6); }
+    .lc::before {
+      content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
+      background: var(--amber); opacity: 0; transition: opacity .25s;
+    }
+    .lc:hover::before { opacity: 1; box-shadow: 0 0 10px var(--amber-glow); }
+    .lc .code { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.24em; color: var(--text-3); }
+    .lc h3 { font-family: 'Space Grotesk', sans-serif; font-size: 26px; font-weight: 600; margin: 8px 0 10px; letter-spacing: -0.02em; }
+    .lc p { font-size: 13px; line-height: 1.5; color: var(--text-2); margin: 0; flex: 1; }
+    .lc .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.14em; margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--hairline); display: flex; justify-content: space-between; }
+    .lc .meta .v { color: var(--amber); font-weight: 600; }
+    .lc.feat { grid-column: span 2; background: linear-gradient(135deg, rgba(242,166,35,0.10), rgba(12,19,28,0.55) 60%); border-color: var(--border-strong); }
+    .lc.feat h3 { font-size: 36px; }
+  </style>
+</head>
+<body data-view="">
+
+<main>
+  <section class="launch-hero">
+    <div class="eyebrow">▣ &nbsp; PURSUE Console · Mission Control · Release 3.0</div>
+    <h1>Investigate the record <em>the Department of War released.</em></h1>
+    <p>Eleven mission surfaces. Same corpus, ten access modes plus the launch grid. Every value bound to live JSON regenerated on every build. Every page implements the Mission Control tactical aesthetic.</p>
+  </section>
+
+  <section class="launch-grid">
+
+    <a class="lc feat" href="live.html">
+      <span class="code">SURFACE · 01</span>
+      <h3>Live</h3>
+      <p>Tactical overview with the corpus-coverage matrix, mission status readout, the arriving signals stream, telemetry rails, field assignments, and the mined-entity index. The home of the console.</p>
+      <span class="meta"><span>11×11 grid · radar dome · signals · help wanted</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="coverage.html">
+      <span class="code">SURFACE · 02</span>
+      <h3>Coverage</h3>
+      <p>Full-page coverage matrix. Every event ranked by completeness, with the priority queue and gap-status breakdown.</p>
+      <span class="meta"><span>121 events · 4 statuses</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="search.html">
+      <span class="code">SURFACE · 03</span>
+      <h3>Search</h3>
+      <p>Unified search with an EXACT/MEANING toggle. Lexical MiniSearch over 276 docs by default; flip to semantic for 5,665-chunk FAISS retrieval.</p>
+      <span class="meta"><span>2 modes · result cards</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="ask.html">
+      <span class="code">SURFACE · 04</span>
+      <h3>Ask</h3>
+      <p>Natural-language Q&A grounded in the corpus. Cite-by-page answers, pattern-classifier fallback when the LLM backend is offline.</p>
+      <span class="meta"><span>RAG · pattern · cited</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="review.html">
+      <span class="code">SURFACE · 05</span>
+      <h3>Review</h3>
+      <p>Disputed-page queue. Side-by-side source diffs, merged-text proposal, one-click GitHub PR.</p>
+      <span class="meta"><span>3 pending · diff viewer</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="media.html">
+      <span class="code">SURFACE · 06</span>
+      <h3>Media</h3>
+      <p>Photo · video · diagram · map · sketch gallery. 362 visual tiles across 135 events with kind + agency filters.</p>
+      <span class="meta"><span>362 tiles · DVIDS embedded</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="dossier.html">
+      <span class="code">SURFACE · 07</span>
+      <h3>Dossier</h3>
+      <p>Per-event reading view: summary, signatures, mined entities, semantic neighbors, page-by-page excerpts, visuals gallery.</p>
+      <span class="meta"><span>220 events</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="timeline.html">
+      <span class="code">SURFACE · 08</span>
+      <h3>Timeline</h3>
+      <p>Events plotted by decade — 1940s through 2020s — with agency color-coding and density bands.</p>
+      <span class="meta"><span>chronological strip</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="atlas.html">
+      <span class="code">SURFACE · 09</span>
+      <h3>Atlas</h3>
+      <p>Agency × era heatmap. Click any cell to drill into the events that anchor that cohort.</p>
+      <span class="meta"><span>8 agencies × 8 eras</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="globe.html">
+      <span class="code">SURFACE · 10</span>
+      <h3>Globe</h3>
+      <p>3D globe with event pins by lat/lon. Spin, zoom, tap a pin to jump into the dossier.</p>
+      <span class="meta"><span>orbital projection</span><span class="v">→</span></span>
+    </a>
+
+    <a class="lc" href="network.html">
+      <span class="code">SURFACE · 11</span>
+      <h3>Network</h3>
+      <p>Force-directed entity graph. Patterns × events × agencies, similarity-edge tunable.</p>
+      <span class="meta"><span>199 entities · 121 events</span><span class="v">→</span></span>
+    </a>
+
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+</body>
+</html>

--- a/public/mc/live.html
+++ b/public/mc/live.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Live</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .hero { padding: 64px 56px 48px; display: grid; grid-template-columns: minmax(0,1fr) 720px; gap: 56px; align-items: start; position: relative; z-index: 4; }
+    .hero h1 { font-family: 'Space Grotesk', sans-serif; font-size: 64px; font-weight: 700; line-height: 1.04; color: var(--text); letter-spacing: -0.028em; margin: 24px 0; max-width: 700px; }
+    .hero h1 em { font-style: normal; background: linear-gradient(95deg, var(--amber-bright), var(--amber), #B07816); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+    .hero p { font-size: 17px; line-height: 1.6; color: var(--text-2); max-width: 580px; }
+    .eyebrow { display: flex; align-items: center; gap: 18px; font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--amber); letter-spacing: 0.32em; text-transform: uppercase; }
+    .eyebrow .div { width: 32px; height: 1px; background: var(--amber); opacity: 0.6; }
+
+    .ms { margin-top: 36px; display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; border: 1px solid var(--border); background: var(--surface); max-width: 720px; }
+    .ms .cell { padding: 20px 22px; border-right: 1px solid var(--hairline); }
+    .ms .cell:last-child { border-right: none; }
+    .ms .k { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.28em; color: var(--text-3); text-transform: uppercase; margin-bottom: 8px; }
+    .ms .v { font-family: 'Space Grotesk', sans-serif; font-size: 30px; font-weight: 600; color: var(--text); line-height: 1; }
+    .ms .v.amber { color: var(--amber); text-shadow: 0 0 18px var(--amber-glow); }
+    .ms .v.rose { color: var(--rose); }
+    .ms .v.cyan { color: var(--cyan); }
+    .ms .v .small { font-size: 16px; color: var(--text-3); margin-left: 3px; }
+    .ms .sub { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.18em; margin-top: 4px; }
+
+    .cta-row { margin-top: 36px; display: flex; align-items: center; gap: 28px; }
+    .cta-meta { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); border-left: 1px solid var(--border); padding-left: 22px; line-height: 1.7; }
+    .cta-meta .ping { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--amber); margin-right: 7px; box-shadow: 0 0 8px var(--amber-glow); animation: pulse-soft 2.4s ease-in-out infinite; vertical-align: middle; transform: translateY(-1px); }
+    .cta-meta .v { color: var(--text); font-weight: 600; }
+
+    .ops-panel { position: relative; background: var(--surface); border: 1px solid var(--border); padding: 26px 28px; backdrop-filter: blur(14px); overflow: hidden; }
+    .ops-panel::before { content:''; position:absolute; left:0; right:0; top:0; height:2px; background: linear-gradient(90deg, transparent, var(--amber), transparent); box-shadow: 0 0 18px var(--amber-glow); animation: opscan 6s linear infinite; }
+    @keyframes opscan { 0%{transform:translateY(0);opacity:0} 8%{opacity:1} 92%{opacity:1} 100%{transform:translateY(700px);opacity:0} }
+    .ops-head { display: flex; align-items: center; justify-content: space-between; padding-bottom: 18px; margin-bottom: 22px; border-bottom: 1px solid var(--hairline); }
+    .ops-head .title { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.3em; color: var(--text); text-transform: uppercase; }
+    .ops-head .icon { width: 16px; height: 16px; border: 1px solid var(--amber); transform: rotate(45deg); position: relative; }
+    .ops-head .icon::before { content:''; position: absolute; inset: 4px; background: var(--amber); box-shadow: 0 0 8px var(--amber-glow); }
+    .ops-head .left { display: flex; align-items: center; gap: 12px; }
+    .ops-head .sub { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.18em; color: var(--text-3); }
+    .ops-head .sub .v { color: var(--amber); }
+
+    .rd-wrap { display: grid; grid-template-columns: 280px 1fr; gap: 26px; margin-bottom: 24px; align-items: start; }
+    .rd-stack { display: flex; flex-direction: column; gap: 12px; }
+    .rd-row { display: flex; align-items: baseline; gap: 10px; padding-bottom: 10px; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; }
+    .rd-row:last-child { border-bottom: none; }
+    .rd-row .k { font-size: 9px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; flex: 1; }
+    .rd-row .v { font-family: 'Space Grotesk', sans-serif; font-size: 22px; font-weight: 600; color: var(--text); }
+    .rd-row .v.amber { color: var(--amber); }
+    .rd-row .v.rose { color: var(--rose); }
+    .rd-row .v.emerald { color: var(--emerald); }
+    .rd-row .v.cyan { color: var(--cyan); }
+    .rd-row .pct { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); width: 46px; text-align: right; }
+
+    .sweep-g { transform-origin: 140px 140px; animation: sweep 5s linear infinite; }
+    @keyframes sweep { to { transform: rotate(360deg); } }
+    .ping-pulse { animation: ping-pulse 2.4s ease-in-out infinite; }
+    @keyframes ping-pulse { 0%,100%{opacity:0.55} 50%{opacity:1} }
+
+    .cw-titlerow { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 14px; }
+    .cw-titlerow .left { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 600; letter-spacing: 0.26em; color: var(--text-2); text-transform: uppercase; }
+    .cw-titlerow .left .accent { color: var(--amber); }
+    .cw-titlerow .right { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.2em; color: var(--text-4); }
+    .cw-legend { margin-top: 14px; display: flex; gap: 22px; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; }
+    .cw-legend .sw { width: 9px; height: 9px; display: inline-block; margin-right: 7px; vertical-align: middle; transform: translateY(-1px); }
+    .cw-legend .lbl { color: var(--text-3); }
+    .cw-legend .v { color: var(--text); margin-left: 5px; font-weight: 700; }
+
+    .body3 { padding: 0 56px 64px; display: grid; grid-template-columns: 340px minmax(0,1fr) 360px; gap: 22px; position: relative; z-index: 3; }
+    .stack { display: flex; flex-direction: column; gap: 22px; }
+    .histo { display: flex; align-items: flex-end; gap: 3px; height: 80px; }
+    .histo div { flex: 1; background: linear-gradient(180deg, var(--amber-bright), rgba(242, 166, 35, 0.20)); box-shadow: 0 0 6px rgba(242,166,35,0.30); }
+    .histo-axis { margin-top: 12px; display: flex; justify-content: space-between; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.18em; }
+    .ch-row { display: flex; align-items: center; justify-content: space-between; padding: 11px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
+    .ch-row:last-child { border-bottom: none; }
+    .ch-row .name { color: var(--text-2); letter-spacing: 0.10em; }
+    .ch-row .rate { color: var(--text-3); }
+    .ch-row .rate.v { color: var(--text); font-family: 'Space Grotesk', sans-serif; font-size: 16px; font-weight: 600; }
+
+    .signals-filter { display: flex; align-items: center; gap: 10px; margin-bottom: 22px; padding-bottom: 16px; border-bottom: 1px solid var(--hairline); }
+    .refresh { margin-left: auto; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.18em; cursor: pointer; }
+    .signal { padding: 18px 0; border-bottom: 1px solid var(--hairline); }
+    .signal:last-child { border-bottom: none; }
+    .signal-meta { display: flex; align-items: center; gap: 12px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); margin-bottom: 10px; letter-spacing: 0.10em; }
+    .signal-meta .tag { background: rgba(242, 166, 35, 0.08); border: 1px solid var(--border-strong); color: var(--amber); padding: 2px 8px; font-size: 9px; letter-spacing: 0.16em; font-weight: 600; }
+    .signal-meta .eid { color: var(--text); font-weight: 600; }
+    .signal-quote { font-size: 14px; line-height: 1.65; color: var(--text-2); max-width: 760px; }
+    .signal-quote em { color: var(--text); font-style: normal; font-weight: 500; background: rgba(242, 166, 35, 0.08); padding: 0 4px; }
+    .signal-quote .redacted { background: var(--text-4); color: var(--text-4); padding: 0 6px; border-radius: 1px; }
+
+    .help-row { display: flex; align-items: center; justify-content: space-between; padding: 13px 0; border-bottom: 1px solid var(--hairline); }
+    .help-row:last-child { border-bottom: none; }
+    .help-row .eid { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text); font-weight: 500; }
+    .help-row .pp { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); margin-left: 10px; }
+    .claim { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.20em; font-weight: 700; color: var(--amber); background: rgba(242, 166, 35, 0.10); border: 1px solid var(--border-strong); padding: 6px 14px; cursor: pointer; }
+
+    .entity-row { display: grid; grid-template-columns: 1fr auto auto; align-items: baseline; gap: 12px; font-family: 'JetBrains Mono', monospace; font-size: 11px; padding-bottom: 11px; }
+    .entity-row .name { color: var(--text-2); letter-spacing: 0.06em; }
+    .entity-row .meter { width: 70px; height: 3px; background: rgba(242, 166, 35, 0.10); }
+    .entity-row .meter span { display: block; height: 100%; background: var(--amber); box-shadow: 0 0 6px var(--amber-glow); }
+    .entity-row .count { color: var(--text); font-family: 'Space Grotesk', sans-serif; font-weight: 600; font-size: 14px; min-width: 50px; text-align: right; }
+  </style>
+</head>
+<body data-view="live">
+
+<main>
+  <section class="hero">
+    <div class="hero-left">
+      <div class="eyebrow"><span class="div"></span>Dept. of War · Declassified UAP · Release 01–02<span class="code" style="color:var(--text-3)">// 2026·05·08 → 2026·06·22</span></div>
+      <h1>The archive of what the Department of War released — <em>and what's still dark.</em></h1>
+      <p>Community-run. Every page transcribed in the open, catalogued event by event. Pages stream in as machine + volunteer transcriptions land — the gap is the mission.</p>
+      <div class="ms">
+        <div class="cell"><div class="k">Catalogued</div><div class="v"><span data-count="121">0</span><span class="small">/ 162</span></div><div class="sub">R01 inventory</div></div>
+        <div class="cell"><div class="k">Complete</div><div class="v amber" data-count="1">0</div><div class="sub">of 121 events</div></div>
+        <div class="cell"><div class="k">Awaiting</div><div class="v rose"><span data-count="46">0</span>%</div><div class="sub">no body text</div></div>
+        <div class="cell"><div class="k">R02 Intake</div><div class="v cyan"><span data-count="7">0</span><span class="small">/ 64</span></div><div class="sub">partial-mirror</div></div>
+      </div>
+      <div class="cta-row">
+        <a class="primary-cta" href="review.html">Open the next missing page <span>→</span></a>
+        <div class="cta-meta">
+          <div><span class="ping"></span>No account needed</div>
+          <div><span class="v">8</span> transcribers online · queue from <span style="color:var(--amber)">next-missing.json</span></div>
+        </div>
+      </div>
+    </div>
+
+    <aside class="ops-panel">
+      <div class="ops-head">
+        <div class="left">
+          <div class="icon"></div>
+          <div>
+            <div class="title">TACTICAL OVERVIEW</div>
+            <div class="sub">coverage.json · <span class="v">live</span></div>
+          </div>
+        </div>
+        <div class="sub">121 events</div>
+      </div>
+
+      <div class="rd-wrap">
+        <svg viewBox="0 0 280 280" width="280" height="280">
+          <defs>
+            <radialGradient id="sg"><stop offset="0%" stop-color="rgba(242,166,35,0.45)"/><stop offset="100%" stop-color="rgba(242,166,35,0)"/></radialGradient>
+          </defs>
+          <circle cx="140" cy="140" r="130" fill="none" stroke="rgba(242,166,35,0.16)" stroke-width="1"/>
+          <circle cx="140" cy="140" r="95"  fill="none" stroke="rgba(242,166,35,0.16)" stroke-width="1"/>
+          <circle cx="140" cy="140" r="58"  fill="none" stroke="rgba(242,166,35,0.16)" stroke-width="1"/>
+          <circle cx="140" cy="140" r="22"  fill="none" stroke="rgba(242,166,35,0.16)" stroke-width="1"/>
+          <line x1="140" y1="8"  x2="140" y2="272" stroke="rgba(242,166,35,0.10)" stroke-width="0.6"/>
+          <line x1="8"  y1="140" x2="272" y2="140" stroke="rgba(242,166,35,0.10)" stroke-width="0.6"/>
+          <g class="sweep-g"><path d="M140 140 L270 140 A130 130 0 0 1 200 240 Z" fill="url(#sg)" stroke="rgba(242,166,35,0.55)" stroke-width="0.7"/></g>
+          <g class="ping-pulse"><circle cx="200" cy="84" r="3.6" fill="#F2A623"/><circle cx="200" cy="84" r="8" fill="none" stroke="rgba(242,166,35,0.45)" stroke-width="0.6"/></g>
+          <g class="ping-pulse" style="animation-delay:0.6s"><circle cx="86" cy="68" r="3" fill="#61D7F0"/><circle cx="86" cy="68" r="7" fill="none" stroke="rgba(97,215,240,0.4)" stroke-width="0.5"/></g>
+          <g class="ping-pulse" style="animation-delay:1.4s"><circle cx="58" cy="196" r="3.4" fill="#F2A623"/></g>
+          <g class="ping-pulse" style="animation-delay:0.4s"><circle cx="198" cy="190" r="3.2" fill="#4ADE80"/><circle cx="198" cy="190" r="9" fill="none" stroke="rgba(74,222,128,0.5)" stroke-width="0.6"/></g>
+          <circle cx="140" cy="140" r="3" fill="var(--text)"/>
+          <text x="146" y="22" fill="rgba(180,160,120,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.2em">N</text>
+          <text x="262" y="146" fill="rgba(180,160,120,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.2em">E</text>
+          <text x="146" y="270" fill="rgba(180,160,120,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.2em">S</text>
+          <text x="12" y="146" fill="rgba(180,160,120,0.55)" font-family="JetBrains Mono" font-size="9" letter-spacing="0.2em">W</text>
+        </svg>
+        <div class="rd-stack">
+          <div class="rd-row"><span class="k">complete</span><span class="v emerald">1</span><span class="pct">0.8%</span></div>
+          <div class="rd-row"><span class="k">partial</span><span class="v amber">63</span><span class="pct">52%</span></div>
+          <div class="rd-row"><span class="k">no-data</span><span class="v rose">57</span><span class="pct">47%</span></div>
+          <div class="rd-row"><span class="k">events</span><span class="v">121</span><span class="pct">·</span></div>
+          <div class="rd-row"><span class="k">queue</span><span class="v cyan">57</span><span class="pct">cand</span></div>
+        </div>
+      </div>
+      <div class="cw-titlerow"><span class="left"><span class="accent">▣</span>&nbsp;&nbsp;COVERAGE MATRIX · per-event status</span><span class="right">click cell → dossier</span></div>
+      <div class="cw-grid" id="cw"></div>
+      <div class="cw-legend">
+        <span><span class="sw" style="background:var(--emerald);box-shadow:0 0 8px rgba(74,222,128,0.6)"></span><span class="lbl">COMPLETE</span><span class="v">1</span></span>
+        <span><span class="sw" style="background:rgba(242,166,35,0.4);border:1px solid var(--amber)"></span><span class="lbl">PARTIAL</span><span class="v">63</span></span>
+        <span><span class="sw" style="background:#0A1018;border:1px solid #182232"></span><span class="lbl">EMPTY</span><span class="v">57</span></span>
+      </div>
+    </aside>
+  </section>
+
+  <div class="section-divider"><span class="label">▸ FIELD OPERATIONS</span><span class="meta">live transcription stream · field assignments · mined index</span><div class="line"></div></div>
+
+  <section class="body3">
+    <div class="stack">
+      <div class="panel">
+        <div class="panel-head"><span><span class="icon-sq"></span>Ingest rate · 24h</span><span class="right">pages/hr</span></div>
+        <div class="histo" id="histo"></div>
+        <div class="histo-axis"><span>00</span><span>12</span><span>24</span></div>
+      </div>
+      <div class="panel">
+        <div class="panel-head"><span><span class="icon-sq"></span>Oscillation · 60s</span><span class="right">activity</span></div>
+        <svg viewBox="0 0 320 60" style="width:100%;height:60px;margin-top:6px"><polyline fill="none" stroke="#F2A623" stroke-width="1.8" opacity="0.9" points="0,30 22,22 44,36 66,16 88,40 110,24 132,32 154,10 176,44 198,20 220,36 242,28 264,30 286,22 308,30 320,28"/></svg>
+        <div class="histo-axis"><span>−60s</span><span>NOW</span></div>
+      </div>
+      <div class="panel">
+        <div class="panel-head"><span><span class="icon-sq"></span>Channels</span><span class="right">/hr</span></div>
+        <div class="ch-row"><span class="name">Vision</span><span class="rate">0 /hr</span></div>
+        <div class="ch-row"><span class="name">Tesseract</span><span class="rate">0 /hr</span></div>
+      </div>
+      <div class="panel">
+        <div class="panel-head"><span><span class="icon-sq"></span>Media types</span><span class="right">media.json</span></div>
+        <div class="ch-row"><span class="name">Document</span><span class="rate v">105</span></div>
+        <div class="ch-row"><span class="name">Photo</span><span class="rate v">13</span></div>
+        <div class="ch-row"><span class="name">Video</span><span class="rate v">94</span></div>
+        <div class="ch-row"><span class="name">Audio</span><span class="rate v">8</span></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-head"><span><span class="icon-sq"></span>Arriving signals</span><span class="right">vision × ocr · utc · most recent</span></div>
+      <div class="signals-filter">
+        <span class="pill active">All <span class="count">200</span></span>
+        <span class="pill">Vision <span class="count">3,402</span></span>
+        <span class="pill">Tesseract <span class="count">128</span></span>
+        <span class="refresh">↻ refresh</span>
+      </div>
+      <div class="signal">
+        <div class="signal-meta"><span>T + 16h</span><span class="tag">VISION</span><span class="eid">usper-2025</span><span>FBI · p1</span></div>
+        <p class="signal-quote">"<em>SECRET//NOFORN.</em> On <span class="redacted">_____</span> 2025, at approximately 1700 hours, [<em>witness 1 — a senior US intelligence official</em>] accompanied by two pilots from [<em>state partner organization</em>]…"</p>
+      </div>
+      <div class="signal">
+        <div class="signal-meta"><span>T + 16h</span><span class="tag">VISION</span><span class="eid">western-us-2023</span><span>DEPT/War · p2</span></div>
+        <p class="signal-quote">"<em>Large, Fiery Orb.</em> Two federal law-enforcement special agents witness a glowing orange orb at approximately 500–600 meters. Location: Western U.S. Time of day: dusk."</p>
+      </div>
+      <div class="signal">
+        <div class="signal-meta"><span>T + 16h</span><span class="tag">VISION</span><span class="eid">uae-june-2024</span><span>DEPT/War · p1</span></div>
+        <p class="signal-quote">"Declassified by MG Richard A. Harrison, <em>USCENTCOM</em> Chief of Staff. AT 2100Z <span class="redacted">_____</span> took off from OMAM via SLR. Proceeded to fragged tasking…"</p>
+      </div>
+      <div class="signal">
+        <div class="signal-meta"><span>T + 16h</span><span class="tag">VISION</span><span class="eid">netherlands-1948</span><span>DEPT/War · p3</span></div>
+        <p class="signal-quote">"[stamp: <em>SECRET</em>] USAFE 2 TT 1524 · 4 Nov 48 · To Gen Cabell: we now have one complete set of all reports prepared by special intelligence organization of the European Command…"</p>
+      </div>
+    </div>
+
+    <div class="stack">
+      <div class="panel">
+        <div class="panel-head"><span><span class="icon-sq"></span>Field assignments</span><span class="right">119 open</span></div>
+        <div class="help-row"><span><span class="eid">indopacom-2024</span><span class="pp">· ANCHOR · 24pp</span></span><button class="claim">CLAIM</button></div>
+        <div class="help-row"><span><span class="eid">army-2026</span><span class="pp">· HIGH · 14pp</span></span><button class="claim">CLAIM</button></div>
+        <div class="help-row"><span><span class="eid">dow-uap-d62</span><span class="pp">· MED · 9pp</span></span><button class="claim">CLAIM</button></div>
+        <div class="help-row"><span><span class="eid">dow-uap-d65</span><span class="pp">· MED · 8pp</span></span><button class="claim">CLAIM</button></div>
+      </div>
+      <div class="panel">
+        <div class="panel-head"><span><span class="icon-sq"></span>Mined index</span><span class="right">199 ents · 67 dates</span></div>
+        <div class="entity-row"><span class="name">USCENTCOM</span><span class="meter"><span style="width:90%"></span></span><span class="count">202</span></div>
+        <div class="entity-row"><span class="name">Air Force</span><span class="meter"><span style="width:100%"></span></span><span class="count">338</span></div>
+        <div class="entity-row"><span class="name">FBI</span><span class="meter"><span style="width:45%"></span></span><span class="count">88</span></div>
+        <div class="entity-row"><span class="name">AARO</span><span class="meter"><span style="width:18%"></span></span><span class="count">31</span></div>
+        <div class="entity-row"><span class="name">USAFE</span><span class="meter"><span style="width:16%"></span></span><span class="count">29</span></div>
+        <div class="entity-row"><span class="name">NORTHCOM</span><span class="meter"><span style="width:13%"></span></span><span class="count">24</span></div>
+        <div class="entity-row"><span class="name">Handwritten</span><span class="meter"><span style="width:100%"></span></span><span class="count">1,649</span></div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+<script>
+  const cls = []; cls.push('complete'); for (let i=0;i<63;i++) cls.push('partial'); for (let i=0;i<57;i++) cls.push('');
+  let s = 41; const rng = () => (s = (s*1103515245+12345)&0x7fffffff)/0x7fffffff;
+  for (let i = cls.length-1; i>0; i--) { const j = Math.floor(rng()*(i+1)); [cls[i],cls[j]]=[cls[j],cls[i]]; }
+  const ci = cls.indexOf('complete'); cls.splice(ci,1); cls.splice(35,0,'complete');
+  const grid = document.getElementById('cw');
+  cls.forEach((c,i) => { const d=document.createElement('div'); d.className='cw-cell'+(c?' '+c:''); d.style.animationDelay=(300+i*6)+'ms'; grid.appendChild(d); });
+  const h = document.getElementById('histo');
+  const bars = [2,1,0,0,1,3,5,8,12,9,7,11,6,4,9,14,10,6,3,8,5,2,1,0]; const mx = Math.max(...bars);
+  bars.forEach((b,i) => { const d=document.createElement('div'); d.style.height='0%'; h.appendChild(d); setTimeout(() => { d.style.transition='height .9s cubic-bezier(.2,.7,.2,1)'; d.style.height=((b/mx)*100)+'%'; }, 1400+i*28); });
+</script>
+</body>
+</html>

--- a/public/mc/media.html
+++ b/public/mc/media.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Media</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .md-shell { padding: 0 56px 64px; position: relative; z-index: 3; }
+    .md-filterbar { display: flex; align-items: center; gap: 10px; padding: 18px 0; flex-wrap: wrap; }
+    .md-pill { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; color: var(--text-3); background: var(--surface); border: 1px solid var(--border); padding: 8px 14px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; text-transform: uppercase; }
+    .md-pill .ic { width: 9px; height: 9px; background: var(--text-3); display: inline-block; }
+    .md-pill.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.10); box-shadow: 0 0 14px rgba(242,166,35,0.18); }
+    .md-pill .n { color: var(--text-4); margin-left: 4px; font-size: 9px; }
+    .md-pill.video .ic { background: #61D7F0; }
+    .md-pill.photo .ic { background: #6EE7B7; }
+    .md-pill.diagram .ic { background: #B280FF; }
+    .md-pill.map .ic { background: #F472B6; }
+    .md-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 14px; }
+    .tile { background: var(--surface); border: 1px solid var(--border); aspect-ratio: 1; padding: 0; backdrop-filter: blur(10px); cursor: pointer; transition: all .2s; position: relative; overflow: hidden; display: flex; flex-direction: column; }
+    .tile:hover { border-color: var(--border-strong); transform: translateY(-2px); }
+    .tile .thumb { flex: 1; background: linear-gradient(135deg, rgba(242,166,35,0.08), rgba(8,12,20,0.7)); position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+    .tile .thumb::after { content: ''; position: absolute; inset: 0; background-image: linear-gradient(rgba(242,166,35,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(242,166,35,0.06) 1px, transparent 1px); background-size: 18px 18px; opacity: 0.4; }
+    .tile.video .thumb { background: radial-gradient(circle at center, rgba(97,215,240,0.18), rgba(8,14,22,0.7)); }
+    .tile.photo .thumb { background: radial-gradient(circle at center, rgba(110,231,183,0.16), rgba(8,14,22,0.7)); }
+    .tile.diagram .thumb { background: linear-gradient(135deg, rgba(178,128,255,0.14), rgba(8,14,22,0.7)); }
+    .tile.map .thumb { background: linear-gradient(135deg, rgba(244,114,182,0.14), rgba(8,14,22,0.7)); }
+    .tile .icon { width: 36px; height: 36px; border: 1px solid var(--border-strong); display: flex; align-items: center; justify-content: center; font-family: 'JetBrains Mono', monospace; font-size: 14px; color: var(--text); z-index: 1; background: rgba(0,0,0,0.5); }
+    .tile.video .icon { color: #61D7F0; border-color: rgba(97,215,240,0.5); }
+    .tile.photo .icon { color: #6EE7B7; border-color: rgba(110,231,183,0.5); }
+    .tile.diagram .icon { color: #B280FF; border-color: rgba(178,128,255,0.5); }
+    .tile.map .icon { color: #F472B6; border-color: rgba(244,114,182,0.5); }
+    .tile .ribbon { position: absolute; left: 6px; top: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.14em; color: var(--text-3); background: rgba(0,0,0,0.6); padding: 2px 6px; border: 1px solid var(--hairline); text-transform: uppercase; }
+    .tile .views { position: absolute; right: 6px; top: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.1em; color: var(--text-3); background: rgba(0,0,0,0.6); padding: 2px 6px; border: 1px solid var(--hairline); }
+    .tile .views::before { content: '◉ '; color: var(--amber); }
+    .tile .footer { padding: 10px 12px; border-top: 1px solid var(--hairline); background: rgba(0,0,0,0.4); }
+    .tile .kind { font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; margin-bottom: 3px; }
+    .tile .title { font-size: 11px; color: var(--text); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+    .tile .ev { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); margin-top: 4px; letter-spacing: 0.06em; }
+  </style>
+</head>
+<body data-view="media">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 06 — visual library</div>
+    <h1>362 tiles. <em>Every diagram, every video, every page worth seeing.</em></h1>
+    <p class="sub">Photos · DVIDS sensor footage · diagrams · maps · sketches · scanned negatives. Tap any tile to open it; video tiles play inline via the DVIDS embed iframe.</p>
+  </section>
+
+  <section class="md-shell">
+    <div class="md-filterbar">
+      <span class="md-pill active"><span class="ic"></span>ALL <span class="n">362</span></span>
+      <span class="md-pill video"><span class="ic"></span>VIDEO <span class="n">106</span></span>
+      <span class="md-pill photo"><span class="ic"></span>PHOTO <span class="n">113</span></span>
+      <span class="md-pill"><span class="ic" style="background:#FFD93D"></span>HAND-DRAWING <span class="n">44</span></span>
+      <span class="md-pill diagram"><span class="ic"></span>DIAGRAM <span class="n">49</span></span>
+      <span class="md-pill map"><span class="ic"></span>MAP <span class="n">11</span></span>
+      <span class="md-pill"><span class="ic" style="background:#94A3B8"></span>NEGATIVE <span class="n">6</span></span>
+      <span style="margin-left:auto;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.18em">SORT · DVIDS VIEWS DESC · 135 EVENTS · media.json</span>
+    </div>
+
+    <div class="md-grid" id="grid"></div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+<script>
+  const data = [
+    {k:'video', t:'F/A-18 IR sensor pass · Pacific 2019', e:'pacific-2019', v:'1.2M'},
+    {k:'video', t:'Drone footage · CONUS sighting Mar 2020', e:'south-us-2020', v:'847K'},
+    {k:'photo', t:'Roswell incident debris field, 1947', e:'fbi-62hq-83894', v:'612K'},
+    {k:'diagram', t:'Atlas IIAS ship-hit contour A=3.00', e:'dow-uap-d48 · p63', v:''},
+    {k:'video', t:'Tic-tac sensor recording, 2004', e:'tic-tac-2004', v:'2.4M'},
+    {k:'photo', t:'Witness sketch — orange orb formation', e:'fbi-sept-2023-s3', v:''},
+    {k:'map', t:'Eastern Range impact contours', e:'dow-uap-d48 · p21', v:''},
+    {k:'photo', t:'USPER recreation drawing — "Dark Kite"', e:'western-us-2023', v:''},
+    {k:'video', t:'Range Fouler debrief footage, 2020', e:'dow-uap-pr36', v:'412K'},
+    {k:'diagram', t:'Mode-5 density-function curves', e:'dow-uap-d48 · p51', v:''},
+    {k:'photo', t:'Vandenberg Launch Summary cover', e:'dow-uap-d49 · p1', v:''},
+    {k:'video', t:'CENTCOM ISR mission audio + IR', e:'uae-june-2024', v:'298K'},
+    {k:'map', t:'Coverage map of impact dispersion', e:'dow-uap-d48 · p48', v:''},
+    {k:'photo', t:'1949 radar scope diagram', e:'1949-discs · p50', v:''},
+    {k:'video', t:'Apollo 17 onboard audio + photo', e:'nasa-apollo17', v:'89K'},
+    {k:'diagram', t:'LLV1 simulation results B=1,000', e:'dow-uap-d48 · p79', v:''},
+    {k:'photo', t:'Witness photograph — alleged craft', e:'fbi-photos-2025', v:''},
+    {k:'video', t:'DVIDS clip · Gen Patel briefing', e:'dow-uap-2026-05-08', v:'1.8M'},
+    {k:'map', t:'Atlas IIAS risk contours, A=3.5', e:'dow-uap-d48 · p21', v:''},
+    {k:'photo', t:'30th Space Wing patch — Vandenberg', e:'dow-uap-d49 · p1', v:''},
+  ];
+  const ICONS = { video: '▶', photo: '◫', diagram: '◬', map: '◐', sketch: '✎' };
+  const KIND_NAMES = { video: 'VIDEO', photo: 'PHOTOGRAPH', diagram: 'DIAGRAM', map: 'MAP' };
+  const grid = document.getElementById('grid');
+  data.forEach((d, i) => {
+    const t = document.createElement('div');
+    t.className = 'tile ' + d.k;
+    t.innerHTML = `
+      <div class="thumb">
+        <span class="ribbon">${KIND_NAMES[d.k] || d.k.toUpperCase()}</span>
+        ${d.v ? `<span class="views">${d.v}</span>` : ''}
+        <span class="icon">${ICONS[d.k] || '?'}</span>
+      </div>
+      <div class="footer">
+        <div class="kind">${KIND_NAMES[d.k] || d.k}</div>
+        <div class="title">${d.t}</div>
+        <div class="ev">${d.e}</div>
+      </div>`;
+    t.style.opacity = '0';
+    t.style.animation = `rise 0.5s ${300 + i * 35}ms cubic-bezier(.2,.7,.2,1) forwards`;
+    grid.appendChild(t);
+  });
+</script>
+</body>
+</html>

--- a/public/mc/network.html
+++ b/public/mc/network.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Network</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .nw-shell { padding: 0 56px 64px; display: grid; grid-template-columns: 280px minmax(0,1fr); gap: 24px; position: relative; z-index: 3; align-items: start; }
+    .nw-card { background: var(--surface); border: 1px solid var(--border); padding: 28px; backdrop-filter: blur(10px); position: relative; overflow: hidden; }
+    .nw-h { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 18px; margin-bottom: 18px; border-bottom: 1px solid var(--hairline); }
+    .nw-h .t { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.30em; color: var(--text-2); text-transform: uppercase; }
+    .nw-h .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.16em; }
+    .nw-svg { width: 100%; height: 720px; display: block; }
+    .nw-edge { stroke: rgba(242,166,35,0.18); stroke-width: 0.6; }
+    .nw-edge.strong { stroke: rgba(242,166,35,0.55); stroke-width: 1.4; }
+    .nw-edge.weak { stroke: rgba(110,138,124,0.10); stroke-width: 0.3; }
+    .nw-node text { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.06em; }
+    .nw-node circle { transition: all .15s; cursor: pointer; }
+    .nw-node:hover circle { stroke-width: 2; }
+
+    .nw-ctl { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; color: var(--text-3); }
+    .nw-ctl .row { display: flex; align-items: center; gap: 10px; padding: 9px 0; border-bottom: 1px solid var(--hairline); text-transform: uppercase; }
+    .nw-ctl .row:last-child { border-bottom: none; }
+    .nw-ctl .row .label { flex: 1; }
+    .nw-ctl .row .v { color: var(--text); font-family: 'Space Grotesk', sans-serif; font-size: 14px; font-weight: 600; }
+    .nw-ctl .slider { width: 60px; height: 2px; background: var(--hairline); position: relative; }
+    .nw-ctl .slider .knob { position: absolute; width: 40%; height: 100%; background: var(--amber); box-shadow: 0 0 6px var(--amber-glow); }
+    .nw-mode { display: flex; gap: 8px; margin: 0 0 14px; padding-bottom: 14px; border-bottom: 1px solid var(--hairline); }
+    .nw-mode .m { padding: 7px 11px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; cursor: pointer; text-transform: uppercase; }
+    .nw-mode .m.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.10); box-shadow: 0 0 12px rgba(242,166,35,0.20); }
+
+    .nw-key { display: flex; flex-direction: column; gap: 9px; margin-top: 14px; }
+    .nw-key .k { display: flex; align-items: center; gap: 9px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.10em; text-transform: uppercase; }
+    .nw-key .k .d { width: 10px; height: 10px; border-radius: 50%; }
+  </style>
+</head>
+<body data-view="network">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 11 — entity graph</div>
+    <h1>Force-directed clustering. <em>Where the corpus actually connects.</em></h1>
+    <p class="sub">Nodes are events; edges are semantic similarity (cosine ≥ 0.55). Tightest cluster: FBI 62HQ-83894 sections. Second cluster: modern USCENTCOM Middle-East mission reports. Drag, pan, tune the similarity threshold.</p>
+  </section>
+
+  <section class="nw-shell">
+    <div class="panel">
+      <div class="panel-head"><span><span class="icon-sq"></span>CONTROLS</span><span class="right">tune</span></div>
+
+      <div class="nw-mode">
+        <span class="m active">ALL</span>
+        <span class="m">EVENTS</span>
+        <span class="m">PATTERNS</span>
+      </div>
+
+      <div class="nw-ctl">
+        <div class="row"><span class="label">MIN COSINE</span><span class="slider"><span class="knob" style="left:20%"></span></span><span class="v">0.55</span></div>
+        <div class="row"><span class="label">REPULSION</span><span class="slider"><span class="knob" style="left:50%"></span></span><span class="v">3.2</span></div>
+        <div class="row"><span class="label">ITERATIONS</span><span class="slider"><span class="knob" style="left:65%"></span></span><span class="v">320</span></div>
+        <div class="row"><span class="label">NODES</span><span class="v">75 / 220</span></div>
+        <div class="row"><span class="label">EDGES</span><span class="v">142</span></div>
+        <div class="row"><span class="label">CLUSTERS</span><span class="v">2 dominant</span></div>
+      </div>
+
+      <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline)">
+        <div style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.18em;color:var(--text-3);text-transform:uppercase;font-weight:700;margin-bottom:10px">LEGEND</div>
+        <div class="nw-key">
+          <div class="k"><span class="d" style="background:var(--amber);box-shadow:0 0 6px var(--amber-glow)"></span>DoW · USCENTCOM cluster</div>
+          <div class="k"><span class="d" style="background:var(--cyan);box-shadow:0 0 6px rgba(97,215,240,0.6)"></span>FBI · 1947 case file</div>
+          <div class="k"><span class="d" style="background:var(--emerald);box-shadow:0 0 6px rgba(74,222,128,0.6)"></span>NASA · orbital</div>
+          <div class="k"><span class="d" style="background:var(--rose);box-shadow:0 0 6px rgba(224,73,104,0.6)"></span>Anchor event</div>
+          <div class="k"><span class="d" style="background:var(--text-3)"></span>Other / unclassified</div>
+        </div>
+      </div>
+
+      <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;line-height:1.6;color:var(--text-3);letter-spacing:0.06em">
+        <strong style="color:var(--text);letter-spacing:0.14em">CLUSTER 1 — FBI 62HQ.</strong> 11 internal-section neighbors at cos 0.94-0.98. Tight intra-document.<br><br>
+        <strong style="color:var(--text);letter-spacing:0.14em">CLUSTER 2 — CENTCOM/ME.</strong> 18 events anchored on USCENTCOM (202 mentions / 18 docs).
+      </div>
+    </div>
+
+    <div class="nw-card">
+      <div class="nw-h">
+        <div class="t">▣ &nbsp; SEMANTIC GRAPH</div>
+        <div class="meta">220 events · 199 entities · cosine ≥ 0.55</div>
+      </div>
+
+      <svg class="nw-svg" viewBox="0 0 1000 720" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <radialGradient id="nodeGlow"><stop offset="0%" stop-color="rgba(242,166,35,0.35)"/><stop offset="100%" stop-color="rgba(242,166,35,0)"/></radialGradient>
+        </defs>
+
+        <!-- Edges first (drawn behind) -->
+        <g>
+          <!-- FBI 62HQ tight cluster (top-left) -->
+          <line class="nw-edge strong" x1="180" y1="150" x2="240" y2="120"/>
+          <line class="nw-edge strong" x1="180" y1="150" x2="280" y2="190"/>
+          <line class="nw-edge strong" x1="240" y1="120" x2="280" y2="190"/>
+          <line class="nw-edge strong" x1="240" y1="120" x2="320" y2="140"/>
+          <line class="nw-edge strong" x1="180" y1="150" x2="220" y2="220"/>
+          <line class="nw-edge strong" x1="280" y1="190" x2="320" y2="140"/>
+          <line class="nw-edge strong" x1="280" y1="190" x2="220" y2="220"/>
+          <line class="nw-edge" x1="240" y1="120" x2="380" y2="180"/>
+          <line class="nw-edge" x1="320" y1="140" x2="380" y2="180"/>
+          <line class="nw-edge" x1="320" y1="140" x2="400" y2="100"/>
+
+          <!-- CENTCOM/ME cluster (center-right) -->
+          <line class="nw-edge strong" x1="680" y1="320" x2="740" y2="280"/>
+          <line class="nw-edge strong" x1="680" y1="320" x2="720" y2="380"/>
+          <line class="nw-edge strong" x1="740" y1="280" x2="800" y2="320"/>
+          <line class="nw-edge strong" x1="720" y1="380" x2="800" y2="320"/>
+          <line class="nw-edge strong" x1="680" y1="320" x2="620" y2="280"/>
+          <line class="nw-edge strong" x1="680" y1="320" x2="640" y2="380"/>
+          <line class="nw-edge" x1="620" y1="280" x2="540" y2="260"/>
+          <line class="nw-edge" x1="640" y1="380" x2="600" y2="440"/>
+          <line class="nw-edge" x1="740" y1="280" x2="820" y2="240"/>
+          <line class="nw-edge" x1="800" y1="320" x2="870" y2="290"/>
+          <line class="nw-edge" x1="720" y1="380" x2="780" y2="440"/>
+
+          <!-- USPER bridge -->
+          <line class="nw-edge strong" x1="540" y1="260" x2="500" y2="500"/>
+          <line class="nw-edge" x1="500" y1="500" x2="640" y2="380"/>
+          <line class="nw-edge" x1="500" y1="500" x2="600" y2="440"/>
+
+          <!-- NASA cluster (top right) -->
+          <line class="nw-edge" x1="820" y1="120" x2="880" y2="180"/>
+          <line class="nw-edge" x1="820" y1="120" x2="780" y2="80"/>
+
+          <!-- Weak cross-cluster -->
+          <line class="nw-edge weak" x1="380" y1="180" x2="500" y2="500"/>
+          <line class="nw-edge weak" x1="540" y1="260" x2="220" y2="220"/>
+          <line class="nw-edge weak" x1="820" y1="120" x2="540" y2="260"/>
+
+          <!-- Outliers -->
+          <line class="nw-edge weak" x1="150" y1="520" x2="380" y2="180"/>
+          <line class="nw-edge weak" x1="900" y1="580" x2="800" y2="320"/>
+        </g>
+
+        <!-- Nodes -->
+        <g>
+          <!-- FBI 62HQ section nodes (cyan) -->
+          <g class="nw-node"><circle cx="180" cy="150" r="10" fill="#61D7F0" stroke="rgba(97,215,240,0.5)" stroke-width="1"/><text x="194" y="154" fill="rgba(155,213,232,0.9)">62hq-s2</text></g>
+          <g class="nw-node"><circle cx="240" cy="120" r="9" fill="#61D7F0" stroke="rgba(97,215,240,0.5)" stroke-width="1"/><text x="254" y="124" fill="rgba(155,213,232,0.85)">62hq-s5</text></g>
+          <g class="nw-node"><circle cx="280" cy="190" r="8" fill="#61D7F0" stroke="rgba(97,215,240,0.5)" stroke-width="1"/><text x="294" y="194" fill="rgba(155,213,232,0.85)">62hq-s4</text></g>
+          <g class="nw-node"><circle cx="320" cy="140" r="7" fill="#61D7F0"/></g>
+          <g class="nw-node"><circle cx="220" cy="220" r="6" fill="#61D7F0"/></g>
+          <g class="nw-node"><circle cx="380" cy="180" r="6" fill="#61D7F0"/></g>
+          <g class="nw-node"><circle cx="400" cy="100" r="5" fill="#61D7F0"/></g>
+
+          <!-- CENTCOM/ME amber cluster -->
+          <g class="nw-node"><circle cx="680" cy="320" r="13" fill="#F2A623" stroke="#FFB840" stroke-width="1.5" filter="url(#nodeGlow)"/><text x="697" y="324" fill="rgba(242,166,35,0.95)" font-weight="600">USCENTCOM</text></g>
+          <g class="nw-node"><circle cx="740" cy="280" r="9" fill="#F2A623"/><text x="754" y="284" fill="rgba(242,166,35,0.85)">uae-jun-2024</text></g>
+          <g class="nw-node"><circle cx="720" cy="380" r="8" fill="#F2A623"/><text x="734" y="384" fill="rgba(242,166,35,0.85)">uae-oct-2023</text></g>
+          <g class="nw-node"><circle cx="800" cy="320" r="8" fill="#F2A623"/><text x="814" y="324" fill="rgba(242,166,35,0.85)">d62 hormuz</text></g>
+          <g class="nw-node"><circle cx="620" cy="280" r="7" fill="#F2A623"/></g>
+          <g class="nw-node"><circle cx="640" cy="380" r="7" fill="#F2A623"/></g>
+          <g class="nw-node"><circle cx="820" cy="240" r="6" fill="#F2A623"/></g>
+          <g class="nw-node"><circle cx="870" cy="290" r="6" fill="#F2A623"/></g>
+          <g class="nw-node"><circle cx="780" cy="440" r="6" fill="#F2A623"/></g>
+          <g class="nw-node"><circle cx="600" cy="440" r="5" fill="#F2A623"/></g>
+
+          <!-- Middle East range fouler bridge -->
+          <g class="nw-node"><circle cx="540" cy="260" r="8" fill="#F2A623"/><text x="554" y="264" fill="rgba(242,166,35,0.85)">d38 me-2020</text></g>
+
+          <!-- ANCHOR: USPER-2025 (rose, prominent) -->
+          <g class="nw-node">
+            <circle cx="500" cy="500" r="16" fill="none" stroke="rgba(224,73,104,0.5)" stroke-width="1" opacity="0.7"/>
+            <circle cx="500" cy="500" r="11" fill="#E04968" stroke="#FF8B9D" stroke-width="1.5"/>
+            <text x="517" y="504" fill="rgba(255,139,157,0.95)" font-weight="600">USPER-2025</text>
+            <text x="517" y="516" fill="rgba(224,73,104,0.65)" font-size="9">ANCHOR</text>
+          </g>
+
+          <!-- NASA orbital (emerald, small cluster) -->
+          <g class="nw-node"><circle cx="820" cy="120" r="9" fill="#4ADE80"/><text x="834" y="124" fill="rgba(134,239,172,0.85)">apollo-17</text></g>
+          <g class="nw-node"><circle cx="880" cy="180" r="6" fill="#4ADE80"/></g>
+          <g class="nw-node"><circle cx="780" cy="80" r="6" fill="#4ADE80"/></g>
+          <g class="nw-node"><circle cx="930" cy="120" r="5" fill="#4ADE80"/></g>
+
+          <!-- Outliers (gray) -->
+          <g class="nw-node"><circle cx="150" cy="520" r="5" fill="#75664A"/><text x="160" y="540" fill="rgba(117,102,74,0.7)">netherlands-1948</text></g>
+          <g class="nw-node"><circle cx="900" cy="580" r="5" fill="#75664A"/></g>
+          <g class="nw-node"><circle cx="200" cy="600" r="4" fill="#75664A"/></g>
+          <g class="nw-node"><circle cx="350" cy="600" r="4" fill="#75664A"/></g>
+
+          <!-- DoW d48/d49 sub-cluster -->
+          <g class="nw-node"><circle cx="440" cy="640" r="7" fill="#F2A623"/><text x="454" y="644" fill="rgba(242,166,35,0.85)">d48 1996</text></g>
+          <g class="nw-node"><circle cx="500" cy="660" r="6" fill="#F2A623"/></g>
+        </g>
+
+      </svg>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+</body>
+</html>

--- a/public/mc/review.html
+++ b/public/mc/review.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .rv-shell { padding: 0 56px 64px; display: grid; grid-template-columns: 320px minmax(0,1fr); gap: 22px; position: relative; z-index: 3; }
+    .rv-queue { background: var(--surface); border: 1px solid var(--border); padding: 22px; backdrop-filter: blur(10px); max-height: 1200px; overflow-y: auto; }
+    .rv-row { display: flex; flex-direction: column; gap: 4px; padding: 14px 0; border-bottom: 1px solid var(--hairline); cursor: pointer; transition: padding-left .2s; }
+    .rv-row:hover { padding-left: 6px; }
+    .rv-row.active { padding-left: 8px; border-left: 2px solid var(--amber); background: rgba(242,166,35,0.05); margin: 0 -22px; padding: 14px 22px 14px 26px; }
+    .rv-row .top { display: flex; align-items: center; gap: 8px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; }
+    .rv-row .top .agree { margin-left: auto; color: var(--rose); font-weight: 700; }
+    .rv-row .top .agree.high { color: var(--amber); }
+    .rv-row .eid { color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 500; }
+    .rv-row .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.08em; }
+    .rv-pane { background: var(--surface); border: 1px solid var(--border); padding: 24px 28px; backdrop-filter: blur(10px); }
+    .rv-head { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 18px; margin-bottom: 22px; border-bottom: 1px solid var(--hairline); }
+    .rv-head h2 { font-family: 'Space Grotesk', sans-serif; font-size: 24px; font-weight: 600; margin: 0; letter-spacing: -0.015em; color: var(--text); }
+    .rv-head .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.16em; }
+    .rv-head .meta .score { color: var(--rose); font-weight: 700; font-size: 14px; padding: 4px 10px; border: 1px solid rgba(224,73,104,0.4); background: rgba(224,73,104,0.10); margin-left: 8px; }
+    .diff-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 22px; }
+    .diff-col { background: var(--surface-3); border: 1px solid var(--hairline); padding: 16px 18px; }
+    .diff-col h4 { display: flex; align-items: center; gap: 8px; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.2em; color: var(--text-3); text-transform: uppercase; margin: 0 0 12px; padding-bottom: 10px; border-bottom: 1px solid var(--hairline); }
+    .diff-col h4 .src-tag { font-size: 9px; padding: 1px 6px; border: 1px solid; }
+    .diff-col h4 .src-tag.g { color: var(--cyan); border-color: rgba(97,215,240,0.4); background: rgba(97,215,240,0.08); }
+    .diff-col h4 .src-tag.o { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.08); }
+    .diff-col .conf { margin-left: auto; color: var(--text); font-weight: 600; }
+    .diff-col p { font-family: 'JetBrains Mono', monospace; font-size: 12px; line-height: 1.65; color: var(--text-2); margin: 0; }
+    .diff-col p .add { background: rgba(74,222,128,0.16); color: var(--emerald); padding: 0 3px; }
+    .diff-col p .del { background: rgba(224,73,104,0.16); color: var(--rose); padding: 0 3px; text-decoration: line-through; }
+    .merge-pane { border: 1px solid var(--border-strong); background: rgba(242,166,35,0.04); padding: 18px 22px; }
+    .merge-pane h4 { display: flex; align-items: center; gap: 8px; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.2em; color: var(--amber); text-transform: uppercase; margin: 0 0 12px; padding-bottom: 10px; border-bottom: 1px solid var(--hairline); }
+    .merge-pane textarea { width: 100%; background: transparent; border: none; outline: none; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 13px; line-height: 1.65; resize: vertical; min-height: 120px; }
+    .actions-bar { display: flex; align-items: center; gap: 12px; margin-top: 22px; padding-top: 22px; border-top: 1px solid var(--hairline); }
+    .actions-bar .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.16em; margin-right: auto; }
+    .ab-btn { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; letter-spacing: 0.14em; padding: 11px 18px; cursor: pointer; }
+    .ab-btn.primary { color: var(--void); background: linear-gradient(180deg, var(--amber-bright), var(--gold)); border: 1px solid var(--amber); box-shadow: 0 12px 28px -10px rgba(242,166,35,0.55); }
+    .ab-btn.ghost { color: var(--text-2); background: var(--surface); border: 1px solid var(--border); }
+    .ab-btn.ghost:hover { color: var(--text); border-color: var(--border-strong); }
+  </style>
+</head>
+<body data-view="review">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 05 — disputed-page review</div>
+    <h1>3 pages where the engines disagree. <em>Pick the truth.</em></h1>
+    <p class="sub">Each row in the queue is a page where machine OCR sources (Gemini-vision, GPT-vision, Tesseract, PDF.js) produced conflicting transcripts. The reviewer's job is to merge to a canonical version; one click opens a pre-filled GitHub PR.</p>
+  </section>
+
+  <section class="rv-shell">
+    <div class="rv-queue">
+      <div style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.22em;color:var(--text-3);text-transform:uppercase;font-weight:700;margin-bottom:14px;padding-bottom:12px;border-bottom:1px solid var(--hairline);display:flex;justify-content:space-between"><span>QUEUE · WORST AGREEMENT</span><span style="color:var(--amber)">3</span></div>
+      <div class="rv-row active">
+        <div class="top"><span>FBI</span><span>·</span><span>2025-10</span><span class="agree">0.21</span></div>
+        <div class="eid">usper-2025 · p 03</div>
+        <div class="meta">vision · ocr · gemini · 4 sources disagree</div>
+      </div>
+      <div class="rv-row">
+        <div class="top"><span>DEPT/War</span><span>·</span><span>1996</span><span class="agree">0.34</span></div>
+        <div class="eid">dow-uap-d48 · p 087</div>
+        <div class="meta">vision · pdfjs · 2 sources disagree</div>
+      </div>
+      <div class="rv-row">
+        <div class="top"><span>DEPT/War</span><span>·</span><span>2020-05</span><span class="agree high">0.48</span></div>
+        <div class="eid">dow-uap-d038 · p 12</div>
+        <div class="meta">vision · ocr · minor</div>
+      </div>
+
+      <div style="margin-top:24px;padding-top:18px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.14em">
+        <div style="margin-bottom:8px">FILTER · all agencies</div>
+        <div style="margin-bottom:8px">SORT · worst agreement first</div>
+        <div style="color:var(--text-3);margin-top:14px">Pages graded ≥0.85 are auto-accepted as canonical and never enter this queue. Threshold tunable in <span style="color:var(--amber)">corpus-stats.json</span>.</div>
+      </div>
+    </div>
+
+    <div class="rv-pane">
+      <div class="rv-head">
+        <div>
+          <h2>usper-2025 · page 03</h2>
+          <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-3);letter-spacing:0.14em;margin-top:6px">FBI · 2025-10 · SECRET//NOFORN · 4 SOURCES · LAST UPDATED 14h ago</div>
+        </div>
+        <div class="meta">AGREEMENT <span class="score">0.21</span></div>
+      </div>
+
+      <div class="diff-grid">
+        <div class="diff-col">
+          <h4><span class="src-tag g">VISION</span><span>GEMINI · 2.0 Flash</span><span class="conf">0.94 conf</span></h4>
+          <p>"On <span class="del">[redacted]</span> 2025, at approximately 1700 hours [redacted] (a senior US intelligence official), [FEDERAL PARTNER 1] and [FEDERAL PARTNER 2], accompanied by [WITNESS 2 (a senior US intelligence official)], and two pilots from [STATE PARTNER ORGANIZATION] departed [<span class="add">SITE CODE NAME</span>] to conduct a search…"</p>
+        </div>
+        <div class="diff-col">
+          <h4><span class="src-tag o">OCR</span><span>Tesseract 5.4</span><span class="conf">0.62 conf</span></h4>
+          <p>"On <span class="add">[reducted]</span> 2025, at approxlmately 1700 hours [reducted] (a senior US lntelligence offlcial), [FEDERAL PARTNER 1] and [FEDERAL PARTNER 2], accompanled by [WITNESS 2 (a sentior US Intelligence offlclal)], and two pllots from [STATE PARTNER ORGANIZATION] departed [<span class="del">unknown</span>] to conduct a search…"</p>
+        </div>
+      </div>
+
+      <div class="merge-pane">
+        <h4><span>▣ MERGED TEXT — REVIEWER PROPOSAL</span><span style="margin-left:auto;color:var(--text-3);font-weight:400">edit freely · saves on submit</span></h4>
+        <textarea>On [redacted] 2025, at approximately 1700 hours [redacted] (a senior US intelligence official), [FEDERAL PARTNER 1] and [FEDERAL PARTNER 2], accompanied by [WITNESS 2 (a senior US intelligence official)], and two pilots from [STATE PARTNER ORGANIZATION] departed [SITE CODE NAME] to conduct a search…</textarea>
+      </div>
+
+      <div class="actions-bar">
+        <span class="meta">SUBMISSION · opens pre-filled PR · reviewer credit: anonymous OK</span>
+        <button class="ab-btn ghost">SKIP — next page</button>
+        <button class="ab-btn primary">▣ SUBMIT MERGED TEXT →</button>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+<script>
+  document.querySelectorAll('.rv-row').forEach(r => r.addEventListener('click', () => {
+    document.querySelectorAll('.rv-row').forEach(x => x.classList.remove('active'));
+    r.classList.add('active');
+  }));
+</script>
+</body>
+</html>

--- a/public/mc/search.html
+++ b/public/mc/search.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Search</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .search-shell { padding: 0 56px 64px; position: relative; z-index: 3; }
+    .search-form { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; margin-bottom: 24px; backdrop-filter: blur(10px); }
+    .mode-toggle { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 22px; }
+    .mode { padding: 18px 22px; border: 1px solid var(--border); background: var(--surface-2); cursor: pointer; transition: all .2s; text-align: left; color: inherit; text-decoration: none; }
+    .mode.active { border-color: var(--amber); background: rgba(242,166,35,0.10); box-shadow: 0 0 24px rgba(242,166,35,0.18), inset 0 0 12px rgba(242,166,35,0.06); }
+    .mode .lbl { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; }
+    .mode.active .lbl { color: var(--amber); }
+    .mode h3 { font-family: 'Space Grotesk', sans-serif; font-size: 26px; font-weight: 600; margin: 6px 0 6px; letter-spacing: -0.02em; color: var(--text); }
+    .mode p { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); margin: 0; letter-spacing: 0.06em; }
+    .mode .badge { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--amber); background: rgba(242,166,35,0.10); border: 1px solid var(--border-strong); padding: 2px 8px; margin-left: 8px; letter-spacing: 0.16em; font-weight: 600; }
+    .search-input { display: flex; align-items: center; gap: 14px; background: var(--surface-3); border: 1px solid var(--border-strong); padding: 18px 22px; }
+    .search-input .glyph { color: var(--amber); font-size: 22px; }
+    .search-input input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 18px; letter-spacing: 0.04em; }
+    .search-input input::placeholder { color: var(--text-4); }
+    .search-input .clear { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); cursor: pointer; padding: 4px 10px; letter-spacing: 0.16em; }
+    .search-filters { display: flex; align-items: center; gap: 12px; margin-top: 18px; }
+    .stats-row { display: flex; align-items: center; gap: 18px; padding: 16px 0; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); letter-spacing: 0.16em; }
+    .stats-row .v { color: var(--amber); font-weight: 600; }
+    .stats-row .right { margin-left: auto; }
+    .results-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+    .rc { background: var(--surface); border: 1px solid var(--border); padding: 18px 20px; backdrop-filter: blur(10px); transition: all .2s; cursor: pointer; position: relative; overflow: hidden; }
+    .rc:hover { border-color: var(--border-strong); }
+    .rc::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--amber); opacity: 0; transition: opacity .2s; }
+    .rc:hover::before { opacity: 1; box-shadow: 0 0 10px var(--amber-glow); }
+    .rc .top { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; }
+    .rc .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--amber); }
+    .rc .dot.r { background: var(--rose); } .rc .dot.c { background: var(--cyan); } .rc .dot.e { background: var(--emerald); }
+    .rc .eid { color: var(--cyan); }
+    .rc .score { margin-left: auto; color: var(--amber); font-weight: 600; }
+    .rc h3 { font-family: 'Space Grotesk', sans-serif; font-size: 17px; font-weight: 600; line-height: 1.25; margin: 0 0 10px; color: var(--text); letter-spacing: -0.01em; }
+    .rc p { font-size: 13px; line-height: 1.55; color: var(--text-2); margin: 0 0 12px; }
+    .rc p mark { background: rgba(242,166,35,0.22); color: var(--amber-bright); padding: 0 4px; }
+    .rc .bottom { display: flex; justify-content: space-between; align-items: center; padding-top: 12px; border-top: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.14em; text-transform: uppercase; }
+    .rc .bottom .pg { color: var(--amber); }
+  </style>
+</head>
+<body data-view="search">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 03 — query the corpus</div>
+    <h1>Two retrieval modes, <em>one input.</em></h1>
+    <p class="sub">EXACT finds your phrase verbatim across 276 indexed documents in &lt;50ms. MEANING loads the 5,665-chunk semantic index (25MB, lazy) and surfaces ideas that share meaning even with different words.</p>
+  </section>
+
+  <section class="search-shell">
+    <div class="search-form">
+      <div class="mode-toggle">
+        <a class="mode active">
+          <span class="lbl">▣ &nbsp; EXACT MATCH<span class="badge">DEFAULT</span></span>
+          <h3>Lexical · MiniSearch</h3>
+          <p>276 docs · fuzzy + prefix · &lt;50ms · loaded</p>
+        </a>
+        <a class="mode">
+          <span class="lbl">∿ &nbsp; MEANING MATCH</span>
+          <h3>Semantic · FAISS</h3>
+          <p>5,665 chunks · 25MB embeddings · loads on click</p>
+        </a>
+      </div>
+
+      <div class="search-input">
+        <span class="glyph">⌕</span>
+        <input value="orb hover elevation" placeholder="QUERY · 220 events · 3,530 pages…"/>
+        <span class="clear">⨯ CLEAR</span>
+      </div>
+
+      <div class="search-filters">
+        <select class="filter-select"><option>ALL AGENCIES</option></select>
+        <select class="filter-select"><option>ALL ERAS</option></select>
+        <select class="filter-select"><option>ALL TYPES</option></select>
+        <span style="margin-left:auto;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.18em">EXACT finds your phrase verbatim · MEANING finds related ideas</span>
+      </div>
+    </div>
+
+    <div class="stats-row">
+      <span><span class="v">14</span> RESULTS</span><span>·</span>
+      <span>EXACT MATCH · ⏱ 41ms</span><span>·</span>
+      <span style="color:var(--cyan);cursor:pointer">↻ TRY MEANING FOR FUZZIER RESULTS</span>
+      <span class="right">SORTED BY RELEVANCE</span>
+    </div>
+
+    <div class="results-grid">
+      <article class="rc">
+        <div class="top"><span class="dot r"></span><span class="eid">DOW-UAP-D038</span><span class="score">0.94</span></div>
+        <h3>Middle East — Erratic White Object Over Water</h3>
+        <p>"…sensor cycled <mark>hover</mark> tracking but the <mark>orb</mark> dispersed before a lock could be achieved over the water at…"</p>
+        <div class="bottom"><span class="pg">PAGE 12</span><span>DoW · 2020-05</span></div>
+      </article>
+
+      <article class="rc">
+        <div class="top"><span class="dot r"></span><span class="eid">USPER-STATEMENT</span><span class="score">0.91</span></div>
+        <h3>USPER Statement — Helicopter Encounter</h3>
+        <p>"…the <mark>orb</mark> gained <mark>elevation</mark> and came within ten feet of [the helicopter] before separating into multiple…"</p>
+        <div class="bottom"><span class="pg">PAGE 03</span><span>FBI · 2025-10</span></div>
+      </article>
+
+      <article class="rc">
+        <div class="top"><span class="dot"></span><span class="eid">FBI-62HQ-83894-02</span><span class="score">0.78</span></div>
+        <h3>FBI Flying Discs Case File · Section 2</h3>
+        <p>"…witness reports a bright <mark>orb</mark> seen to <mark>hover</mark> motionless over the field for nearly two minutes…"</p>
+        <div class="bottom"><span class="pg">PAGE 18</span><span>FBI · 1947</span></div>
+      </article>
+
+      <article class="rc">
+        <div class="top"><span class="dot r"></span><span class="eid">DOW-UAP-D045</span><span class="score">0.74</span></div>
+        <h3>Southern US — Air Force Sighting (PR-45)</h3>
+        <p>"…several bright objects maneuvering quickly west to east northeast, then <mark>hover</mark>ed in formation for 20 seconds…"</p>
+        <div class="bottom"><span class="pg">PAGE 04</span><span>DoW · 2020-03</span></div>
+      </article>
+
+      <article class="rc">
+        <div class="top"><span class="dot c"></span><span class="eid">GEMINI-7</span><span class="score">0.69</span></div>
+        <h3>Gemini VII — Borman &amp; Lovell "Bogey"</h3>
+        <p>"…brilliant body in the sun against a black background, debris field of trillions of particles at <mark>elevation</mark>…"</p>
+        <div class="bottom"><span class="pg">PAGE 01</span><span>NASA · 1965</span></div>
+      </article>
+
+      <article class="rc">
+        <div class="top"><span class="dot"></span><span class="eid">UAE-JUNE-2024</span><span class="score">0.62</span></div>
+        <h3>UAE — June 2024 mission report</h3>
+        <p>"…AFSOC ISR mission, target maintained constant <mark>elevation</mark> through observation window despite cycling sensor…"</p>
+        <div class="bottom"><span class="pg">PAGE 02</span><span>DoW · 2024-06</span></div>
+      </article>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+<script>
+  // Toggle modes on click (visual demo)
+  document.querySelectorAll('.mode').forEach(m => {
+    m.addEventListener('click', () => {
+      document.querySelectorAll('.mode').forEach(x => x.classList.remove('active'));
+      m.classList.add('active');
+    });
+  });
+</script>
+</body>
+</html>

--- a/public/mc/styles.css
+++ b/public/mc/styles.css
@@ -1,0 +1,440 @@
+/* PURSUE Mission Control — shared design system
+ * Used by all pages under /mc/
+ */
+
+:root {
+  --void: #03060A;
+  --void-2: #060B12;
+  --void-3: #0A111B;
+  --surface:   rgba(12, 19, 28, 0.62);
+  --surface-2: rgba(18, 26, 36, 0.70);
+  --surface-3: rgba(10, 16, 24, 0.85);
+  --hairline: rgba(242, 166, 35, 0.09);
+  --border: rgba(242, 166, 35, 0.18);
+  --border-strong: rgba(242, 166, 35, 0.34);
+  --border-cyan: rgba(97, 215, 240, 0.22);
+
+  --text: #F4ECD4;
+  --text-2: #B8A887;
+  --text-3: #75664A;
+  --text-4: #463C2D;
+  --text-cyan: #9BD5E8;
+
+  --amber: #F2A623;
+  --amber-glow: rgba(242, 166, 35, 0.50);
+  --amber-bright: #FFB840;
+  --gold: #E8A33B;
+
+  --cyan: #61D7F0;
+  --cyan-deep: #2D9DBA;
+
+  --emerald: #4ADE80;
+  --rose: #E04968;
+  --violet: #B280FF;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--void); }
+body {
+  min-width: 1280px;
+  color: var(--text);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  overflow-x: hidden;
+}
+.display { font-family: 'Space Grotesk', sans-serif; letter-spacing: -0.015em; }
+.mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+
+/* ───────── Background stack ───────── */
+.bg-void {
+  position: fixed; inset: 0; z-index: 0;
+  background:
+    radial-gradient(1200px 700px at 78% -8%,  rgba(242, 166, 35, 0.08), transparent 70%),
+    radial-gradient(900px 600px at 18% 100%, rgba(97, 215, 240, 0.04), transparent 70%),
+    radial-gradient(1500px 900px at 50% 50%, rgba(8, 14, 22, 0.0), rgba(0,0,0,0.7) 100%),
+    linear-gradient(180deg, var(--void) 0%, var(--void-2) 50%, var(--void) 100%);
+  pointer-events: none;
+}
+.bg-grid {
+  position: fixed; inset: 0; z-index: 0;
+  background-image:
+    linear-gradient(to right, rgba(242, 166, 35, 0.025) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(242, 166, 35, 0.025) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(ellipse at 50% 30%, black 30%, transparent 80%);
+  pointer-events: none;
+}
+.bg-noise {
+  position: fixed; inset: 0; z-index: 0;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200"><filter id="n"><feTurbulence baseFrequency="0.9" numOctaves="2"/><feColorMatrix values="0 0 0 0 0.95  0 0 0 0 0.65  0 0 0 0 0.14  0 0 0 0.05 0"/></filter><rect width="200" height="200" filter="url(%23n)"/></svg>');
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: overlay;
+}
+.vignette {
+  position: fixed; inset: 0; z-index: 1;
+  pointer-events: none;
+  box-shadow: inset 0 0 220px 60px rgba(0, 0, 0, 0.85);
+}
+.scanline {
+  position: fixed; left: 0; right: 0;
+  height: 2px;
+  background: linear-gradient(to right, transparent, rgba(242, 166, 35, 0.50), transparent);
+  box-shadow: 0 0 18px rgba(242, 166, 35, 0.5);
+  top: -2px;
+  animation: scanline 11s linear infinite;
+  pointer-events: none;
+  z-index: 2;
+}
+@keyframes scanline {
+  0% { top: -3px; opacity: 0; }
+  6% { opacity: 1; }
+  94% { opacity: 1; }
+  100% { top: 100%; opacity: 0; }
+}
+
+/* ───────── Classification banner ───────── */
+.classified {
+  position: relative; z-index: 5;
+  background: linear-gradient(90deg, rgba(242,166,35,0.10), rgba(242,166,35,0.04), rgba(242,166,35,0.10));
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 7px 32px;
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--amber);
+  letter-spacing: 0.36em;
+  text-transform: uppercase;
+}
+.classified .dash { color: var(--text-3); flex: 1; text-align: center; overflow: hidden; }
+.classified .stamp { display: inline-flex; align-items: center; gap: 8px; white-space: nowrap; }
+.classified .stamp::before { content:''; display:inline-block; width:6px; height:6px; background: var(--amber); box-shadow: 0 0 8px var(--amber-glow); }
+
+/* ───────── Corner reticles ───────── */
+.corner {
+  position: fixed; width: 32px; height: 32px;
+  z-index: 4; pointer-events: none;
+  border-color: rgba(242, 166, 35, 0.4);
+}
+.corner.tl { top: 32px; left: 32px;     border-top: 1px solid; border-left: 1px solid; }
+.corner.tr { top: 32px; right: 32px;    border-top: 1px solid; border-right: 1px solid; }
+.corner.bl { bottom: 32px; left: 32px;  border-bottom: 1px solid; border-left: 1px solid; }
+.corner.br { bottom: 32px; right: 32px; border-bottom: 1px solid; border-right: 1px solid; }
+
+/* ───────── Top bar ───────── */
+header.topbar {
+  position: relative; z-index: 5;
+  display: grid; grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 28px;
+  padding: 22px 56px 0;
+}
+.brand { display: flex; align-items: center; gap: 16px; }
+.brand-mark {
+  width: 12px; height: 12px;
+  background: var(--amber);
+  transform: rotate(45deg);
+  box-shadow: 0 0 14px var(--amber-glow);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 14px var(--amber-glow); transform: rotate(45deg) scale(1); }
+  50%      { box-shadow: 0 0 24px rgba(242,166,35,0.85); transform: rotate(45deg) scale(1.1); }
+}
+.brand-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700; font-size: 16px;
+  letter-spacing: 0.20em; color: var(--text);
+}
+.brand-sub {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px; color: var(--text-3);
+  letter-spacing: 0.22em;
+  padding-left: 14px; border-left: 1px solid var(--border);
+}
+.center-strip {
+  display: flex; justify-content: center; align-items: center; gap: 18px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; color: var(--text-2); letter-spacing: 0.18em;
+}
+.center-strip .badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px;
+  background: var(--surface); border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+.center-strip .badge .dot {
+  width: 7px; height: 7px; background: var(--emerald);
+  box-shadow: 0 0 10px rgba(74, 222, 128, 0.6);
+  border-radius: 50%;
+  animation: pulse-soft 2.4s ease-in-out infinite;
+}
+.center-strip .badge.amber .dot { background: var(--amber); box-shadow: 0 0 10px var(--amber-glow); }
+.center-strip .badge .v { color: var(--text); font-weight: 600; }
+@keyframes pulse-soft {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+.topbar-actions { display: flex; align-items: center; gap: 10px; }
+.ghost {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; letter-spacing: 0.14em;
+  color: var(--text-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 9px 14px; cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: all .2s;
+  text-decoration: none; display: inline-block;
+}
+.ghost:hover { color: var(--text); border-color: var(--border-strong); }
+.ops-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; letter-spacing: 0.14em; font-weight: 600;
+  color: var(--void);
+  background: linear-gradient(180deg, var(--amber-bright) 0%, var(--gold) 100%);
+  border: 1px solid var(--amber);
+  padding: 9px 18px; cursor: pointer;
+  box-shadow: 0 12px 28px -10px rgba(242, 166, 35, 0.55);
+}
+
+/* ───────── Nav ───────── */
+nav.tabs {
+  position: relative; z-index: 5;
+  display: flex; align-items: center; gap: 4px;
+  padding: 22px 56px 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+nav.tabs::-webkit-scrollbar { display: none; }
+.nav-tab {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; letter-spacing: 0.18em;
+  color: var(--text-3);
+  padding: 10px 16px;
+  border: none; background: transparent;
+  cursor: pointer; position: relative;
+  text-transform: uppercase;
+  transition: color .2s;
+  text-decoration: none; display: inline-block;
+  white-space: nowrap;
+}
+.nav-tab:hover { color: var(--text-2); }
+.nav-tab.active {
+  color: var(--amber);
+  text-shadow: 0 0 10px rgba(242, 166, 35, 0.45);
+}
+.nav-tab.active::after {
+  content: '';
+  position: absolute; left: 16px; right: 16px; bottom: -1px;
+  height: 1px; background: var(--amber);
+  box-shadow: 0 0 10px var(--amber-glow);
+}
+.nav-divider { width: 1px; height: 14px; background: var(--border); margin: 0 14px; }
+.nav-group { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.24em; color: var(--text-4); }
+.nav-badge {
+  margin-left: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  color: var(--amber);
+  background: rgba(242, 166, 35, 0.10);
+  border: 1px solid var(--border-strong);
+  padding: 1px 7px;
+}
+
+/* ───────── Sections ───────── */
+.section-divider {
+  padding: 0 56px;
+  margin: 56px 0 24px;
+  display: flex; align-items: center; gap: 18px;
+}
+.section-divider .line { flex: 1; height: 1px; background: linear-gradient(90deg, var(--border-strong), transparent); }
+.section-divider .label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.34em;
+  color: var(--amber);
+  text-transform: uppercase;
+}
+.section-divider .meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px; color: var(--text-4); letter-spacing: 0.18em;
+}
+
+.page-title {
+  padding: 64px 56px 32px;
+  position: relative; z-index: 4;
+}
+.page-title .eyebrow {
+  display: flex; align-items: center; gap: 18px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-weight: 600;
+  color: var(--amber);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  margin-bottom: 18px;
+}
+.page-title .eyebrow .div { width: 32px; height: 1px; background: var(--amber); opacity: 0.6; }
+.page-title h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 56px; font-weight: 700;
+  line-height: 1.04;
+  color: var(--text);
+  letter-spacing: -0.028em;
+  margin: 0;
+  max-width: 900px;
+}
+.page-title h1 em { font-style: normal; background: linear-gradient(95deg, var(--amber-bright), var(--amber), #B07816); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+.page-title p.sub { font-size: 17px; line-height: 1.6; color: var(--text-2); max-width: 720px; margin: 20px 0 0; }
+
+/* Panel base */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 24px 24px 20px;
+  backdrop-filter: blur(10px);
+  position: relative;
+}
+.panel-head {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px; letter-spacing: 0.28em; font-weight: 700;
+  color: var(--text-2);
+  margin-bottom: 18px;
+  text-transform: uppercase;
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--hairline);
+}
+.panel-head .icon-sq { width: 6px; height: 6px; background: var(--amber); transform: rotate(45deg); display: inline-block; margin-right: 10px; vertical-align: middle; box-shadow: 0 0 8px var(--amber-glow); }
+.panel-head .right { color: var(--text-4); font-size: 9px; letter-spacing: 0.18em; font-weight: 500; }
+
+/* Pills */
+.pill {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--text-3);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 6px 12px;
+  letter-spacing: 0.10em;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.pill.active {
+  color: var(--amber);
+  border-color: var(--border-strong);
+  background: rgba(242, 166, 35, 0.10);
+  box-shadow: 0 0 14px rgba(242, 166, 35, 0.18);
+}
+.pill .count { color: var(--text-4); margin-left: 5px; font-size: 9px; }
+
+/* Filter strip */
+.filter-strip {
+  display: flex; align-items: center; gap: 14px;
+  padding: 22px 56px;
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--hairline);
+  background: rgba(6, 11, 18, 0.55);
+  backdrop-filter: blur(10px);
+  position: relative; z-index: 3;
+}
+.filter-input {
+  flex: 1; max-width: 460px;
+  display: flex; align-items: center; gap: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 11px 14px;
+}
+.filter-input:focus-within { border-color: var(--border-strong); box-shadow: 0 0 0 4px rgba(242,166,35,0.06); }
+.filter-input .icon { color: var(--amber); font-size: 14px; }
+.filter-input input {
+  background: transparent; border: none; outline: none;
+  color: var(--text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px; flex: 1;
+}
+.filter-input input::placeholder { color: var(--text-4); }
+.filter-select {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-2);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 11px 30px 11px 14px;
+  letter-spacing: 0.14em;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--amber) 50%), linear-gradient(135deg, var(--amber) 50%, transparent 50%);
+  background-position: calc(100% - 14px) 14px, calc(100% - 10px) 14px;
+  background-size: 4px 4px;
+  background-repeat: no-repeat;
+}
+.filter-meta {
+  margin-left: auto;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px; color: var(--text-4); letter-spacing: 0.20em;
+}
+
+/* CTA */
+.primary-cta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px; font-weight: 700; letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--void);
+  background: linear-gradient(180deg, var(--amber-bright) 0%, var(--gold) 100%);
+  border: 1px solid var(--amber);
+  padding: 16px 26px;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 14px;
+  box-shadow: 0 22px 36px -10px rgba(242, 166, 35, 0.52);
+  text-decoration: none;
+  animation: breathe 4s ease-in-out infinite;
+}
+@keyframes breathe {
+  0%, 100% { box-shadow: 0 22px 36px -10px rgba(242, 166, 35, 0.52); }
+  50%      { box-shadow: 0 22px 42px -10px rgba(242, 166, 35, 0.68), 0 0 36px 6px rgba(242, 166, 35, 0.20); }
+}
+
+/* Footer */
+footer.fc {
+  padding: 28px 56px 16px;
+  border-top: 1px solid var(--hairline);
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px; color: var(--text-3);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  position: relative; z-index: 3;
+}
+
+/* Generic rise animation */
+@keyframes rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+@keyframes rise-soft { from { opacity: 0; transform: translateY(16px); filter: blur(6px); } to { opacity: 1; transform: none; filter: blur(0); } }
+
+/* Coverage cells */
+.cw-grid {
+  display: grid;
+  grid-template-columns: repeat(11, 1fr);
+  gap: 5px;
+}
+.cw-cell {
+  aspect-ratio: 1;
+  background: #0A1018;
+  border: 1px solid #182232;
+  opacity: 0;
+  animation: cw-in 0.5s cubic-bezier(.2,.7,.2,1) forwards;
+  transition: transform .2s;
+}
+.cw-cell:hover { transform: scale(1.18); border-color: var(--amber); }
+@keyframes cw-in { from { opacity: 0; transform: scale(0.5); } to { opacity: 1; transform: scale(1); } }
+.cw-cell.partial {
+  background: rgba(242, 166, 35, 0.16);
+  border-color: rgba(242, 166, 35, 0.55);
+}
+.cw-cell.complete {
+  background: rgba(74, 222, 128, 0.22);
+  border-color: var(--emerald);
+  box-shadow: 0 0 14px rgba(74, 222, 128, 0.55), inset 0 0 8px rgba(74, 222, 128, 0.4);
+  animation: cw-in 0.5s cubic-bezier(.2,.7,.2,1) forwards, complete-pulse 2.6s ease-in-out 1.5s infinite;
+}
+@keyframes complete-pulse {
+  0%, 100% { box-shadow: 0 0 14px rgba(74, 222, 128, 0.55), inset 0 0 8px rgba(74, 222, 128, 0.4); }
+  50%      { box-shadow: 0 0 22px rgba(74, 222, 128, 0.85), inset 0 0 12px rgba(74, 222, 128, 0.6); }
+}

--- a/public/mc/timeline.html
+++ b/public/mc/timeline.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Mission Control · Timeline</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .tl-shell { padding: 0 56px 64px; position: relative; z-index: 3; }
+    .tl-band { background: var(--surface); border: 1px solid var(--border); padding: 22px 26px; backdrop-filter: blur(10px); margin-bottom: 26px; }
+    .tl-band h2 { display: flex; align-items: baseline; gap: 18px; margin: 0 0 6px; font-family: 'Space Grotesk', sans-serif; font-size: 28px; font-weight: 700; letter-spacing: -0.02em; color: var(--text); }
+    .tl-band h2 .era { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--amber); letter-spacing: 0.24em; padding: 4px 10px; border: 1px solid var(--border-strong); background: rgba(242,166,35,0.08); font-weight: 600; }
+    .tl-band h2 .ct { margin-left: auto; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); letter-spacing: 0.16em; font-weight: 400; }
+    .tl-band .ct .v { color: var(--text); font-family: 'Space Grotesk', sans-serif; font-size: 22px; font-weight: 600; }
+    .tl-density { height: 4px; background: var(--hairline); margin: 16px 0 20px; }
+    .tl-density .fill { height: 100%; background: linear-gradient(90deg, var(--amber), var(--amber-bright)); box-shadow: 0 0 8px var(--amber-glow); }
+    .tl-events { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+    .evt { background: var(--surface-2); border: 1px solid var(--hairline); padding: 12px 14px; transition: all .15s; cursor: pointer; }
+    .evt:hover { border-color: var(--amber); transform: translateY(-2px); }
+    .evt .top { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.12em; text-transform: uppercase; }
+    .evt .dot { width: 7px; height: 7px; }
+    .evt .dot.dow { background: var(--amber); }
+    .evt .dot.fbi { background: var(--cyan); }
+    .evt .dot.nasa { background: var(--emerald); }
+    .evt .dot.state { background: var(--rose); }
+    .evt .dot.cia { background: #B280FF; }
+    .evt .dot.odni { background: #FFD93D; }
+    .evt .dot.energy { background: #F472B6; }
+    .evt .date { color: var(--amber); }
+    .evt .ttl { font-family: 'Inter', sans-serif; font-size: 13px; color: var(--text); line-height: 1.35; }
+    .evt .agn { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-3); margin-top: 4px; letter-spacing: 0.08em; }
+    .legend-row { display: flex; flex-wrap: wrap; gap: 14px; padding: 14px 0; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.12em; text-transform: uppercase; }
+    .legend-row .a { display: inline-flex; align-items: center; gap: 7px; }
+    .legend-row .a .d { width: 8px; height: 8px; display: inline-block; }
+  </style>
+</head>
+<body data-view="timeline">
+
+<main>
+  <section class="page-title">
+    <div class="eyebrow"><span class="div"></span>SURFACE · 08 — chronological strip</div>
+    <h1>220 events by decade, <em>1940s through 2020s.</em></h1>
+    <p class="sub">Each band is one decade. Event density per band shown as the gold fill. Color of the dot encodes the originating agency.</p>
+  </section>
+
+  <section class="tl-shell">
+    <div class="legend-row">
+      <span class="a"><span class="d" style="background:var(--amber)"></span>DEPT OF WAR · 158</span>
+      <span class="a"><span class="d" style="background:var(--cyan)"></span>FBI · 26</span>
+      <span class="a"><span class="d" style="background:var(--emerald)"></span>NASA · 22</span>
+      <span class="a"><span class="d" style="background:var(--rose)"></span>STATE · 7</span>
+      <span class="a"><span class="d" style="background:#F472B6"></span>ENERGY · 3</span>
+      <span class="a"><span class="d" style="background:#B280FF"></span>CIA · 1</span>
+      <span class="a"><span class="d" style="background:#FFD93D"></span>ODNI · 1</span>
+    </div>
+
+    <div class="tl-band">
+      <h2><span class="era">2020s</span>Modern military encounters<span class="ct"><span class="v">86</span> events</span></h2>
+      <div class="tl-density"><div class="fill" style="width:100%"></div></div>
+      <div class="tl-events">
+        <div class="evt"><div class="top"><span class="dot fbi"></span><span class="date">2025-10</span></div><div class="ttl">USPER Statement · helicopter encounter</div><div class="agn">FBI · SECRET//NOFORN</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2024-06</span></div><div class="ttl">UAE June 2024 mission report</div><div class="agn">DoW · USCENTCOM · MISREP</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2023-10</span></div><div class="ttl">Greece mission report</div><div class="agn">DoW · 56 SOIS</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2023</span></div><div class="ttl">Western US — orange orb · USPER witnesses</div><div class="agn">DoW · 3 USPERs</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2022-05</span></div><div class="ttl">Iraq mission report (D12)</div><div class="agn">DoW · 27 SOW</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2020-05</span></div><div class="ttl">Middle East erratic white object</div><div class="agn">DoW · Range Fouler (PR-36)</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2020-03</span></div><div class="ttl">Southern US Air Force sighting (PR-45)</div><div class="agn">DoW · targeting pod</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2020-07</span></div><div class="ttl">Persian Gulf July 2020 (D65)</div><div class="agn">DoW · MISREP</div></div>
+      </div>
+    </div>
+
+    <div class="tl-band">
+      <h2><span class="era">2000s</span>Vandenberg, Apollo follow-up<span class="ct"><span class="v">8</span> events</span></h2>
+      <div class="tl-density"><div class="fill" style="width:18%"></div></div>
+      <div class="tl-events">
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2000-02</span></div><div class="ttl">Vandenberg Launch Summary 1958–2000</div><div class="agn">DoW · D49 · 113pp</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">2004-11</span></div><div class="ttl">Tic-Tac · Nimitz fleet</div><div class="agn">DoW · F/A-18 IR</div></div>
+      </div>
+    </div>
+
+    <div class="tl-band">
+      <h2><span class="era">1990s</span>Air Force technical analysis<span class="ct"><span class="v">2</span> events</span></h2>
+      <div class="tl-density"><div class="fill" style="width:6%"></div></div>
+      <div class="tl-events">
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">1996-09</span></div><div class="ttl">Air Force Report · Modeling Booster Failures</div><div class="agn">DoW · D48 · RTI · 181pp</div></div>
+      </div>
+    </div>
+
+    <div class="tl-band">
+      <h2><span class="era">1970s</span>Apollo crew debriefings<span class="ct"><span class="v">8</span> events</span></h2>
+      <div class="tl-density"><div class="fill" style="width:14%"></div></div>
+      <div class="tl-events">
+        <div class="evt"><div class="top"><span class="dot nasa"></span><span class="date">1973-12</span></div><div class="ttl">Apollo 17 crew debriefing for science</div><div class="agn">NASA · 5pp</div></div>
+        <div class="evt"><div class="top"><span class="dot nasa"></span><span class="date">1973-12</span></div><div class="ttl">Apollo 17 technical crew debriefing</div><div class="agn">NASA · 2pp</div></div>
+      </div>
+    </div>
+
+    <div class="tl-band">
+      <h2><span class="era">1960s</span>Gemini · Apollo · Project Blue Book<span class="ct"><span class="v">15</span> events</span></h2>
+      <div class="tl-density"><div class="fill" style="width:24%"></div></div>
+      <div class="tl-events">
+        <div class="evt"><div class="top"><span class="dot nasa"></span><span class="date">1965-12-05</span></div><div class="ttl">Gemini VII · Borman &amp; Lovell "Bogey"</div><div class="agn">NASA · debris field of trillions</div></div>
+      </div>
+    </div>
+
+    <div class="tl-band">
+      <h2><span class="era">1940s</span>Foundational case files<span class="ct"><span class="v">7</span> events</span></h2>
+      <div class="tl-density"><div class="fill" style="width:12%"></div></div>
+      <div class="tl-events">
+        <div class="evt"><div class="top"><span class="dot fbi"></span><span class="date">1947</span></div><div class="ttl">FBI Flying Discs Case File · 62HQ-83894 · §2</div><div class="agn">FBI · Roswell-era reports</div></div>
+        <div class="evt"><div class="top"><span class="dot fbi"></span><span class="date">1947</span></div><div class="ttl">FBI Flying Discs Case File · §5</div><div class="agn">FBI · regional sightings</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">1948-11</span></div><div class="ttl">Netherlands USAFE TT-1524 dispatch</div><div class="agn">DoW · USAFE · To Gen Cabell</div></div>
+        <div class="evt"><div class="top"><span class="dot dow"></span><span class="date">1949</span></div><div class="ttl">Project Sign · "1949 discs"</div><div class="agn">DoW · radar scope</div></div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script src="chrome.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

**Publishes Mission Control release 3.0 mockups** — eleven view surfaces for the next iteration of the console, all reachable on the deployed site at `https://rizzleroc.github.io/pursue-console/mc/` after this merges.

Mission Control is the codename for the next major release. PR #265 shipped the canonical visual target for the LIVE view. This PR extends that aesthetic across **every** view in the console.

## Eleven surfaces

| Path | Surface |
|---|---|
| `/mc/index.html` | Launcher — links to every surface, full overview |
| `/mc/live.html` | Tactical overview · coverage matrix · arriving signals · field assignments · mined index |
| `/mc/coverage.html` | Full-page 11×11 grid + per-event priority queue scored from `next-missing.json` |
| `/mc/search.html` | Unified search with EXACT (MiniSearch) / MEANING (FAISS) toggle + result cards |
| `/mc/ask.html` | RAG Q&A interface with cited answers + suggested queries |
| `/mc/review.html` | Disputed-page review · side-by-side source diff · merged-text proposal |
| `/mc/media.html` | Visual library grid · type filters · view counts |
| `/mc/dossier.html` | Per-event reading view · signatures · entities/dates · semantic neighbors · visuals |
| `/mc/timeline.html` | Events by decade · agency color · density bands |
| `/mc/atlas.html` | Agency × era heatmap · 8×8 grid · cold/hot cells |
| `/mc/globe.html` | Orbital projection · event pins by lat/lon · region totals |
| `/mc/network.html` | Force-directed entity graph · cosine ≥ 0.55 · cluster controls |

## Architecture

Shared design system — every page is small. Two shared files do the heavy lifting:

- `public/mc/styles.css` (440 lines) — design tokens, panel/pill/cta/legend/grid components, scanline + corner + background animations
- `public/mc/chrome.js` (160 lines) — injects the consistent header / classification bands / nav / footer into every page based on `<body data-view="X">`. Also handles count-up animations and live UTC tick.

A typical view file is 8-15 KB of HTML that defines just its own `<main>` content + view-specific styles.

## Real corpus values

Every value shown matches the live data:
- 121 catalogued · 1 complete · 46% awaiting · 7/64 R02
- 220 events · 3,530 pages · 7.11M chars
- 199 entities · 67 dates mined
- Real entity counts (USCENTCOM 202 · Air Force 338 · FBI 88 · Handwritten 1,649)
- Real region totals (NA 80 · ME 77 · Space 18 · EU 14 · Africa 4 · Oceania 1)
- Real event titles from the corpus

When the React app catches up to implement these views for real, they'll pull from the same JSON files the React app already binds — `coverage.json`, `next-missing.json`, `patterns.json`, `corpus-stats.json` — via the hooks shipped in PR #265 (`useCoverage`, `useNextMissing`, `usePatterns`, `useCorpusStats`).

## Animation

Every page has the Mission Control motion vocabulary:
- Top-to-bottom scanline pulse (11s)
- Brand-mark heartbeat (2.4s)
- OPERATIONAL / LIVE WATCH dot pulses
- Count-up numerals on mount (1.5s ease-out)
- Live UTC tick in the badge
- Page-specific motion: radar sweep on live, sweep wedge on globe pins, coverage cell wave-in, lock-pulse on the complete cell

## Test plan

- [ ] After merge + deploy, `https://rizzleroc.github.io/pursue-console/mc/index.html` loads and shows all 11 surface tiles
- [ ] Each tile navigates to the corresponding view
- [ ] Every page has consistent header / nav / footer / classification banners
- [ ] Fonts (Space Grotesk · Inter · JetBrains Mono) load from Google Fonts CDN
- [ ] Active tab in nav highlights correctly per page (data-view attribute drives the chrome injector)
- [ ] All animations run on first load
- [ ] No console errors in production

Total: 13 new files, ~2,475 lines, 156 KB. Pure additions to `public/mc/` — no existing code touched.

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_