### PR TITLE
feat(mc): turn every Mission Control interaction real

### DIFF
--- a/public/mc/atlas.html
+++ b/public/mc/atlas.html
@@ -27,6 +27,7 @@
     .at-grid .cell.h5 .v { color: var(--void); }
     .at-grid .cell.h4 .v { color: var(--void); }
     .at-grid .cell .v.zero { color: var(--text-4); }
+    .at-grid a.cell { color: inherit; text-decoration: none; }
     .at-summary { margin-top: 26px; padding-top: 22px; border-top: 1px solid var(--hairline); display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
     .at-summary .s { padding-left: 18px; border-left: 1px solid var(--hairline); }
     .at-summary .s:first-child { padding-left: 0; border-left: none; }
@@ -273,10 +274,15 @@
       var rt = rowTotals[a[0]];
       ERA_KEYS.forEach(function (c) {
         var n = M[a[0]][c];
-        var cell = el("div", "cell " + densityClass(n));
+        var cell;
         if (n === 0) {
+          cell = el("div", "cell " + densityClass(n));
           cell.appendChild(el("span", "v zero", "&middot;"));
         } else {
+          cell = el("a", "cell " + densityClass(n));
+          cell.setAttribute("href", "search.html?agency=" + encodeURIComponent(a[0]) + "&era=" + encodeURIComponent(c));
+          cell.style.textDecoration = "none";
+          cell.style.color = "inherit";
           cell.appendChild(el("span", "v", String(n)));
           var pct = rt ? Math.round((n / rt) * 100) : 0;
           cell.appendChild(el("span", "pct", pct + "%"));

--- a/public/mc/coverage.html
+++ b/public/mc/coverage.html
@@ -11,8 +11,14 @@
     .body2 { padding: 0 56px 64px; display: grid; grid-template-columns: minmax(0,1fr) 380px; gap: 24px; position: relative; z-index: 3; }
     .cov-card { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; backdrop-filter: blur(10px); }
     .cov-grid { display: grid; grid-template-columns: repeat(11, 1fr); gap: 8px; max-width: 700px; margin: 22px auto; }
-    .cov-cell { aspect-ratio: 1; background: #0A1018; border: 1px solid #182232; opacity: 0; animation: cov-in 0.5s cubic-bezier(.2,.7,.2,1) forwards; transition: transform .15s; cursor: pointer; }
+    .cov-cell { aspect-ratio: 1; background: #0A1018; border: 1px solid #182232; opacity: 0; animation: cov-in 0.5s cubic-bezier(.2,.7,.2,1) forwards; transition: transform .15s; cursor: pointer; display: block; text-decoration: none; color: inherit; }
     .cov-cell:hover { transform: scale(1.18); border-color: var(--amber); }
+    a.cov-cell { display: block; text-decoration: none; color: inherit; }
+    .queue-row.linked { text-decoration: none; color: inherit; cursor: pointer; transition: background .15s; }
+    .queue-row.linked:hover { background: rgba(242,166,35,0.04); }
+    .queue-row .right-actions { display: flex; align-items: center; gap: 10px; }
+    .claim-pill { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--amber); border: 1px solid rgba(242,166,35,0.45); padding: 4px 8px; text-decoration: none; transition: background .15s, border-color .15s; font-weight: 600; }
+    .claim-pill:hover { background: rgba(242,166,35,0.12); border-color: var(--amber); }
     @keyframes cov-in { from { opacity: 0; transform: scale(.5); } to { opacity: 1; transform: scale(1); } }
     .cov-cell.partial { background: rgba(242,166,35,0.18); border-color: rgba(242,166,35,0.55); }
     .cov-cell.complete { background: rgba(74,222,128,0.25); border-color: var(--emerald); box-shadow: 0 0 14px rgba(74,222,128,0.55); animation: cov-in 0.5s cubic-bezier(.2,.7,.2,1) forwards, cp 2.6s ease-in-out 1.5s infinite; }
@@ -26,7 +32,7 @@
     .cov-summary .v.amber { color: var(--amber); text-shadow: 0 0 14px var(--amber-glow); }
     .cov-summary .v.rose { color: var(--rose); }
     .cov-summary .sub { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.08em; }
-    .queue-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; align-items: baseline; }
+    .queue-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; align-items: center; }
     .queue-row:last-child { border-bottom: none; }
     .queue-row .left { display: flex; flex-direction: column; gap: 3px; }
     .queue-row .eid { font-size: 12px; color: var(--text); font-weight: 500; }
@@ -84,7 +90,7 @@
       <div class="queue-row"><div class="left"><span class="eid">dow-uap-d63</span><span class="meta"><span class="med">MED</span> · 8pp · 0%</span></div><span class="pri">2.16</span></div>
       <div class="queue-row"><div class="left"><span class="eid">dow-uap-d54</span><span class="meta"><span class="med">MED</span> · 7pp · 23%</span></div><span class="pri">2.14</span></div>
       </div>
-      <a class="primary-cta" href="review.html" style="margin-top:24px;width:100%;justify-content:center">Open queue head <span>→</span></a>
+      <a class="primary-cta" id="queue-head-cta" href="review.html" style="margin-top:24px;width:100%;justify-content:center">Open queue head <span>→</span></a>
     </div>
   </section>
 </main>
@@ -100,12 +106,24 @@
     // 'complete' | 'partial' | (anything else → empty/dark cell, bare .cov-cell).
     function renderGrid(cells) {
       grid.innerHTML = '';
+      const byEvent = (window.MC && typeof window.MC.get === 'function') ? window.MC.get('coverage.byEvent', []) : [];
       cells.forEach((c, i) => {
-        const d = document.createElement('div');
         const cls = c === 'complete' ? ' complete' : c === 'partial' ? ' partial' : '';
-        d.className = 'cov-cell' + cls;
-        d.style.animationDelay = (300 + i * 5) + 'ms';
-        grid.appendChild(d);
+        const status = c === 'complete' ? 'complete' : c === 'partial' ? 'partial' : 'empty';
+        const entry = byEvent[i];
+        const eid = entry && (entry.eventId || entry.eid);
+        let cell;
+        if (eid && window.MC && window.MC.url && typeof window.MC.url.dossier === 'function') {
+          cell = document.createElement('a');
+          cell.href = window.MC.url.dossier(eid);
+          cell.dataset.eid = eid;
+          cell.title = eid + ' · ' + status;
+        } else {
+          cell = document.createElement('div');
+        }
+        cell.className = 'cov-cell' + cls;
+        cell.style.animationDelay = (300 + i * 5) + 'ms';
+        grid.appendChild(cell);
       });
     }
 
@@ -128,9 +146,13 @@
         const flag = String(q.flag || '').toLowerCase();
         const flagCls = FLAG_CLASS[flag] || 'med';
         const pri = (typeof q.priority === 'number' ? q.priority : parseFloat(q.priority) || 0);
+        const hasUrl = window.MC && window.MC.url;
 
-        const row = document.createElement('div');
-        row.className = 'queue-row';
+        const row = document.createElement(q.eid && hasUrl ? 'a' : 'div');
+        row.className = 'queue-row' + (q.eid && hasUrl ? ' linked' : '');
+        if (q.eid && hasUrl) {
+          row.href = 'dossier.html?eid=' + encodeURIComponent(q.eid);
+        }
 
         const left = document.createElement('div');
         left.className = 'left';
@@ -147,12 +169,27 @@
         left.appendChild(eid);
         left.appendChild(meta);
 
+        const rightActions = document.createElement('span');
+        rightActions.className = 'right-actions';
+
         const priEl = document.createElement('span');
         priEl.className = 'pri' + (flag === 'anchor' ? ' amber' : '');
         priEl.textContent = pri.toFixed(2);
+        rightActions.appendChild(priEl);
+
+        if (q.eid && hasUrl && typeof window.MC.url.claim === 'function') {
+          const claim = document.createElement('a');
+          claim.className = 'claim-pill';
+          claim.href = window.MC.url.claim(q.eid, q.page);
+          claim.target = '_blank';
+          claim.rel = 'noopener';
+          claim.textContent = 'CLAIM →';
+          claim.addEventListener('click', (e) => { e.stopPropagation(); });
+          rightActions.appendChild(claim);
+        }
 
         row.appendChild(left);
-        row.appendChild(priEl);
+        row.appendChild(rightActions);
         list.appendChild(row);
       });
     }
@@ -162,6 +199,17 @@
       if (!D) return false;
       if (Array.isArray(D.coverageCells) && D.coverageCells.length) renderGrid(D.coverageCells);
       renderQueue(D.queueTop8);
+      // Update bottom CTA → deep-link into queue head dossier.
+      const cta = document.getElementById('queue-head-cta');
+      if (cta) {
+        const queue = Array.isArray(D.queue) ? D.queue : (Array.isArray(D.queueTop8) ? D.queueTop8 : []);
+        const head = queue[0];
+        if (head && head.eid && window.MC.url && typeof window.MC.url.dossier === 'function') {
+          cta.href = window.MC.url.dossier(head.eid);
+        } else {
+          cta.href = 'review.html';
+        }
+      }
       return true;
     }
 

