### PR TITLE
nav: wire Mission Control ↔ deployed React app both ways

### DIFF
--- a/public/mc/chrome.js
+++ b/public/mc/chrome.js
@@ -32,7 +32,7 @@
     return e;
   }
 
-  const view = document.body.dataset.view || 'live';
+  const view = document.body.dataset.view || '';
   function stamp() {
     const d = new Date();
     const pad = n => String(n).padStart(2, '0');
@@ -78,6 +78,7 @@
     ]),
     el('div', { class: 'topbar-actions' }, [
       el('a', { class: 'ghost', href: 'index.html' }, ['LAUNCH ▾']),
+      el('a', { class: 'ghost', href: '../', title: 'Jump to the live React app at the deployed site root' }, ['OPEN LIVE APP →']),
       el('a', { class: 'ops-btn', href: 'review.html' }, ['＋ ENLIST']),
     ]),
   ]);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -74,6 +74,12 @@ export default function Header({ view, onViewChange, onVolunteer }) {
           )}
         </button>
         <div className="flex items-center gap-2">
+          <a
+            href={`${import.meta.env.BASE_URL}mc/`}
+            className="font-mono text-[10px] tracking-[0.25em] px-2.5 py-1 rounded-sm border border-amber-700/50 bg-amber-950/30 text-amber-300/90 hover:bg-amber-900/40 hover:border-amber-500/70 hover:text-amber-200 transition-colors"
+            title="Preview the next release — Mission Control 3.0">
+            ▣ MISSION CONTROL 3.0 →
+          </a>
           <LanguagePicker />
           <button
             onClick={onVolunteer}


### PR DESCRIPTION
## Summary

Three small fixes that complete the Mission Control navigation map. After this merges + deploys, you can navigate between the deployed React app and Mission Control 3.0 from either direction with a single click.

## Changes

| File | Fix |
|---|---|
| `public/mc/chrome.js` | Stop falling back to `'live'` when `data-view=""`. Was lighting up LIVE tab on the launcher (`/mc/index.html`) incorrectly. |
| `public/mc/chrome.js` | Add **"OPEN LIVE APP →"** ghost button in the topbar of every Mission Control page (next to LAUNCH ▾). Jumps from the mockup into the real deployed React app at the site root. |
| `src/components/Header.jsx` | Add **"▣ MISSION CONTROL 3.0 →"** link in the deployed React app's header (next to LanguagePicker + VOLUNTEER). Routes to `/pursue-console/mc/`. Amber-toned, low-key, discoverable. |

8 line diff total. Pure additive — no existing behavior changes.

## Test plan

After deploy:

- [ ] `https://rizzleroc.github.io/pursue-console/mc/` — no tab is highlighted (launcher state)
- [ ] `https://rizzleroc.github.io/pursue-console/mc/coverage.html` — COVERAGE tab highlights
- [ ] Every `/mc/*.html` page shows **OPEN LIVE APP →** in the topbar and clicking it goes to `/pursue-console/`
- [ ] `https://rizzleroc.github.io/pursue-console/` — header shows **▣ MISSION CONTROL 3.0 →** and clicking it goes to `/pursue-console/mc/`

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_