### PR TITLE
fix(mc): count-up cells use setTimeout (rAF was firing 0 fps in some contexts)

### DIFF
--- a/public/mc/chrome.js
+++ b/public/mc/chrome.js
@@ -129,23 +129,37 @@
   // Count-up helper. Targets come from the static data-count attribute by
   // default; if the element also carries data-mc-count="<deriveKey>", the
   // LIVE value from the data layer overrides it once MC is ready.
+  // Uses setTimeout rather than requestAnimationFrame: rAF is throttled to
+  // ~0 fps in headless / non-visible / accessibility contexts, leaving the
+  // cells stuck on their fallback. setTimeout fires reliably everywhere.
   function easeOut(t) { return 1 - Math.pow(1 - t, 3); }
+  const FRAME_MS = 33; // ~30fps; perceptually identical to rAF for short animations
+  const DUR_MS = 1500;
+  function animateOne(elx) {
+    let target = parseFloat(elx.dataset.count);
+    const liveKey = elx.dataset.mcCount;
+    if (liveKey && window.MC && window.MC.derive && window.MC.derive[liveKey] != null) {
+      const lv = window.MC.derive[liveKey];
+      if (typeof lv === 'number' && isFinite(lv)) target = lv;
+    }
+    if (!isFinite(target)) return;
+    // Mark so we don't re-animate from 0 every time MC revalidates — write
+    // the target value directly on subsequent passes.
+    if (elx._mcAnimated) {
+      elx.textContent = Math.round(target).toLocaleString();
+      return;
+    }
+    elx._mcAnimated = true;
+    const start = Date.now();
+    (function step() {
+      const elapsed = Date.now() - start;
+      const t = Math.min(1, elapsed / DUR_MS);
+      elx.textContent = Math.round(target * easeOut(t)).toLocaleString();
+      if (t < 1) setTimeout(step, FRAME_MS);
+    })();
+  }
   function runCountUp() {
-    document.querySelectorAll('[data-count]').forEach(elx => {
-      let target = parseFloat(elx.dataset.count);
-      const liveKey = elx.dataset.mcCount;
-      if (liveKey && window.MC && window.MC.derive && window.MC.derive[liveKey] != null) {
-        const lv = window.MC.derive[liveKey];
-        if (typeof lv === 'number' && isFinite(lv)) target = lv;
-      }
-      const start = performance.now();
-      function frame(now) {
-        const t = Math.min(1, (now - start) / 1500);
-        elx.textContent = Math.round(target * easeOut(t)).toLocaleString();
-        if (t < 1) requestAnimationFrame(frame);
-      }
-      requestAnimationFrame(frame);
-    });
+    document.querySelectorAll('[data-count]').forEach(animateOne);
   }
 
   // Live review badge from the data layer
@@ -158,11 +172,12 @@
   }
 
   if (window.MC && typeof window.MC.ready === 'function') {
-    // Live data present — run count-up against real targets once loaded.
+    // Live data present — animate count-up to LIVE targets once MC is ready,
+    // and re-sync (without re-animating) on every revalidation.
     window.MC.ready().then(() => { runCountUp(); updateReviewBadge(); });
-    window.MC.onUpdate(() => { updateReviewBadge(); });
-    // If MC is slow, still animate the static fallbacks after 1.2s.
-    setTimeout(() => { if (!window.MC._loaded) runCountUp(); }, 1200);
+    window.MC.onUpdate(() => { runCountUp(); updateReviewBadge(); });
+    // Fallback if MC stays slow: still animate the static data-count targets.
+    setTimeout(() => { if (!window.MC._loaded) runCountUp(); }, 1500);
   } else {
     setTimeout(runCountUp, 600);
   }


### PR DESCRIPTION
## Summary

Fixes the only remaining bug in the deployed Mission Control live-data wiring: the four mission-status readout cells on `/mc/live.html` (CATALOGUED · COMPLETE · AWAITING · R02 INTAKE) and the four summary cells on `/mc/coverage.html` were stuck on their fallback "0" placeholder.

## Root cause

`requestAnimationFrame` callbacks were firing 0 times in some rendering contexts. Diagnosed via `whipgen_web_eval` against the deployed page:

```
mc_loaded: true
MC.derive.coverageTotal: 220, coverageComplete: 3   ← data layer correct
Summary cells: 4 cells, data-mc-count keys correct  ← bindings correct
Manual textContent write: ✓ (writes 220/3/68/149)   ← DOM accepts writes
rAF probe (60 callbacks over 1500ms): fired 0 times ← rAF throttled
setTimeout probe: fires normally                     ← workable path
```

Every other `[data-mc]` binding on the page rendered correctly (radar rail, legend, signals feed, mined index, etc) — the bug was isolated to the rAF-driven count-up animation.

This is the well-known browser behavior: `requestAnimationFrame` is paused or throttled to ~0 fps in headless / non-visible / accessibility-mode / battery-saver / mobile-background-tab contexts. Real users with the tab in foreground would see the animation; everyone else got "0".

## Fix

Switched count-up to a 33ms `setTimeout` loop (~30fps; perceptually identical for a 1.5s animation). Runs reliably everywhere.

Also: count-up now re-runs on every `MC.onUpdate` (was: only first `MC.ready`). The `_mcAnimated` guard makes subsequent passes idempotent — writes the target value directly without restarting the 0→target animation every 60s revalidation.

## Test plan

- [ ] After deploy, `/mc/live.html` shows CATALOGUED **121/162** · COMPLETE **3** · AWAITING **98%** · R02 INTAKE **7/64** (animated up from 0)
- [ ] `/mc/coverage.html` summary cells show TOTAL CATALOGUED **220** · COMPLETE **3** · PARTIAL **68** · NO DATA **149**
- [ ] No regression on the other live bindings (radar rail / legend / signals / queue / mined index — all already verified live in production)
- [ ] On 60s revalidation: cells stay at their live values (no re-animation flicker)

1 file, +34 / −19. Pure fix.

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_