--- a/public/mc/data.js
+++ b/public/mc/data.js
@@ -199,6 +199,46 @@
       .sort((a, b) => b.count - a.count)
       .slice(0, n);
   };
+  // shape/behavior/sensor terms for one event (dossier signatures)
+  MC.signaturesForEvent = (eid) => {
+    const out = { shape: [], behavior: [], sensor: [] };
+    for (const k of Object.keys(out)) {
+      const bucket = MC.get(`patterns.byKind.${k}`, []);
+      out[k] = bucket
+        .map((t) => {
+          const hit = (t.events || []).find((x) => x.eid === eid);
+          return hit ? { term: t.term, count: hit.count } : null;
+        })
+        .filter(Boolean)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 5);
+    }
+    return out;
+  };
+  // event metadata lookup (by id)
+  MC.byEid = (eid) => {
+    if (!MC.derive || !MC.derive.events) return null;
+    return MC.derive.events.find((e) => e.id === eid) || null;
+  };
+  // URL helpers
+  MC.url = {
+    dossier: (eid, extra = "") => `dossier.html?eid=${encodeURIComponent(eid)}${extra ? "&" + extra : ""}`,
+    claim:   (eid, page) => {
+      // Pre-fill a GitHub issue against the repo, type:cataloguing label,
+      // body referencing the eid + page so a volunteer can pick it up.
+      const repo = "rizzleroc/pursue-console";
+      const title = `[transcribe] ${eid} · p${page || 1}`;
+      const body = `Claim this page for transcription. Source: \`public/next-missing.json\` queue.\n\n- **Event:** \`${eid}\`\n- **Page:** ${page || 1}\n\nSee HOW-CAN-I-HELP.md for the workflow.`;
+      return `https://github.com/${repo}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=cataloguing`;
+    },
+  };
+  // URL query parsing
+  MC.query = (() => {
+    const qs = new URLSearchParams(window.location.search);
+    const out = {};
+    qs.forEach((v, k) => { out[k] = v; });
+    return out;
+  })();
 
   // ─────────── Declarative text binding ───────────
   // <span data-mc="r1Catalogued"></span>  → MC.derive.r1Catalogued

--- a/public/mc/dossier.html
+++ b/public/mc/dossier.html
@@ -210,14 +210,16 @@
 // ── Dossier live-data wiring ──────────────────────────────────────────────
 // Binds the page to window.MC (data.js). Every hardcoded value in the markup
 // above stays as the fallback: we only overwrite a node once real data for it
-// exists, so a fetch failure degrades to the static mockup.
+// exists, so a fetch failure degrades to the static mockup. The subject event
+// is determined by the ?eid=... URL param; if that resolves we render it,
+// otherwise we fall back to a preferred chain (fbi anchor → usper → first w/ neighbors).
 (function () {
   if (!window.MC || !MC.ready) return;
 
-  // Candidate subjects, best first. fbi-62hq83894 is the strongest real anchor
-  // (234 chunks + 10 neighbors + rich entity/shape/behavior/sensor coverage);
-  // usper-2025 is the legacy hardcoded subject and resolves too.
+  // Candidate subjects in priority order after the URL param.
   var PREFERRED = ["fbi-62hq83894", "usper-2025"];
+  var lastRenderedEid = null; // guard against onUpdate flicker
+
   var esc = function (s) {
     return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
       return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
@@ -226,37 +228,35 @@
 
   function pickSubject() {
     var events = (MC.derive && MC.derive.events) || [];
-    var sim = (MC.derive && MC.derive.similarity) || {};
     var hasN = function (id) { return MC.neighbors(id, 1).length > 0; };
-    var inEvents = function (id) { return events.some(function (e) { return e.id === id; }); };
-    // 1) preferred ids present in events + similarity graph
+    // 1) URL ?eid=... if it resolves to a real event
+    var qEid = MC.query && MC.query.eid;
+    if (qEid && MC.byEid(qEid)) return qEid;
+    // 2) preferred ids that exist
     for (var i = 0; i < PREFERRED.length; i++) {
-      var id = PREFERRED[i];
-      if (inEvents(id) && hasN(id)) return id;
+      if (MC.byEid(PREFERRED[i])) return PREFERRED[i];
     }
-    // 2) any event that has neighbors
+    // 3) first event with a similarity entry
     for (var j = 0; j < events.length; j++) {
       if (hasN(events[j].id)) return events[j].id;
     }
-    // 3) any event at all, else the legacy default
+    // 4) any event at all, else the legacy default
     return events.length ? events[0].id : "usper-2025";
   }
 
-  // Per-event terms for a pattern kind, sorted by per-event count; falls back
-  // to the global top terms (by total) when the event mentions none.
-  function kindForEvent(kind, eid) {
-    var items = MC.get("patterns.byKind." + kind, []) || [];
-    var hits = items.map(function (e) {
-      var hit = (e.events || []).find(function (x) { return x.eid === eid; });
-      return hit ? { term: e.term, n: hit.count } : null;
-    }).filter(Boolean).sort(function (a, b) { return b.n - a.n; });
-    if (hits.length) return hits;
-    return items.slice()
-      .sort(function (a, b) { return (b.total || 0) - (a.total || 0); })
-      .map(function (e) { return { term: e.term, n: e.total }; });
+  // Map agency → existing .dot class. NASA gets an inline emerald color because
+  // there isn't a dedicated .dot.e class. anchor flag overrides → rose.
+  function agencyDot(rec) {
+    if (!rec) return { cls: "z", style: "" };
+    if (rec.flag === "anchor") return { cls: "r", style: "" };
+    var a = (rec.agency || "").toLowerCase();
+    if (a.indexOf("department of war") >= 0 || a === "dow") return { cls: "a", style: "" };
+    if (a === "fbi") return { cls: "c", style: "" };
+    if (a === "nasa") return { cls: "", style: "background:var(--emerald)" };
+    return { cls: "z", style: "" };
   }
 
-  function renderChips(containerLabel, kind, eid) {
+  function renderChips(containerLabel, kind, rows) {
     // find the .sig-chips that follows the matching .label
     var labels = document.querySelectorAll(".sig-grid .label");
     var target = null;
@@ -266,58 +266,52 @@
       }
     }
     if (!target || !target.classList.contains("sig-chips")) return;
-    var rows = kindForEvent(kind, eid);
-    if (!rows.length) return; // keep fallback chips
+    if (!rows || !rows.length) {
+      target.innerHTML = '<span style="color:var(--text-4);font-size:11px">—</span>';
+      return;
+    }
     target.innerHTML = rows.slice(0, 5).map(function (r) {
       return '<span class="sig-chip ' + kind + '">' + esc(r.term) +
-        ' <span class="v">' + esc(r.n) + '</span></span>';
+        ' <span class="v">' + esc(r.count) + '</span></span>';
     }).join("");
-  }
-
-  function dotClass(cos) {
-    if (cos >= 0.85) return "r";   // rose — very strong
-    if (cos >= 0.70) return "a";   // amber — strong
-    if (cos >= 0.55) return "c";   // cyan — moderate
-    return "z";                    // grey — weak
   }
 
   function render() {
     var events = (MC.derive && MC.derive.events) || [];
     if (!events.length) return; // no data yet → keep full static fallback
     var eid = pickSubject();
-    var rec = events.find(function (e) { return e.id === eid; });
+    var rec = MC.byEid(eid);
+    if (!rec) return; // keep the static fallback content and bail
+    if (eid === lastRenderedEid) return; // no-op on re-fire with same subject
+    lastRenderedEid = eid;
 
     // 1) Header ------------------------------------------------------------
-    if (rec) {
-      var metaRow = document.querySelector(".ds-header .meta-row");
-      if (metaRow) {
-        var anchorPill = metaRow.querySelector(".anchor");
-        if (anchorPill) anchorPill.style.display = (rec.flag === "anchor") ? "" : "none";
-        var idEl = metaRow.querySelector(".id");
-        if (idEl) idEl.textContent = rec.id;
-        // agency is the first plain <span> after the id (markup: id · agency · stamp · date · title)
-        var spans = metaRow.querySelectorAll("span");
-        // spans: [anchor?, id, "·", agency, "·", stamp, "·", date, "·", title]
-        var agencyEl = idEl ? idEl.nextElementSibling && idEl.nextElementSibling.nextElementSibling : null;
-        if (agencyEl && !agencyEl.classList.contains("stamp")) agencyEl.textContent = rec.agency || agencyEl.textContent;
-        var dateEl = metaRow.querySelector(".stamp");
-        // date is the span two after .stamp (stamp · date)
-        if (dateEl) {
-          var afterStamp = dateEl.nextElementSibling && dateEl.nextElementSibling.nextElementSibling;
-          if (afterStamp) afterStamp.textContent = rec.date || afterStamp.textContent;
-          // last span = short descriptor → use the title text
-          var lastSpan = spans[spans.length - 1];
-          if (lastSpan && lastSpan !== afterStamp) lastSpan.textContent = rec.title || lastSpan.textContent;
-        }
+    var metaRow = document.querySelector(".ds-header .meta-row");
+    if (metaRow) {
+      var anchorPill = metaRow.querySelector(".anchor");
+      if (anchorPill) anchorPill.style.display = (rec.flag === "anchor") ? "" : "none";
+      var idEl = metaRow.querySelector(".id");
+      if (idEl) idEl.textContent = String(rec.id || "").toUpperCase();
+      // markup: [anchor?] · id · "·" · agency · "·" · stamp · "·" · date · "·" · descriptor
+      var spans = metaRow.querySelectorAll("span");
+      var agencyEl = idEl ? idEl.nextElementSibling && idEl.nextElementSibling.nextElementSibling : null;
+      if (agencyEl && !agencyEl.classList.contains("stamp")) agencyEl.textContent = rec.agency || agencyEl.textContent;
+      var stampEl = metaRow.querySelector(".stamp");
+      if (stampEl) {
+        var afterStamp = stampEl.nextElementSibling && stampEl.nextElementSibling.nextElementSibling;
+        if (afterStamp) afterStamp.textContent = rec.date || afterStamp.textContent;
+        var lastSpan = spans[spans.length - 1];
+        if (lastSpan && lastSpan !== afterStamp) lastSpan.textContent = rec.title || lastSpan.textContent;
       }
-      var h1 = document.querySelector(".ds-header h1");
-      if (h1 && rec.title) h1.textContent = rec.title;
     }
+    var h1 = document.querySelector(".ds-header h1");
+    if (h1 && rec.title) h1.textContent = rec.title;
 
     // 2) Signatures --------------------------------------------------------
-    renderChips("SHAPE", "shape", eid);
-    renderChips("BEHAVIOR", "behavior", eid);
-    renderChips("SENSOR", "sensor", eid);
+    var sigs = (MC.signaturesForEvent && MC.signaturesForEvent(eid)) || { shape: [], behavior: [], sensor: [] };
+    renderChips("SHAPE", "shape", sigs.shape);
+    renderChips("BEHAVIOR", "behavior", sigs.behavior);
+    renderChips("SENSOR", "sensor", sigs.sensor);
 
     // 3) Entities & dates --------------------------------------------------
     var ents = MC.entitiesForEvent(eid, 8);
@@ -325,7 +319,6 @@
     if (entCol && ents.length) {
       var heading = entCol.querySelector("div");
       var head = heading ? heading.outerHTML : "";
-      // update "(N in event)" label
       head = head.replace(/\(\s*\d+\s+in event\s*\)/i, "(" + ents.length + " in event)");
       entCol.innerHTML = head + ents.map(function (e) {
         return '<div class="ent-row"><span class="name">' + esc(e.term) +
@@ -333,7 +326,8 @@
           '<span class="ct">' + esc(e.count) + '</span></div>';
       }).join("");
     }
-    // header counts: "199 ents · 67 dates"
+    // header counts: "patterns.json · N ents · M dates" (data-mc already covers
+    // entityCount/dateCount where bound, but the dossier header uses literal text)
     var entHdr = document.querySelectorAll(".ds-section .ds-h .r");
     entHdr.forEach(function (el) {
       if (/ents\b/.test(el.textContent) && /dates\b/.test(el.textContent)) {
@@ -349,17 +343,30 @@
       var t = sec.querySelector(".ds-h .t");
       if (t && /SEMANTIC NEIGHBORS/i.test(t.textContent)) nbSection = sec;
     });
-    if (nbSection && neigh.length) {
-      // remove existing static rows, keep the .ds-h header
-      nbSection.querySelectorAll(".nb-row").forEach(function (n) { n.remove(); });
-      var frag = neigh.map(function (nb) {
-        return '<div class="nb-row"><div class="left"><span class="dot ' + dotClass(nb.cos) +
-          '"></span><span class="t">' + esc(nb.eid) + '</span></div>' +
-          '<span class="cos">' + nb.cos.toFixed(2) + '</span></div>';
-      }).join("");
-      nbSection.insertAdjacentHTML("beforeend", frag);
+    if (nbSection) {
+      // strip both existing rows and any prior empty-notice
+      nbSection.querySelectorAll(".nb-row, .nb-empty").forEach(function (n) { n.remove(); });
       var rHdr = nbSection.querySelector(".ds-h .r");
-      if (rHdr) rHdr.textContent = neigh.length + " · event-similarity.json";
+      if (!neigh.length) {
+        nbSection.insertAdjacentHTML(
+          "beforeend",
+          '<div class="nb-empty" style="font-family:\'JetBrains Mono\',monospace;font-size:11px;color:var(--text-4);padding:14px 0;line-height:1.5">no semantic neighbors — outside the 75-event embedding cohort</div>'
+        );
+        if (rHdr) rHdr.textContent = "0 · event-similarity.json";
+      } else {
+        var frag = neigh.map(function (nb) {
+          var nbRec = MC.byEid(nb.eid);
+          var dot = agencyDot(nbRec);
+          var label = (nbRec && nbRec.title) || nb.eid;
+          var href = "dossier.html?eid=" + encodeURIComponent(nb.eid);
+          return '<a class="nb-row" href="' + href + '" style="text-decoration:none;color:inherit"><div class="left">' +
+            '<span class="dot ' + dot.cls + '"' + (dot.style ? ' style="' + dot.style + '"' : '') + '></span>' +
+            '<span class="t">' + esc(label) + '</span></div>' +
+            '<span class="cos">' + nb.cos.toFixed(2) + '</span></a>';
+        }).join("");
+        nbSection.insertAdjacentHTML("beforeend", frag);
+        if (rHdr) rHdr.textContent = neigh.length + " · event-similarity.json";
+      }
     }
   }
 

--- a/public/mc/globe.html
+++ b/public/mc/globe.html
@@ -41,15 +41,15 @@
 <main>
   <section class="page-title">
     <div class="eyebrow"><span class="div"></span>SURFACE · 10 — orbital projection</div>
-    <h1><span id="gl-eventcount">220</span> events plotted by lat/lon. <em>The blank zones tell their own story.</em></h1>
-    <p class="sub">Pins encode region density: hot amber where multiple events cluster, cool cyan for single sightings. Africa and Oceania are nearly empty — archive gap, not data gap. Drag to spin · scroll to zoom · tap any pin to open its dossier.</p>
+    <h1><span id="gl-eventcount">100</span> events plotted by lat/lon. <em>The blank zones tell their own story.</em></h1>
+    <p class="sub"><span id="gl-plotted">100</span> events plotted · <span id="gl-pending">120</span> pending coordinates. Pins encode region density: hot amber where multiple events cluster, cool cyan for single sightings. Africa and Oceania are nearly empty — archive gap, not data gap. Tap any pin to open its dossier.</p>
   </section>
 
   <section class="gl-shell">
     <div class="gl-card">
       <div class="gl-h">
         <div class="t"><div class="icon"></div>WORLD VIEW · ORTHOGRAPHIC</div>
-        <div class="meta">LAT/LON · 220 EVENTS · projection equirectangular</div>
+        <div class="meta">LAT/LON · <span id="gl-meta-count">220</span> EVENTS · projection equirectangular</div>
       </div>
 
       <svg class="globe-svg" viewBox="0 0 1100 580" xmlns="http://www.w3.org/2000/svg">
@@ -132,6 +132,9 @@
           <g class="pin"><circle cx="410" cy="68" r="3" fill="rgba(74,222,128,0.7)"/></g>
         </g>
 
+        <!-- Per-event pins (populated by JS from MC.derive.events) -->
+        <g id="event-pins"></g>
+
         <!-- Center crosshair -->
         <line x1="475" y1="285" x2="475" y2="295" stroke="rgba(244,236,212,0.5)" stroke-width="1"/>
         <line x1="470" y1="290" x2="480" y2="290" stroke="rgba(244,236,212,0.5)" stroke-width="1"/>
@@ -213,6 +216,84 @@
       }
     }
 
+    // Per-event pin colour by region.
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+    var XLINK_NS = 'http://www.w3.org/1999/xlink';
+    var REGION_FILL = {
+      'North America': 'rgba(242,166,35,0.85)',
+      'Middle East':   'rgba(242,166,35,0.85)',
+      'Europe':        'rgba(97,215,240,0.85)',
+      'Asia-Pacific':  'rgba(97,215,240,0.85)',
+      'Asia':          'rgba(97,215,240,0.85)',
+      'Space':         'rgba(74,222,128,0.85)',
+      'Africa':        'rgba(224,73,104,0.85)',
+      'Oceania':       'rgba(224,73,104,0.85)',
+      'Unknown':       'rgba(184,168,135,0.55)'
+    };
+
+    function project(lat, lng) {
+      var x = 80 + ((lng + 180) / 360) * 940;
+      var y = 290 - (lat / 90) * 250;
+      if (x < 80)   x = 80;
+      if (x > 1020) x = 1020;
+      if (y < 40)   y = 40;
+      if (y > 540)  y = 540;
+      return [x, y];
+    }
+
+    function renderEventPins(events) {
+      var host = document.getElementById('event-pins');
+      if (!host || !events) return 0;
+      // Clear any previously-rendered pins (idempotent under MC.onUpdate).
+      while (host.firstChild) host.removeChild(host.firstChild);
+      var plotted = 0;
+      var dossier = (window.MC && window.MC.url && window.MC.url.dossier) || function (id) { return 'dossier.html?eid=' + encodeURIComponent(id); };
+      for (var i = 0; i < events.length; i++) {
+        var ev = events[i];
+        var c = ev.coords || [0, 0];
+        if (c[0] === 0 && c[1] === 0) continue;
+        var xy = project(c[0], c[1]);
+        var region = ev.region || 'Unknown';
+        var fill = REGION_FILL[region] || REGION_FILL['Unknown'];
+        var isAnchor = ev.flag === 'anchor';
+
+        var a = document.createElementNS(SVG_NS, 'a');
+        a.setAttributeNS(XLINK_NS, 'href', dossier(ev.id));
+        a.setAttribute('href', dossier(ev.id));
+
+        if (isAnchor) {
+          var ring = document.createElementNS(SVG_NS, 'circle');
+          ring.setAttribute('cx', xy[0]);
+          ring.setAttribute('cy', xy[1]);
+          ring.setAttribute('r', 9);
+          ring.setAttribute('fill', 'none');
+          ring.setAttribute('stroke', fill);
+          ring.setAttribute('stroke-width', 0.6);
+          ring.setAttribute('opacity', 0.55);
+          a.appendChild(ring);
+        }
+
+        var dot = document.createElementNS(SVG_NS, 'circle');
+        dot.setAttribute('cx', xy[0]);
+        dot.setAttribute('cy', xy[1]);
+        dot.setAttribute('r', isAnchor ? 5 : 3);
+        dot.setAttribute('fill', fill);
+
+        var title = document.createElementNS(SVG_NS, 'title');
+        title.textContent = (ev.title || ev.id) + ' · ' + region;
+        a.appendChild(title);
+        a.appendChild(dot);
+        host.appendChild(a);
+        plotted++;
+      }
+      return plotted;
+    }
+
+    function setText(id, value) {
+      var el = document.getElementById(id);
+      if (el) el.textContent = value;
+    }
+
     function renderFromMC() {
       var D = window.MC && window.MC.derive;
       if (!D) return false;
@@ -220,10 +301,16 @@
         renderRegions(D.byRegion);
         renderPins(D.byRegion);
       }
-      if (D.eventCount != null) {
-        var ec = document.getElementById('gl-eventcount');
-        if (ec) ec.textContent = D.eventCount;
+      var total = (D.eventCount != null) ? D.eventCount : (D.events ? D.events.length : 0);
+      if (D.events && D.events.length) {
+        var plotted = renderEventPins(D.events);
+        setText('gl-eventcount', plotted);
+        setText('gl-plotted', plotted);
+        setText('gl-pending', Math.max(0, total - plotted));
+      } else if (D.eventCount != null) {
+        setText('gl-eventcount', D.eventCount);
       }
+      if (total) setText('gl-meta-count', total);
       return true;
     }
 

--- a/public/mc/index.html
+++ b/public/mc/index.html
@@ -106,7 +106,7 @@
       <span class="meta"><span><span data-mc="mediaTotal">362</span> tiles · DVIDS embedded</span><span class="v">→</span></span>
     </a>
 
-    <a class="lc" href="dossier.html">
+    <a class="lc" href="dossier.html?eid=fbi-62hq83894">
       <span class="code">SURFACE · 07</span>
       <h3>Dossier</h3>
       <p>Per-event reading view: summary, signatures, mined entities, semantic neighbors, page-by-page excerpts, visuals gallery.</p>

--- a/public/mc/live.html
+++ b/public/mc/live.html
@@ -101,6 +101,8 @@
     .entity-row .meter { width: 70px; height: 3px; background: rgba(242, 166, 35, 0.10); }
     .entity-row .meter span { display: block; height: 100%; background: var(--amber); box-shadow: 0 0 6px var(--amber-glow); }
     .entity-row .count { color: var(--text); font-family: 'Space Grotesk', sans-serif; font-weight: 600; font-size: 14px; min-width: 50px; text-align: right; }
+    .mc-link { text-decoration: none; color: inherit; display: contents; }
+    a.entity-row { text-decoration: none; color: inherit; }
   </style>
 </head>
 <body data-view="live">
@@ -188,14 +190,14 @@
         <div class="histo-axis"><span>00</span><span>12</span><span>24</span></div>
       </div>
       <div class="panel">
-        <div class="panel-head"><span><span class="icon-sq"></span>Oscillation · 60s</span><span class="right">activity</span></div>
-        <svg viewBox="0 0 320 60" style="width:100%;height:60px;margin-top:6px"><polyline fill="none" stroke="#F2A623" stroke-width="1.8" opacity="0.9" points="0,30 22,22 44,36 66,16 88,40 110,24 132,32 154,10 176,44 198,20 220,36 242,28 264,30 286,22 308,30 320,28"/></svg>
+        <div class="panel-head"><span><span class="icon-sq"></span>Oscillation · 60s</span><span class="right" id="osc-caption">activity</span></div>
+        <svg viewBox="0 0 320 60" style="width:100%;height:60px;margin-top:6px"><polyline id="osc-line" fill="none" stroke="#F2A623" stroke-width="1.8" opacity="0.9" points="0,30 22,22 44,36 66,16 88,40 110,24 132,32 154,10 176,44 198,20 220,36 242,28 264,30 286,22 308,30 320,28"/></svg>
         <div class="histo-axis"><span>−60s</span><span>NOW</span></div>
       </div>
       <div class="panel">
         <div class="panel-head"><span><span class="icon-sq"></span>Channels</span><span class="right">/hr</span></div>
-        <div class="ch-row"><span class="name">Vision</span><span class="rate">0 /hr</span></div>
-        <div class="ch-row"><span class="name">Tesseract</span><span class="rate">0 /hr</span></div>
+        <div class="ch-row"><span class="name">Vision</span><span class="rate" id="ch-vision">0 /hr</span></div>
+        <div class="ch-row"><span class="name">Tesseract</span><span class="rate" id="ch-ocr">0 /hr</span></div>
       </div>
       <div class="panel">
         <div class="panel-head"><span><span class="icon-sq"></span>Media types</span><span class="right">media.json</span></div>
@@ -264,10 +266,23 @@
 
 <script src="chrome.js" defer></script>
 <script>
-  // ── Ingest histogram (static, not data-layer driven) ──
+  // ── Ingest histogram (static fallback; replaced live by renderIngest()) ──
   const h = document.getElementById('histo');
   const bars = [2,1,0,0,1,3,5,8,12,9,7,11,6,4,9,14,10,6,3,8,5,2,1,0]; const mx = Math.max(...bars);
   bars.forEach((b,i) => { const d=document.createElement('div'); d.style.height='0%'; h.appendChild(d); setTimeout(() => { d.style.transition='height .9s cubic-bezier(.2,.7,.2,1)'; d.style.height=((b/mx)*100)+'%'; }, 1400+i*28); });
+
+  // Human-readable "ago" (e.g. "16h ago", "3d ago", "12m ago")
+  function humanAgo(ms){
+    if (!isFinite(ms) || ms < 0) return 'just now';
+    const s = Math.floor(ms/1000);
+    if (s < 60) return s + 's ago';
+    const m = Math.floor(s/60);
+    if (m < 60) return m + 'm ago';
+    const hr = Math.floor(m/60);
+    if (hr < 24) return hr + 'h ago';
+    const d = Math.floor(hr/24);
+    return d + 'd ago';
+  }
 
   // ── Coverage grid: deterministic random fallback (used if MC fails) ──
   function renderCoverageFallback() {
@@ -320,9 +335,16 @@
     const faOpen = document.getElementById('fa-open');
     if (faOpen && Array.isArray(D.queue)) faOpen.textContent = D.queue.length;
 
-    // CTA title hint
+    // CTA title hint + redirect to next-missing dossier
     const cta = document.getElementById('next-cta');
-    if (cta && D.queueTop && D.queueTop.eid) cta.title = 'Next: ' + D.queueTop.eid;
+    if (cta) {
+      if (D.queueTop && D.queueTop.eid) cta.title = 'Next: ' + D.queueTop.eid;
+      if (Array.isArray(D.queue) && D.queue.length && D.queue[0] && D.queue[0].eid && MC.url && MC.url.dossier) {
+        cta.href = MC.url.dossier(D.queue[0].eid);
+      } else {
+        cta.href = 'review.html';
+      }
+    }
 
     // Arriving signals from feedEntries
     const sig = document.getElementById('signals');
@@ -330,9 +352,13 @@
       sig.innerHTML = D.feedEntries.slice(0,5).map(e => {
         const src = (e.source || '').toString().toUpperCase() || 'VISION';
         const meta = [e.agency, (e.page != null ? 'p'+e.page : '')].filter(Boolean).join(' · ');
+        const eid = e.eventId || e.title || '';
+        const eidHtml = eid && MC.url && MC.url.dossier
+          ? '<a class="eid" href="'+esc(MC.url.dossier(eid))+'" style="text-decoration:none;color:inherit">'+esc(eid)+'</a>'
+          : '<span class="eid">'+esc(eid)+'</span>';
         return '<div class="signal">'
           + '<div class="signal-meta"><span class="tag">'+esc(src)+'</span>'
-          + '<span class="eid">'+esc(e.eventId||e.title||'')+'</span>'
+          + eidHtml
           + (meta ? '<span>'+esc(meta)+'</span>' : '')
           + '</div>'
           + '<p class="signal-quote">'+esc(e.snippet||'')+'</p>'
@@ -345,10 +371,93 @@
     if (asg && Array.isArray(D.queue) && D.queue.length) {
       asg.innerHTML = D.queue.slice(0,4).map(q => {
         const bits = [q.flag, q.reason].filter(Boolean).map(x => String(x).toUpperCase()).join(' · ');
-        return '<div class="help-row"><span><span class="eid">'+esc(q.eid||'')+'</span>'
+        const eid = q.eid || '';
+        const page = q.page || 1;
+        const dossierUrl = eid && MC.url && MC.url.dossier ? MC.url.dossier(eid) : '#';
+        const claimUrl = eid && MC.url && MC.url.claim ? MC.url.claim(eid, page) : '#';
+        return '<div class="help-row">'
+          + '<a href="'+esc(dossierUrl)+'" style="text-decoration:none;color:inherit;flex:1;min-width:0">'
+          + '<span class="eid">'+esc(eid)+'</span>'
           + (bits ? '<span class="pp">· '+esc(bits)+'</span>' : '')
-          + '</span><button class="claim">CLAIM</button></div>';
+          + '</a>'
+          + '<a class="claim" href="'+esc(claimUrl)+'" target="_blank" rel="noopener">CLAIM</a>'
+          + '</div>';
       }).join('');
+    }
+
+    // Ingest histogram · 24 hourly buckets over the last 24h
+    const histo = document.getElementById('histo');
+    if (histo && Array.isArray(D.feedEntries) && D.feedEntries.length) {
+      const now = Date.now();
+      const counts = new Array(24).fill(0);
+      D.feedEntries.forEach(e => {
+        const t = e && e.modifiedAt;
+        if (typeof t !== 'number') return;
+        const b = Math.max(0, Math.min(23, Math.floor((now - t) / 3600000)));
+        counts[b]++;
+      });
+      // bucket 0 = current hour; display wants "24h ago" on the left, "now" on right.
+      const display = counts.slice().reverse();
+      const maxC = Math.max(1, ...display);
+      histo.innerHTML = '';
+      display.forEach(c => {
+        const d = document.createElement('div');
+        d.style.height = ((c / maxC) * 100) + '%';
+        if (c === 0) d.style.opacity = '0.12';
+        d.title = c + ' page(s)';
+        histo.appendChild(d);
+      });
+    }
+
+    // Oscillation · 60s · 12 buckets of 5s each
+    const osc = document.getElementById('osc-line');
+    const oscCap = document.getElementById('osc-caption');
+    if (osc && Array.isArray(D.feedEntries)) {
+      const now = Date.now();
+      const buckets = new Array(12).fill(0);
+      D.feedEntries.forEach(e => {
+        const t = e && e.modifiedAt;
+        if (typeof t !== 'number') return;
+        const diff = now - t;
+        if (diff >= 0 && diff < 60000) {
+          const b = Math.min(11, Math.floor(diff / 5000));
+          // bucket 0 = freshest (closest to now) → display on right
+          buckets[11 - b]++;
+        }
+      });
+      const total = buckets.reduce((a,b)=>a+b, 0);
+      if (total > 0) {
+        const mx = Math.max(1, ...buckets);
+        const pts = buckets.map((c,i) => (i*26.66).toFixed(2) + ',' + (30 - (c/mx)*22).toFixed(2)).join(' ');
+        osc.setAttribute('points', pts);
+        osc.setAttribute('opacity', '0.9');
+        if (oscCap) oscCap.textContent = total + ' in 60s';
+      } else {
+        // No live activity — keep the demo polyline but dim it, show last-build age.
+        osc.setAttribute('opacity', '0.25');
+        if (oscCap) {
+          const feedRaw = (MC.data && MC.data.feed) || {};
+          const gen = feedRaw.generatedAt ? Date.parse(feedRaw.generatedAt) : NaN;
+          const ageStr = isFinite(gen) ? humanAgo(now - gen) : 'unknown';
+          oscCap.textContent = 'no live activity · last build ' + ageStr;
+        }
+      }
+    }
+
+    // Channels · /hr — vision vs ocr (tesseract) in the last 60 minutes
+    const chV = document.getElementById('ch-vision');
+    const chO = document.getElementById('ch-ocr');
+    if ((chV || chO) && Array.isArray(D.feedEntries)) {
+      const now = Date.now();
+      let v = 0, o = 0;
+      D.feedEntries.forEach(e => {
+        const t = e && e.modifiedAt;
+        if (typeof t !== 'number' || (now - t) > 3600000 || (now - t) < 0) return;
+        if (e.source === 'vision') v++;
+        else if (e.source === 'ocr') o++;
+      });
+      if (chV) chV.textContent = v + ' /hr';
+      if (chO) chO.textContent = o + ' /hr';
     }
 
     // Mined index from topEntities
@@ -358,9 +467,12 @@
       const maxM = Math.max(...top.map(e => e.mentions||0), 1);
       ents.innerHTML = top.map(e => {
         const w = Math.max(6, Math.round(((e.mentions||0)/maxM)*100));
-        return '<div class="entity-row"><span class="name">'+esc(e.term||'')+'</span>'
+        const term = e.term || '';
+        const href = 'search.html?q=' + encodeURIComponent(term);
+        return '<a class="entity-row" href="'+esc(href)+'">'
+          + '<span class="name">'+esc(term)+'</span>'
           + '<span class="meter"><span style="width:'+w+'%"></span></span>'
-          + '<span class="count">'+esc((e.mentions||0).toLocaleString())+'</span></div>';
+          + '<span class="count">'+esc((e.mentions||0).toLocaleString())+'</span></a>';
       }).join('');
     }
   }

--- a/public/mc/review.html
+++ b/public/mc/review.html
@@ -13,6 +13,7 @@
     .rv-row { display: flex; flex-direction: column; gap: 4px; padding: 14px 0; border-bottom: 1px solid var(--hairline); cursor: pointer; transition: padding-left .2s; }
     .rv-row:hover { padding-left: 6px; }
     .rv-row.active { padding-left: 8px; border-left: 2px solid var(--amber); background: rgba(242,166,35,0.05); margin: 0 -22px; padding: 14px 22px 14px 26px; }
+    .rv-row-link { text-decoration: none; color: inherit; display: block; }
     .rv-row .top { display: flex; align-items: center; gap: 8px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; }
     .rv-row .top .agree { margin-left: auto; color: var(--rose); font-weight: 700; }
     .rv-row .top .agree.high { color: var(--amber); }
@@ -57,21 +58,21 @@
     <div class="rv-queue">
       <div id="rv-queue-head" style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.22em;color:var(--text-3);text-transform:uppercase;font-weight:700;margin-bottom:14px;padding-bottom:12px;border-bottom:1px solid var(--hairline);display:flex;justify-content:space-between"><span id="rv-queue-label">QUEUE · WORST AGREEMENT</span><span id="rv-queue-count" style="color:var(--amber)">3</span></div>
       <div id="rv-queue-list">
-      <div class="rv-row active">
+      <a class="rv-row-link" href="dossier.html?eid=usper-2025"><div class="rv-row active">
         <div class="top"><span>FBI</span><span>·</span><span>2025-10</span><span class="agree">0.21</span></div>
         <div class="eid">usper-2025 · p 03</div>
         <div class="meta">vision · ocr · gemini · 4 sources disagree</div>
-      </div>
-      <div class="rv-row">
+      </div></a>
+      <a class="rv-row-link" href="dossier.html?eid=dow-uap-d48"><div class="rv-row">
         <div class="top"><span>DEPT/War</span><span>·</span><span>1996</span><span class="agree">0.34</span></div>
         <div class="eid">dow-uap-d48 · p 087</div>
         <div class="meta">vision · pdfjs · 2 sources disagree</div>
-      </div>
-      <div class="rv-row">
+      </div></a>
+      <a class="rv-row-link" href="dossier.html?eid=dow-uap-d038"><div class="rv-row">
         <div class="top"><span>DEPT/War</span><span>·</span><span>2020-05</span><span class="agree high">0.48</span></div>
         <div class="eid">dow-uap-d038 · p 12</div>
         <div class="meta">vision · ocr · minor</div>
-      </div>
+      </div></a>
       </div>
 
       <div style="margin-top:24px;padding-top:18px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.14em">
@@ -108,8 +109,8 @@
 
       <div class="actions-bar">
         <span class="meta">SUBMISSION · opens pre-filled PR · reviewer credit: anonymous OK</span>
-        <button class="ab-btn ghost">SKIP — next page</button>
-        <button class="ab-btn primary">▣ SUBMIT MERGED TEXT →</button>
+        <button class="ab-btn ghost" style="cursor:default">SKIP — next page</button>
+        <a id="rv-submit-btn" class="ab-btn primary" href="#" target="_blank" rel="noopener" style="text-decoration:none;display:inline-block">▣ SUBMIT MERGED TEXT →</a>
       </div>
     </div>
   </section>
@@ -164,7 +165,8 @@
     const count = document.getElementById('rv-queue-count');
     if (count) count.textContent = n;
 
-    // Queue list — top 12 from the transcription queue
+    // Queue list — top 12 from the transcription queue. Each row is wrapped
+    // in an anchor to MC.url.dossier(eid) so click → dossier.
     const list = document.getElementById('rv-queue-list');
     if (list) {
       list.innerHTML = q.slice(0, 12).map((item, i) => {
@@ -175,12 +177,14 @@
         const reason = (item.reason || '').toString();
         const meta = [reason, 'priority ' + (item.priority ?? '—')]
           .filter(Boolean).join(' · ');
-        return '<div class="rv-row' + (i === 0 ? ' active' : '') + '">'
+        const href = MC.url && MC.url.dossier ? MC.url.dossier(eid) : '#';
+        return '<a class="rv-row-link" href="' + esc(href) + '">'
+          + '<div class="rv-row' + (i === 0 ? ' active' : '') + '">'
           + '<div class="top"><span>' + esc(agency) + '</span><span>·</span>'
           + '<span class="agree high">' + esc(flag || '—') + '</span></div>'
           + '<div class="eid">' + esc(eid) + (pg ? ' · ' + esc(pg) : '') + '</div>'
           + '<div class="meta">' + esc(meta) + '</div>'
-          + '</div>';
+          + '</div></a>';
       }).join('');
     }
 
@@ -188,6 +192,13 @@
     const pane = document.getElementById('rv-pane-title');
     if (pane && q[0] && q[0].eid) {
       pane.textContent = q[0].eid + (q[0].page != null ? ' · page ' + q[0].page : '');
+    }
+
+    // Bind the SUBMIT MERGED TEXT primary button → pre-filled GitHub issue
+    // for the first queued page (MC.url.claim(eid, page)).
+    const submitBtn = document.getElementById('rv-submit-btn');
+    if (submitBtn && q[0] && MC.url && MC.url.claim) {
+      submitBtn.href = MC.url.claim(q[0].eid, q[0].page);
     }
   }
 

--- a/public/mc/search.html
+++ b/public/mc/search.html
@@ -28,13 +28,13 @@
     .stats-row .v { color: var(--amber); font-weight: 600; }
     .stats-row .right { margin-left: auto; }
     .results-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-    .rc { background: var(--surface); border: 1px solid var(--border); padding: 18px 20px; backdrop-filter: blur(10px); transition: all .2s; cursor: pointer; position: relative; overflow: hidden; }
+    .rc { background: var(--surface); border: 1px solid var(--border); padding: 18px 20px; backdrop-filter: blur(10px); transition: all .2s; cursor: pointer; position: relative; overflow: hidden; display: block; color: inherit; text-decoration: none; }
     .rc:hover { border-color: var(--border-strong); }
     .rc::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--amber); opacity: 0; transition: opacity .2s; }
     .rc:hover::before { opacity: 1; box-shadow: 0 0 10px var(--amber-glow); }
     .rc .top { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; }
     .rc .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--amber); }
-    .rc .dot.r { background: var(--rose); } .rc .dot.c { background: var(--cyan); } .rc .dot.e { background: var(--emerald); }
+    .rc .dot.r { background: var(--rose); } .rc .dot.c { background: var(--cyan); } .rc .dot.e { background: var(--emerald); } .rc .dot.g { background: var(--text-4); }
     .rc .eid { color: var(--cyan); }
     .rc .score { margin-left: auto; color: var(--amber); font-weight: 600; }
     .rc h3 { font-family: 'Space Grotesk', sans-serif; font-size: 17px; font-weight: 600; line-height: 1.25; margin: 0 0 10px; color: var(--text); letter-spacing: -0.01em; }
@@ -42,6 +42,12 @@
     .rc p mark { background: rgba(242,166,35,0.22); color: var(--amber-bright); padding: 0 4px; }
     .rc .bottom { display: flex; justify-content: space-between; align-items: center; padding-top: 12px; border-top: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.14em; text-transform: uppercase; }
     .rc .bottom .pg { color: var(--amber); }
+    .empty-state { display: none; border: 1px dashed var(--border-strong); padding: 40px 32px; text-align: center; font-family: 'JetBrains Mono', monospace; color: var(--text-3); letter-spacing: 0.14em; font-size: 12px; background: var(--surface); }
+    .empty-state.on { display: block; }
+    .empty-state h3 { font-family: 'Space Grotesk', sans-serif; color: var(--amber); font-size: 20px; letter-spacing: -0.01em; margin: 0 0 8px; }
+    .meaning-note { display: none; margin-top: 12px; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--cyan); letter-spacing: 0.10em; }
+    .meaning-note.on { display: block; }
+    .browse-hint { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.18em; margin: 0 0 12px; }
   </style>
 </head>
 <body data-view="search">
@@ -56,113 +62,278 @@
   <section class="search-shell">
     <div class="search-form">
       <div class="mode-toggle">
-        <a class="mode active">
+        <a class="mode active" id="mode-exact">
           <span class="lbl">▣ &nbsp; EXACT MATCH<span class="badge">DEFAULT</span></span>
           <h3>Lexical · MiniSearch</h3>
           <p>276 docs · fuzzy + prefix · &lt;50ms · loaded</p>
         </a>
-        <a class="mode">
+        <a class="mode" id="mode-meaning">
           <span class="lbl">∿ &nbsp; MEANING MATCH</span>
           <h3>Semantic · FAISS</h3>
           <p>5,665 chunks · 25MB embeddings · loads on click</p>
         </a>
       </div>
+      <div class="meaning-note" id="meaning-note">∿ MEANING MATCH requires the 25MB embedding bundle — coming soon. Sticking with EXACT for now.</div>
 
       <div class="search-input">
         <span class="glyph">⌕</span>
-        <input id="search-q" value="orb hover elevation" placeholder="QUERY · 220 events · 3,530 pages…"/>
-        <span class="clear">⨯ CLEAR</span>
+        <input id="search-q" value="" placeholder="QUERY · 220 events · 3,530 pages…" autocomplete="off"/>
+        <span class="clear" id="search-clear">⨯ CLEAR</span>
       </div>
 
       <div class="search-filters">
-        <select class="filter-select"><option>ALL AGENCIES</option></select>
-        <select class="filter-select"><option>ALL ERAS</option></select>
-        <select class="filter-select"><option>ALL TYPES</option></select>
+        <select class="filter-select" id="filter-agency"><option value="ALL">ALL AGENCIES</option></select>
+        <select class="filter-select" id="filter-era"><option value="ALL">ALL ERAS</option></select>
+        <select class="filter-select" id="filter-type"><option value="ALL">ALL TYPES</option></select>
         <span style="margin-left:auto;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.18em">EXACT finds your phrase verbatim · MEANING finds related ideas</span>
       </div>
     </div>
 
     <div class="stats-row">
-      <span><span class="v">14</span> RESULTS</span><span>·</span>
-      <span>EXACT MATCH · ⏱ 41ms</span><span>·</span>
-      <span style="color:var(--cyan);cursor:pointer">↻ TRY MEANING FOR FUZZIER RESULTS</span>
-      <span class="right">SORTED BY RELEVANCE</span>
+      <span><span class="v" id="stat-count">0</span> RESULTS</span><span>·</span>
+      <span id="stat-mode">EXACT MATCH · ⏱ <span id="stat-ms">0</span>ms</span><span>·</span>
+      <span style="color:var(--cyan);cursor:pointer" id="hint-meaning">↻ TRY MEANING FOR FUZZIER RESULTS</span>
+      <span class="right" id="stat-sort">SORTED BY RELEVANCE</span>
     </div>
 
-    <div class="results-grid">
-      <article class="rc">
-        <div class="top"><span class="dot r"></span><span class="eid">DOW-UAP-D038</span><span class="score">0.94</span></div>
-        <h3>Middle East — Erratic White Object Over Water</h3>
-        <p>"…sensor cycled <mark>hover</mark> tracking but the <mark>orb</mark> dispersed before a lock could be achieved over the water at…"</p>
-        <div class="bottom"><span class="pg">PAGE 12</span><span>DoW · 2020-05</span></div>
-      </article>
-
-      <article class="rc">
-        <div class="top"><span class="dot r"></span><span class="eid">USPER-STATEMENT</span><span class="score">0.91</span></div>
-        <h3>USPER Statement — Helicopter Encounter</h3>
-        <p>"…the <mark>orb</mark> gained <mark>elevation</mark> and came within ten feet of [the helicopter] before separating into multiple…"</p>
-        <div class="bottom"><span class="pg">PAGE 03</span><span>FBI · 2025-10</span></div>
-      </article>
-
-      <article class="rc">
-        <div class="top"><span class="dot"></span><span class="eid">FBI-62HQ-83894-02</span><span class="score">0.78</span></div>
-        <h3>FBI Flying Discs Case File · Section 2</h3>
-        <p>"…witness reports a bright <mark>orb</mark> seen to <mark>hover</mark> motionless over the field for nearly two minutes…"</p>
-        <div class="bottom"><span class="pg">PAGE 18</span><span>FBI · 1947</span></div>
-      </article>
-
-      <article class="rc">
-        <div class="top"><span class="dot r"></span><span class="eid">DOW-UAP-D045</span><span class="score">0.74</span></div>
-        <h3>Southern US — Air Force Sighting (PR-45)</h3>
-        <p>"…several bright objects maneuvering quickly west to east northeast, then <mark>hover</mark>ed in formation for 20 seconds…"</p>
-        <div class="bottom"><span class="pg">PAGE 04</span><span>DoW · 2020-03</span></div>
-      </article>
-
-      <article class="rc">
-        <div class="top"><span class="dot c"></span><span class="eid">GEMINI-7</span><span class="score">0.69</span></div>
-        <h3>Gemini VII — Borman &amp; Lovell "Bogey"</h3>
-        <p>"…brilliant body in the sun against a black background, debris field of trillions of particles at <mark>elevation</mark>…"</p>
-        <div class="bottom"><span class="pg">PAGE 01</span><span>NASA · 1965</span></div>
-      </article>
-
-      <article class="rc">
-        <div class="top"><span class="dot"></span><span class="eid">UAE-JUNE-2024</span><span class="score">0.62</span></div>
-        <h3>UAE — June 2024 mission report</h3>
-        <p>"…AFSOC ISR mission, target maintained constant <mark>elevation</mark> through observation window despite cycling sensor…"</p>
-        <div class="bottom"><span class="pg">PAGE 02</span><span>DoW · 2024-06</span></div>
-      </article>
+    <p class="browse-hint" id="browse-hint">BROWSE / SUGGESTED · top events by flag weight</p>
+    <div class="results-grid" id="results-grid"></div>
+    <div class="empty-state" id="empty-state">
+      <h3>NO MATCHES</h3>
+      <div>try MEANING MATCH for fuzzier semantic results, or relax your filters</div>
     </div>
   </section>
 </main>
 
 <script src="data.js"></script>
-
 <script src="chrome.js" defer></script>
 <script>
-  // Toggle modes on click (visual demo)
-  document.querySelectorAll('.mode').forEach(m => {
-    m.addEventListener('click', () => {
-      document.querySelectorAll('.mode').forEach(x => x.classList.remove('active'));
-      m.classList.add('active');
-    });
+(function(){
+  // Visual mode toggle — MEANING is out of scope, show note, don't flip.
+  var modeExact = document.getElementById('mode-exact');
+  var modeMeaning = document.getElementById('mode-meaning');
+  var meaningNote = document.getElementById('meaning-note');
+  modeExact.addEventListener('click', function(){
+    modeExact.classList.add('active');
+    modeMeaning.classList.remove('active');
+    meaningNote.classList.remove('on');
+  });
+  modeMeaning.addEventListener('click', function(){
+    // Don't actually flip — just surface the note.
+    meaningNote.classList.add('on');
   });
 
-  // ── Live data layer: corpus-scale numbers in the input placeholder ──
-  // (eventCount + pagesIndexed). Index sizes 276 docs / 5,665 chunks stay static.
+  // Sync placeholder with live corpus scale (kept from original).
   function syncSearchScale(MC){
-    const D = MC && MC.derive; if (!D) return;
-    const q = document.getElementById('search-q');
+    var D = MC && MC.derive; if (!D) return;
+    var q = document.getElementById('search-q');
     if (!q) return;
-    const ev = (typeof D.eventCount === 'number' && D.eventCount > 0)
-      ? D.eventCount : 220;
-    const pg = (typeof D.pagesIndexed === 'number' && D.pagesIndexed > 0)
-      ? D.pagesIndexed.toLocaleString() : '3,530';
+    var ev = (typeof D.eventCount === 'number' && D.eventCount > 0) ? D.eventCount : 220;
+    var pg = (typeof D.pagesIndexed === 'number' && D.pagesIndexed > 0) ? D.pagesIndexed.toLocaleString() : '3,530';
     q.placeholder = 'QUERY · ' + ev + ' events · ' + pg + ' pages…';
   }
-  if (window.MC && typeof window.MC.ready === 'function') {
-    window.MC.ready().then(() => syncSearchScale(window.MC));
-    window.MC.onUpdate(() => syncSearchScale(window.MC));
+
+  // Agency → dot class.
+  function dotClass(agency){
+    var a = (agency || '').toString().toUpperCase();
+    if (a === 'DOW' || a === 'DEPT OF WAR' || a === 'DEPARTMENT OF WAR') return ''; // amber default
+    if (a === 'FBI') return 'c';
+    if (a === 'NASA') return 'e';
+    if (a === 'ANCHOR') return 'r';
+    return 'g';
   }
+
+  // Flag-weight (for default "BROWSE / SUGGESTED" listing).
+  function flagWeight(f){
+    var x = (f || '').toString().toLowerCase();
+    if (x === 'anchor') return 4;
+    if (x === 'high')   return 3;
+    if (x === 'med' || x === 'medium') return 2;
+    if (x === 'low')    return 1;
+    return 0;
+  }
+
+  // Escape for safe HTML interpolation.
+  function esc(s){
+    return String(s == null ? '' : s)
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+      .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  }
+
+  // ── Scoring ──
+  // title substring → 10 · id substring → 8 · agency/region/type/era substring → 4
+  // exact tag/era token match → 2 · per-token sum, top 24.
+  function scoreEvent(ev, tokens){
+    var total = 0;
+    var title  = (ev.title  || '').toLowerCase();
+    var id     = (ev.id     || '').toLowerCase();
+    var agency = (ev.agency || '').toLowerCase();
+    var region = (ev.region || '').toLowerCase();
+    var era    = (ev.era    || '').toLowerCase();
+    var type   = (ev.type   || '').toLowerCase();
+    for (var i = 0; i < tokens.length; i++){
+      var t = tokens[i];
+      if (!t) continue;
+      if (title.indexOf(t)  !== -1) total += 10;
+      if (id.indexOf(t)     !== -1) total += 8;
+      if (agency.indexOf(t) !== -1) total += 4;
+      if (region.indexOf(t) !== -1) total += 4;
+      if (type.indexOf(t)   !== -1) total += 4;
+      if (era.indexOf(t)    !== -1) total += 4;
+      if (era === t || type === t)  total += 2;
+    }
+    return total;
+  }
+
+  function tokenize(q){
+    return (q || '').toLowerCase().split(/\s+/).filter(Boolean);
+  }
+
+  // Card renderer.
+  function cardHTML(ev, score, MC){
+    var href = (MC && MC.url && MC.url.dossier) ? MC.url.dossier(ev.id) : ('dossier.html?eid=' + encodeURIComponent(ev.id));
+    var dot = dotClass(ev.agency);
+    var snippet = [ev.date, ev.region, ev.agency, ev.type].filter(Boolean).join(' · ');
+    var scoreStr = (typeof score === 'number') ? score.toFixed(0) : '';
+    return '' +
+      '<a class="rc" href="' + esc(href) + '">' +
+        '<div class="top">' +
+          '<span class="dot ' + dot + '"></span>' +
+          '<span class="eid">' + esc(ev.id) + '</span>' +
+          (scoreStr ? '<span class="score">' + esc(scoreStr) + '</span>' : '') +
+        '</div>' +
+        '<h3>' + esc(ev.title || ev.id) + '</h3>' +
+        '<p>' + esc(snippet) + '</p>' +
+        '<div class="bottom">' +
+          '<span class="pg">' + esc((ev.agency || '—').toString().toUpperCase()) + '</span>' +
+          '<span>' + esc(ev.date || ev.era || '') + '</span>' +
+        '</div>' +
+      '</a>';
+  }
+
+  function applyFilters(events, f){
+    if (!f.agency && !f.era && !f.type) return events;
+    return events.filter(function(e){
+      if (f.agency && f.agency !== 'ALL' && (e.agency || '') !== f.agency) return false;
+      if (f.era    && f.era    !== 'ALL' && (e.era    || '') !== f.era)    return false;
+      if (f.type   && f.type   !== 'ALL' && (e.type   || '') !== f.type)   return false;
+      return true;
+    });
+  }
+
+  function populateFilter(sel, values, leadLabel){
+    // Keep the existing leading "ALL ..." option, append the rest.
+    while (sel.options.length > 1) sel.remove(1);
+    values.slice().sort().forEach(function(v){
+      var o = document.createElement('option');
+      o.value = v;
+      o.textContent = v;
+      sel.appendChild(o);
+    });
+  }
+
+  MC.ready().then(function(){
+    syncSearchScale(MC);
+    MC.onUpdate(function(){ syncSearchScale(MC); });
+
+    var events = (MC.derive && MC.derive.events) || [];
+    var byAgency = (MC.derive && MC.derive.byAgency) || {};
+    var byEra    = (MC.derive && MC.derive.byEra)    || {};
+    var typeSet  = {};
+    events.forEach(function(e){ if (e && e.type) typeSet[e.type] = true; });
+
+    var selAgency = document.getElementById('filter-agency');
+    var selEra    = document.getElementById('filter-era');
+    var selType   = document.getElementById('filter-type');
+    populateFilter(selAgency, Object.keys(byAgency));
+    populateFilter(selEra,    Object.keys(byEra));
+    populateFilter(selType,   Object.keys(typeSet));
+
+    var inp        = document.getElementById('search-q');
+    var clearBtn   = document.getElementById('search-clear');
+    var grid       = document.getElementById('results-grid');
+    var emptyEl    = document.getElementById('empty-state');
+    var statCount  = document.getElementById('stat-count');
+    var statMs     = document.getElementById('stat-ms');
+    var statSort   = document.getElementById('stat-sort');
+    var browseHint = document.getElementById('browse-hint');
+
+    function currentFilters(){
+      return { agency: selAgency.value, era: selEra.value, type: selType.value };
+    }
+
+    function render(){
+      var t0 = performance.now();
+      var q = (inp.value || '').trim();
+      var f = currentFilters();
+      var base = applyFilters(events, f);
+      var out, isBrowse = false;
+
+      if (!q){
+        // BROWSE / SUGGESTED — top 12 by flag weight.
+        isBrowse = true;
+        out = base.slice().sort(function(a, b){ return flagWeight(b.flag) - flagWeight(a.flag); }).slice(0, 12);
+      } else {
+        var tokens = tokenize(q);
+        var scored = [];
+        for (var i = 0; i < base.length; i++){
+          var s = scoreEvent(base[i], tokens);
+          if (s > 0) scored.push({ ev: base[i], score: s });
+        }
+        scored.sort(function(a, b){ return b.score - a.score; });
+        out = scored.slice(0, 24);
+      }
+
+      var t1 = performance.now();
+      var ms = Math.max(0, Math.round(t1 - t0));
+
+      // Stats row.
+      statCount.textContent = out.length;
+      statMs.textContent = ms;
+      statSort.textContent = isBrowse ? 'SORTED BY FLAG WEIGHT' : 'SORTED BY RELEVANCE';
+
+      // Browse hint vs. results.
+      browseHint.style.display = isBrowse ? '' : 'none';
+
+      // Empty state — only when there's a query AND no hits.
+      if (out.length === 0 && q){
+        emptyEl.classList.add('on');
+        grid.innerHTML = '';
+        return;
+      }
+      emptyEl.classList.remove('on');
+
+      // Cap render at 24.
+      var html = '';
+      var capped = out.slice(0, 24);
+      for (var j = 0; j < capped.length; j++){
+        var row = isBrowse ? { ev: capped[j], score: null } : capped[j];
+        html += cardHTML(row.ev, row.score, MC);
+      }
+      grid.innerHTML = html;
+    }
+
+    // Debounced input (~120ms).
+    var deb;
+    function schedule(){
+      clearTimeout(deb);
+      deb = setTimeout(render, 120);
+    }
+
+    inp.addEventListener('input', schedule);
+    clearBtn.addEventListener('click', function(){
+      inp.value = '';
+      render();
+      inp.focus();
+    });
+    selAgency.addEventListener('change', render);
+    selEra.addEventListener('change', render);
+    selType.addEventListener('change', render);
+
+    // Initial paint.
+    render();
+  });
+})();
 </script>
 </body>
 </html>

--- a/public/mc/timeline.html
+++ b/public/mc/timeline.html
@@ -19,6 +19,7 @@
     .tl-events { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
     .evt { background: var(--surface-2); border: 1px solid var(--hairline); padding: 12px 14px; transition: all .15s; cursor: pointer; }
     .evt:hover { border-color: var(--amber); transform: translateY(-2px); }
+    .evt a, a.evt { color: inherit; text-decoration: none; display: block; height: 100%; }
     .evt .top { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.12em; text-transform: uppercase; }
     .evt .dot { width: 7px; height: 7px; }
     .evt .dot.dow { background: var(--amber); }
@@ -177,11 +178,13 @@
   }
 
   function cardHTML(ev) {
-    return '<div class="evt"><div class="top">' +
+    var eid = ev.id || "";
+    var href = (MC.url && MC.url.dossier) ? MC.url.dossier(eid) : ("dossier.html?eid=" + encodeURIComponent(eid));
+    return '<a class="evt" href="' + esc(href) + '" data-eid="' + esc(eid) + '" style="text-decoration:none;color:inherit"><div class="top">' +
       '<span class="dot ' + dotClass(ev.agency) + '"></span>' +
       '<span class="date">' + esc(ev.date || "—") + '</span></div>' +
       '<div class="ttl">' + esc(ev.title || "Untitled") + '</div>' +
-      '<div class="agn">' + agnLine(ev) + '</div></div>';
+      '<div class="agn">' + agnLine(ev) + '</div></a>';
   }
 
   function bandHTML(eraKey, events, maxCount) {


### PR DESCRIPTION
## Summary

PR #268 wired every /mc surface to live JSON; PR #269 fixed the count-up
animation. This PR wires the **interaction layer** — cards are now
clickable, search actually searches, the globe plots real coordinates,
the dossier reads `?eid=…` from the URL, CLAIM buttons open prefilled
GitHub issues.

## Data layer (`public/mc/data.js`)

- `MC.byEid(id)`, `MC.signaturesForEvent(id)`, `MC.entitiesForEvent(id)`
- `MC.url.dossier(eid)` and `MC.url.claim(eid, page)` helpers
- `MC.query` parses the URL search string once at load

## Per-page

| Surface | Before | After |
|---|---|---|
| Dossier | Hardcoded fbi-62hq83894 | `?eid=…` URL param resolves any event (fallback fbi → usper → first-with-neighbours) |
| Coverage | Decorative grid | 128 cell anchors → dossier · 8 queue rows → dossier · 8 CLAIM pills → GitHub issue · hero CTA → top-of-queue |
| Search | 6 static result cards | Real fuzzy over 220 events: `Σ_tokens [10·title + 8·id + 4·agency/region/type/era + 2·exact era/type]`, 120ms debounce, 24 cap, agency/era/type filters from live tallies, empty-state on miss |
| Globe | 8 decorative hotspots | 100 pins from real coords (equirectangular projection), per-region fill, anchor flags get outer ring, each pin → dossier |
| Live | Static histogram + polyline + decorative rows | 24-bucket hourly histogram from `feedEntries[].modifiedAt` · 60s oscillation from 5s buckets · field-assignment row → dossier · CLAIM → GitHub issue · signal eid → dossier · mined-index row → `search.html?q=term` · hero CTA → top-of-queue |
| Review | Static rows + dead CLAIM | Rows → dossier · primary CTA → GitHub issue for top-of-queue |
| Timeline / Atlas / Index | Inert | Timeline cards → dossier · Atlas heatmap (non-zero) → `search.html?agency=…&era=…` · Index launcher tile → real dossier |

## Test plan

Verified via Playwright against locally-served `public/`:

- [x] Every page reaches `MC._loaded` with 46 derive keys / 220 events / coverageTotal 128
- [x] `dossier.html?eid=fbi-62hq83894` renders "FBI Flying Discs Case File 62-HQ-83894"
- [x] `dossier.html?eid=usper-2025` renders the USPER event
- [x] Coverage has 128 cell anchors + 8 queue rows + 8 claim pills
- [x] Globe `#event-pins` has 100 pin anchors (115 circles inc. anchor outer rings)
- [x] Search default shows 12 cards; query "fbi" → 24 cards with top-card href = `dossier.html?eid=fbi-62hq83894`
- [x] Live: 24 histogram bars, 4 CLAIM anchors, 5 clickable signal eids
- [x] Inline JS parses cleanly on every modified file
- [ ] Verify in production after merge

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_