### PR TITLE
feat(mc): production parity — full-text search, real media filters, force-directed network, side-by-side review, pattern Ask

### DIFF
--- a/public/mc/ask.html
+++ b/public/mc/ask.html
@@ -11,9 +11,10 @@
     .ask-shell { padding: 0 56px 64px; display: grid; grid-template-columns: minmax(0,1fr) 340px; gap: 24px; position: relative; z-index: 3; }
     .ask-card { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; backdrop-filter: blur(10px); }
     .mode-pill-row { display: flex; gap: 10px; margin-bottom: 22px; }
-    .mp { padding: 10px 16px; border: 1px solid var(--border); background: var(--surface-2); cursor: pointer; font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; }
+    .mp { padding: 10px 16px; border: 1px solid var(--border); background: var(--surface-2); cursor: pointer; font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; user-select: none; }
     .mp.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.08); box-shadow: 0 0 14px rgba(242,166,35,0.18); }
     .mp .badge { background: rgba(74,222,128,0.10); border: 1px solid rgba(74,222,128,0.4); color: var(--emerald); padding: 1px 6px; margin-left: 8px; font-size: 9px; }
+    .mp .badge.local { background: rgba(184,168,135,0.10); border-color: var(--border); color: var(--text-3); }
     .ask-input { display: flex; flex-direction: column; gap: 12px; background: var(--surface-3); border: 1px solid var(--border-strong); padding: 22px; }
     .ask-input textarea { background: transparent; border: none; outline: none; color: var(--text); font-family: 'Inter', sans-serif; font-size: 16px; line-height: 1.5; resize: vertical; min-height: 88px; }
     .ask-input textarea::placeholder { color: var(--text-4); }
@@ -21,24 +22,39 @@
     .ask-input-row .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.18em; flex: 1; }
     .ask-input-row .meta .v { color: var(--amber); }
     .ask-input-row .send { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.18em; color: var(--void); background: linear-gradient(180deg, var(--amber-bright), var(--gold)); border: 1px solid var(--amber); padding: 10px 22px; cursor: pointer; }
-    .qa { margin-top: 32px; }
+
+    .qa { margin-top: 28px; display: flex; flex-direction: column; gap: 0; }
     .q { display: flex; align-items: flex-start; gap: 14px; padding: 22px 0 16px; border-bottom: 1px solid var(--hairline); }
+    .q:last-child { border-bottom: none; }
     .q .avatar { width: 32px; height: 32px; border: 1px solid var(--border-strong); display: flex; align-items: center; justify-content: center; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.12em; color: var(--text-2); flex-shrink: 0; }
     .q .avatar.user { background: rgba(97,215,240,0.10); border-color: rgba(97,215,240,0.4); color: var(--cyan); }
     .q .avatar.ai { background: rgba(242,166,35,0.10); border-color: var(--border-strong); color: var(--amber); }
-    .q .body { flex: 1; }
+    .q .body { flex: 1; min-width: 0; }
     .q .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.14em; margin-bottom: 8px; }
     .q .body p { font-size: 15px; line-height: 1.65; color: var(--text-2); margin: 0 0 12px; }
     .q .body p strong { color: var(--text); font-weight: 600; }
-    .q .body p em { color: var(--text); font-style: normal; font-weight: 500; background: rgba(242,166,35,0.06); padding: 0 4px; }
-    .cite { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--cyan); background: rgba(97,215,240,0.10); border: 1px solid rgba(97,215,240,0.30); padding: 1px 6px; margin: 0 3px; vertical-align: super; }
-    .src-list { margin-top: 14px; display: flex; flex-direction: column; gap: 8px; padding-top: 14px; border-top: 1px solid var(--hairline); }
-    .src { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: baseline; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); }
-    .src .n { color: var(--cyan); font-weight: 600; }
-    .src .title { color: var(--text-2); }
-    .src .pg { color: var(--text-4); }
+    .q .body p em { color: var(--amber); font-style: normal; font-weight: 500; }
+
+    /* Result rows */
+    .a-rows { display: flex; flex-direction: column; gap: 0; margin-top: 6px; padding-top: 10px; border-top: 1px solid var(--hairline); }
+    .a-row { display: grid; grid-template-columns: auto 1fr auto; gap: 12px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--hairline); text-decoration: none; color: inherit; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+    .a-row:last-child { border-bottom: none; }
+    .a-row:hover { color: var(--amber); }
+    .a-row .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--amber); align-self: center; }
+    .a-row .dot.r { background: var(--rose); }
+    .a-row .dot.c { background: var(--cyan); }
+    .a-row .dot.e { background: var(--emerald); }
+    .a-row .name { color: var(--text); }
+    .a-row .name .id { color: var(--cyan); margin-right: 8px; font-size: 11px; }
+    .a-row .pg { color: var(--text-4); font-size: 10px; letter-spacing: 0.16em; }
+    .more-row { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.16em; padding: 8px 0; }
+
+    .smart-note { padding: 22px 26px; background: var(--surface-2); border: 1px dashed var(--border-strong); margin-bottom: 22px; }
+    .smart-note h4 { font-family: 'Space Grotesk', sans-serif; font-size: 16px; color: var(--amber); margin: 0 0 8px; }
+    .smart-note p { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); line-height: 1.6; margin: 0; letter-spacing: 0.06em; }
+    .smart-note p code { color: var(--cyan); }
+
     .suggest { padding: 0; }
-    .suggest h4 { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; margin: 0 0 14px; }
     .suggest .sg { display: block; padding: 12px 0; border-bottom: 1px solid var(--hairline); cursor: pointer; transition: color .15s; color: var(--text-2); text-decoration: none; }
     .suggest .sg:hover { color: var(--text); }
     .suggest .sg:last-child { border-bottom: none; }
@@ -50,78 +66,276 @@
 
 <main>
   <section class="page-title">
-    <div class="eyebrow"><span class="div"></span>SURFACE · 04 — natural-language Q&A</div>
-    <h1>Ask the corpus a question, <em>get a cited answer.</em></h1>
-    <p class="sub">SMART mode runs a RAG pipeline against the 5,665-chunk semantic index and a frontier LLM. PATTERN mode falls back to a local classifier when the LLM backend is offline.</p>
+    <div class="eyebrow"><span class="div"></span>SURFACE · 04 — natural-language Q&amp;A</div>
+    <h1>Ask the corpus a question, <em>get a structured answer.</em></h1>
+    <p class="sub">PATTERN mode is a local intent classifier — instant, free, runs over the catalogue's shape (agency / era / category / cross-refs). SMART mode runs RAG against the semantic index via your local pursue-vision-mcp daemon.</p>
   </section>
 
   <section class="ask-shell">
     <div class="ask-card">
 
       <div class="mode-pill-row">
-        <span class="mp active">∿ SMART <span class="badge">RAG + LLM</span></span>
-        <span class="mp">▣ PATTERN <span style="background:rgba(184,168,135,0.10);border:1px solid var(--border);color:var(--text-3);padding:1px 6px;margin-left:8px;font-size:9px">LOCAL</span></span>
+        <span class="mp active" data-mode="pattern">▣ PATTERN <span class="badge local">LOCAL · INSTANT</span></span>
+        <span class="mp" data-mode="smart">∿ SMART <span class="badge">RAG + LLM</span></span>
+      </div>
+
+      <div id="smart-note" class="smart-note" style="display:none">
+        <h4>SMART mode requires your local pursue-vision-mcp daemon</h4>
+        <p>SMART runs <code>scripts/build-embeddings.py</code> output through a transformers.js MiniLM (25MB) and ships top-K passages to your logged-in Claude / ChatGPT / Gemini tab via <code>pursue-vision-mcp</code>. Not bundled into the static /mc/ surface. Stick with PATTERN here, or open the live React app: <a href="../" style="color:var(--cyan);text-decoration:none">→ ../</a></p>
       </div>
 
       <div class="ask-input">
-        <textarea placeholder="Ask anything about the corpus — events, entities, sources, dates, patterns…">What does the corpus suggest about helicopter encounters with orbs at low altitude?</textarea>
+        <textarea id="q-input" placeholder="Ask anything about the catalogue — &#34;NASA events&#34;, &#34;1960s&#34;, &#34;anchor events about CENTCOM&#34;, &#34;physics-relevant&#34;, &#34;release 02&#34;…">show me the physics-relevant events</textarea>
         <div class="ask-input-row">
-          <span class="meta">SOURCE · <span class="v"><span data-mc="pagesIndexed" data-mc-format="comma">3,530</span> pages · 5,665 chunks · <span data-mc="eventCount">220</span> events</span></span>
-          <button class="send">▶ INVESTIGATE</button>
+          <span class="meta">CORPUS · <span class="v"><span data-mc="pagesIndexed" data-mc-format="comma">3,530</span> pages · <span data-mc="eventCount">220</span> events</span></span>
+          <button class="send" id="q-send">▶ INVESTIGATE</button>
         </div>
       </div>
 
-      <div class="qa">
-        <div class="q">
-          <div class="avatar user">YOU</div>
-          <div class="body">
-            <div class="meta">02·06 · 17:21 UTC · SMART · WEB</div>
-            <p>What does the corpus suggest about helicopter encounters with orbs at low altitude?</p>
-          </div>
-        </div>
-
-        <div class="q">
-          <div class="avatar ai">▣</div>
-          <div class="body">
-            <div class="meta">02·06 · 17:21:14 UTC · SMART · CLAUDE-3.7 · 4 SOURCES</div>
-            <p>The corpus contains one anchor event matching this profile: a late-2025 FBI 302 statement from a senior US intelligence official aboard a search helicopter at a US military facility <span class="cite">[1]</span>. The narrative describes an <em>LP/OP-tracked orb</em> that "gained elevation, came within ten feet of [the helicopter]" before separating into a swarm of orbs in triangle formation that "moved in all directions" <span class="cite">[2]</span>.</p>
-            <p>Adjacent DoW mission reports show similar low-altitude small-object encounters but in fixed-wing contexts: <strong>UAE June 2024</strong> records an object flying straight at 140 knots over water at the same general altitude band as a returning aircraft <span class="cite">[3]</span>. The <strong>Western US 2023</strong> dossier provides a complementary ground-witness account of a "Large, Fiery Orb" at ~500–600m observed by federal law-enforcement agents <span class="cite">[4]</span>.</p>
-            <p>The corpus does not contain a second helicopter-vs-orb event matching the USPER profile. <span style="color:var(--text-3)">Confidence: 0.86 · Caveat: 46% of catalogued events lack body text.</span></p>
-
-            <div class="src-list">
-              <div class="src"><span class="n">[1]</span><span class="title">USPER Statement · Senior USIC Official · helicopter encounter, US military facility</span><span class="pg">FBI · p1</span></div>
-              <div class="src"><span class="n">[2]</span><span class="title">USPER Statement · "swarm of lights in triangle formation"</span><span class="pg">FBI · p3</span></div>
-              <div class="src"><span class="n">[3]</span><span class="title">UAE June 2024 mission report · 140kt at low altitude over water</span><span class="pg">DoW · p6</span></div>
-              <div class="src"><span class="n">[4]</span><span class="title">Western US 2023 · "Large, Fiery Orb" at 500–600m, dusk</span><span class="pg">DoW · p2</span></div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div class="qa" id="qa"></div>
     </div>
 
     <div class="panel">
-      <div class="panel-head"><span><span class="icon-sq"></span>Suggested queries</span><span class="right">community curated</span></div>
-      <div class="suggest">
-        <a class="sg"><div class="q-text">Which events involve multiple USIC witnesses?</div><div class="q-meta">3 hits in corpus</div></a>
-        <a class="sg"><div class="q-text">Sightings classified as "orb" near military facilities, 2020–2025?</div><div class="q-meta">7 hits</div></a>
-        <a class="sg"><div class="q-text">List USCENTCOM events with FLIR sensor readouts</div><div class="q-meta">12 hits</div></a>
-        <a class="sg"><div class="q-text">Which 1947 documents mention "Roswell"?</div><div class="q-meta">FBI 62HQ section 2 + 5</div></a>
-        <a class="sg"><div class="q-text">Compare Gemini VII bogey vs Apollo 17 debrief language</div><div class="q-meta">cross-event analysis</div></a>
-        <a class="sg"><div class="q-text">What patterns dominate the 2020s cohort?</div><div class="q-meta">light / hover / vertical</div></a>
-        <a class="sg"><div class="q-text">List events that have signature "split" or "swarm"</div><div class="q-meta">3 hits</div></a>
+      <div class="panel-head"><span><span class="icon-sq"></span>Suggested queries</span><span class="right">click to run</span></div>
+      <div class="suggest" id="suggest">
+        <a class="sg" data-q="physics-relevant events"><div class="q-text">Physics-relevant events</div><div class="q-meta">primary-source sensor data linked to theoretical research</div></a>
+        <a class="sg" data-q="anchor events"><div class="q-text">Anchor events</div><div class="q-meta">flagged ANCHOR — the corpus's primary cases</div></a>
+        <a class="sg" data-q="release 02"><div class="q-text">Release 02 events</div><div class="q-meta">the second war.gov declassification batch</div></a>
+        <a class="sg" data-q="NASA events"><div class="q-text">NASA events</div><div class="q-meta">orbital and astronaut accounts</div></a>
+        <a class="sg" data-q="1960s events"><div class="q-text">1960s events</div><div class="q-meta">Gemini-era era cohort</div></a>
+        <a class="sg" data-q="FBI"><div class="q-text">FBI events</div><div class="q-meta">62HQ-83894 and successors</div></a>
+        <a class="sg" data-q="oak ridge"><div class="q-text">Oak Ridge mentions</div><div class="q-meta">cross-references and matches</div></a>
+        <a class="sg" data-q="critical priority"><div class="q-text">Critical-priority events</div><div class="q-meta">tier-1 evidence chains</div></a>
       </div>
     </div>
   </section>
 </main>
 
 <script src="data.js"></script>
-
 <script src="chrome.js" defer></script>
 <script>
-  document.querySelectorAll('.mp').forEach(m => m.addEventListener('click', () => {
-    document.querySelectorAll('.mp').forEach(x => x.classList.remove('active'));
-    m.classList.add('active');
-  }));
+(function(){
+  if (!window.MC || !MC.ready) return;
+
+  // ─── Pattern mode (vanilla port of src/lib/askEngine.js's intent core) ───
+  var AGENCY_ALIASES = [
+    ['nasa','NASA'], ['fbi','FBI'],
+    ['dow','Department of War'], ['dod','Department of War'], ['defense','Department of War'], ['war','Department of War'],
+    ['state','Department of State'], ['dos','Department of State'],
+    ['cia','Central Intelligence Agency'], ['intel agency','Central Intelligence Agency'],
+    ['doe','Department of Energy'], ['energy','Department of Energy'],
+    ['odni','Office of the Director of National Intelligence'], ['intelligence office','Office of the Director of National Intelligence'],
+  ];
+  var STOP = new Set('the a an what was is are were does did do about data on of in to from for by or and that which whats this these those with like just get back you so can be been has have had there its any i me tell show find list all into across records record documents document docs doc files file reports report anything everything things stuff please us event events case cases case-file dossier dossiers catalogue catalog hits matches result results'.split(' '));
+
+  function lc(s){ return (s||'').toLowerCase().trim(); }
+  function tokens(s){ return lc(s).replace(/[^a-z0-9' ]+/g, ' ').split(/\s+/).filter(Boolean).filter(function(t){ return !STOP.has(t); }); }
+
+  function detectAgency(q){
+    for (var i = 0; i < AGENCY_ALIASES.length; i++){
+      var alias = AGENCY_ALIASES[i][0];
+      if (new RegExp('\\b' + alias + '\\b').test(q)) return AGENCY_ALIASES[i][1];
+    }
+    return null;
+  }
+  function detectEra(q){
+    var m = q.match(/\b(?:19|20)?(\d0)s\b/);
+    if (m) return m[1] + 's';
+    var w = { sixties:'60s', seventies:'70s', eighties:'80s', nineties:'90s', forties:'40s', fifties:'50s' };
+    for (var k in w) if (q.indexOf(k) !== -1) return w[k];
+    return null;
+  }
+  function detectRelease(q){
+    if (/release\s*(?:0?2|two|ii)|r\s*02|rel\s*2/.test(q)) return 'Release 02';
+    if (/release\s*(?:0?1|one|i)|r\s*01|rel\s*1/.test(q))  return 'Release 01';
+    return null;
+  }
+  function detectFlag(q){
+    if (/\banchor\b/.test(q)) return 'anchor';
+    if (/\bhigh[- ]?flag\b|\bhigh[- ]?priority\b/.test(q)) return 'high';
+    return null;
+  }
+  function detectPriority(q){
+    if (/\bcritical\b/.test(q)) return 'critical';
+    return null;
+  }
+  function detectCategory(q){
+    if (/physics[- ]?relevant|physics events|theoretical/.test(q)) return 'physics-relevant';
+    if (/nuclear[- ]?site|nuclear facilit/.test(q)) return 'nuclear-site';
+    if (/primary[- ]?source/.test(q)) return 'primary-source';
+    return null;
+  }
+
+  // Score per token — same shape as search but with one extra crossRef boost.
+  function score(ev, toks){
+    var t = 0, title=(ev.title||'').toLowerCase(), id=(ev.id||'').toLowerCase();
+    var loc=(ev.loc||'').toLowerCase(), agency=(ev.agency||'').toLowerCase();
+    var tagBlob = Array.isArray(ev.tags) ? ev.tags.join(' ').toLowerCase() : '';
+    var refBlob = Array.isArray(ev.crossRefs) ? ev.crossRefs.map(function(r){return r.id||'';}).join(' ').toLowerCase() : '';
+    for (var i = 0; i < toks.length; i++){
+      var x = toks[i];
+      if (title.indexOf(x) >= 0) t += 10;
+      if (id.indexOf(x) >= 0)    t += 8;
+      if (loc.indexOf(x) >= 0)   t += 6;
+      if (tagBlob.indexOf(x) >= 0) t += 6;
+      if (refBlob.indexOf(x) >= 0) t += 6;
+      if (agency.indexOf(x) >= 0) t += 4;
+    }
+    return t;
+  }
+
+  function dotClass(rec){
+    if (!rec) return '';
+    if (rec.flag === 'anchor') return 'r';
+    var a = (rec.agency || '').toLowerCase();
+    if (a === 'fbi') return 'c';
+    if (a === 'nasa') return 'e';
+    return '';
+  }
+
+  function ask(q){
+    var events = (MC.derive && MC.derive.events) || [];
+    var ql = lc(q);
+    if (!ql) return null;
+
+    var agency  = detectAgency(ql);
+    var era     = detectEra(ql);
+    var release = detectRelease(ql);
+    var flag    = detectFlag(ql);
+    var priority= detectPriority(ql);
+    var cat     = detectCategory(ql);
+
+    var filtered = events.slice();
+    var reasons = [];
+
+    if (agency)  { filtered = filtered.filter(function(e){ return e.agency === agency; }); reasons.push(agency); }
+    if (era)     { filtered = filtered.filter(function(e){ return e.era === era; }); reasons.push(era); }
+    if (release) { filtered = filtered.filter(function(e){ return e.release === release; }); reasons.push(release); }
+    if (flag)    { filtered = filtered.filter(function(e){ return e.flag === flag; }); reasons.push('FLAG=' + flag); }
+    if (priority){ filtered = filtered.filter(function(e){ return e.priority === priority; }); reasons.push('PRIORITY=' + priority); }
+    if (cat)     { filtered = filtered.filter(function(e){ return Array.isArray(e.category) && e.category.indexOf(cat) !== -1; }); reasons.push('CATEGORY=' + cat); }
+
+    // Always score the residual against query tokens — even if a structured
+    // intent already matched, the user might also want keyword ranking
+    // ("NASA Apollo Borman" — agency NASA + keyword Borman → score).
+    var toks = tokens(ql).filter(function(t){
+      // Drop tokens we already used as structured-intent triggers.
+      if (agency && (toks_str(AGENCY_ALIASES).indexOf(t) >= 0)) return false;
+      if (era && /^\d0s$/.test(t)) return false;
+      if (release && (t === 'release' || t === 'r' || t === '01' || t === '02' || t === 'rel')) return false;
+      if (cat && (t === 'physics' || t === 'physics-relevant' || t === 'relevant' || t === 'nuclear')) return false;
+      if (priority && t === priority) return false;
+      if (flag && t === flag) return false;
+      return true;
+    });
+
+    var hasStructured = agency || era || release || flag || priority || cat;
+    if (toks.length){
+      var scored = [];
+      for (var i = 0; i < filtered.length; i++){
+        var s = score(filtered[i], toks);
+        if (s > 0) scored.push({ ev: filtered[i], score: s });
+      }
+      scored.sort(function(a, b){ return b.score - a.score; });
+      // If scoring zeroed out but the user supplied a structured intent
+      // that already matched, keep the structured set (sorted by flag).
+      if (scored.length || !hasStructured){
+        filtered = scored.map(function(r){ return r.ev; });
+      } else {
+        var fwA = { anchor: 4, high: 3, med: 2, low: 1 };
+        filtered = filtered.slice().sort(function(a, b){ return (fwA[b.flag]||0) - (fwA[a.flag]||0); });
+      }
+    } else {
+      // No keyword scoring → sort by flag weight so the prominent ones land first.
+      var fw = { anchor: 4, high: 3, med: 2, low: 1 };
+      filtered = filtered.slice().sort(function(a, b){ return (fw[b.flag]||0) - (fw[a.flag]||0); });
+    }
+
+    return {
+      total: filtered.length,
+      events: filtered.slice(0, 24),
+      intent: { agency: agency, era: era, release: release, flag: flag, priority: priority, category: cat, tokens: toks },
+      reasonLabel: reasons.length ? reasons.join(' · ') : (toks.length ? 'KEYWORD: ' + toks.join(' ') : 'EVERYTHING')
+    };
+  }
+  function toks_str(arr){ return arr.map(function(p){ return p[0]; }); }
+
+  function esc(s){ return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
+
+  function nowLabel(){
+    var d = new Date(), p = function(n){ return String(n).padStart(2, '0'); };
+    return p(d.getUTCMonth()+1) + '·' + p(d.getUTCDate()) + ' · ' + p(d.getUTCHours()) + ':' + p(d.getUTCMinutes()) + ' UTC · PATTERN';
+  }
+
+  function ansHTML(q, res){
+    if (!res){ return ''; }
+    var rows = res.events.map(function(ev){
+      var dot = dotClass(ev);
+      return '<a class="a-row" href="' + esc(MC.url.dossier(ev.id)) + '">' +
+        '<span class="dot ' + dot + '"></span>' +
+        '<span class="name"><span class="id">' + esc((ev.id||'').toUpperCase()) + '</span>' + esc(ev.title || '—') + '</span>' +
+        '<span class="pg">' + esc(ev.agency || '') + (ev.date ? ' · ' + esc(ev.date) : '') + '</span>' +
+      '</a>';
+    }).join('');
+    var more = (res.total > res.events.length) ? '<div class="more-row">+ ' + (res.total - res.events.length) + ' more · refine the query to narrow</div>' : '';
+    var headline = res.total
+      ? 'Found <strong>' + res.total + '</strong> ' + (res.total === 1 ? 'event' : 'events') + ' matching <em>' + esc(res.reasonLabel) + '</em>.'
+      : 'No catalogue events match this query. Try <em>physics-relevant</em>, <em>NASA</em>, <em>1960s</em>, <em>release 02</em>, or a keyword like <em>Borman</em> or <em>Pantex</em>.';
+    return '<div class="q"><div class="avatar user">YOU</div><div class="body"><div class="meta">' + nowLabel() + '</div><p>' + esc(q) + '</p></div></div>' +
+      '<div class="q"><div class="avatar ai">▣</div><div class="body"><div class="meta">' + nowLabel() + ' · ' + res.total + ' RESULTS</div>' +
+      '<p>' + headline + '</p>' +
+      (res.events.length ? '<div class="a-rows">' + rows + more + '</div>' : '') +
+      '</div></div>';
+  }
+
+  // ─── DOM wiring ───
+  var qaEl    = document.getElementById('qa');
+  var inputEl = document.getElementById('q-input');
+  var sendBtn = document.getElementById('q-send');
+  var modeBar = document.querySelector('.mode-pill-row');
+  var smartNote = document.getElementById('smart-note');
+  var mode = 'pattern';
+
+  function runQuery(q){
+    if (!q) return;
+    if (mode === 'smart'){
+      smartNote.style.display = '';
+      qaEl.innerHTML = '';
+      return;
+    }
+    var res = ask(q);
+    qaEl.innerHTML = ansHTML(q, res);
+    qaEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  sendBtn.addEventListener('click', function(){ runQuery(inputEl.value.trim()); });
+  inputEl.addEventListener('keydown', function(e){
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)){
+      e.preventDefault();
+      runQuery(inputEl.value.trim());
+    }
+  });
+  modeBar.querySelectorAll('.mp').forEach(function(m){
+    m.addEventListener('click', function(){
+      modeBar.querySelectorAll('.mp').forEach(function(x){ x.classList.remove('active'); });
+      m.classList.add('active');
+      mode = m.dataset.mode;
+      if (mode === 'smart'){ smartNote.style.display = ''; }
+      else { smartNote.style.display = 'none'; }
+    });
+  });
+  document.querySelectorAll('#suggest .sg').forEach(function(a){
+    a.addEventListener('click', function(){
+      inputEl.value = a.dataset.q;
+      runQuery(a.dataset.q);
+    });
+  });
+
+  MC.ready().then(function(){
+    // Initial run so the page lands on a real answer (default question).
+    runQuery(inputEl.value.trim());
+  });
+})();
 </script>
 </body>
 </html>

--- a/public/mc/lib/minisearch.js
+++ b/public/mc/lib/minisearch.js
@@ -1,0 +1,2005 @@
+/** @ignore */
+const ENTRIES = 'ENTRIES';
+/** @ignore */
+const KEYS = 'KEYS';
+/** @ignore */
+const VALUES = 'VALUES';
+/** @ignore */
+const LEAF = '';
+/**
+ * @private
+ */
+class TreeIterator {
+    constructor(set, type) {
+        const node = set._tree;
+        const keys = Array.from(node.keys());
+        this.set = set;
+        this._type = type;
+        this._path = keys.length > 0 ? [{ node, keys }] : [];
+    }
+    next() {
+        const value = this.dive();
+        this.backtrack();
+        return value;
+    }
+    dive() {
+        if (this._path.length === 0) {
+            return { done: true, value: undefined };
+        }
+        const { node, keys } = last$1(this._path);
+        if (last$1(keys) === LEAF) {
+            return { done: false, value: this.result() };
+        }
+        const child = node.get(last$1(keys));
+        this._path.push({ node: child, keys: Array.from(child.keys()) });
+        return this.dive();
+    }
+    backtrack() {
+        if (this._path.length === 0) {
+            return;
+        }
+        const keys = last$1(this._path).keys;
+        keys.pop();
+        if (keys.length > 0) {
+            return;
+        }
+        this._path.pop();
+        this.backtrack();
+    }
+    key() {
+        return this.set._prefix + this._path
+            .map(({ keys }) => last$1(keys))
+            .filter(key => key !== LEAF)
+            .join('');
+    }
+    value() {
+        return last$1(this._path).node.get(LEAF);
+    }
+    result() {
+        switch (this._type) {
+            case VALUES: return this.value();
+            case KEYS: return this.key();
+            default: return [this.key(), this.value()];
+        }
+    }
+    [Symbol.iterator]() {
+        return this;
+    }
+}
+const last$1 = (array) => {
+    return array[array.length - 1];
+};
+
+/* eslint-disable no-labels */
+/**
+ * @ignore
+ */
+const fuzzySearch = (node, query, maxDistance) => {
+    const results = new Map();
+    if (query === undefined)
+        return results;
+    // Number of columns in the Levenshtein matrix.
+    const n = query.length + 1;
+    // Matching terms can never be longer than N + maxDistance.
+    const m = n + maxDistance;
+    // Fill first matrix row and column with numbers: 0 1 2 3 ...
+    const matrix = new Uint8Array(m * n).fill(maxDistance + 1);
+    for (let j = 0; j < n; ++j)
+        matrix[j] = j;
+    for (let i = 1; i < m; ++i)
+        matrix[i * n] = i;
+    recurse(node, query, maxDistance, results, matrix, 1, n, '');
+    return results;
+};
+// Modified version of http://stevehanov.ca/blog/?id=114
+// This builds a Levenshtein matrix for a given query and continuously updates
+// it for nodes in the radix tree that fall within the given maximum edit
+// distance. Keeping the same matrix around is beneficial especially for larger
+// edit distances.
+//
+//           k   a   t   e   <-- query
+//       0   1   2   3   4
+//   c   1   1   2   3   4
+//   a   2   2   1   2   3
+//   t   3   3   2   1  [2]  <-- edit distance
+//   ^
+//   ^ term in radix tree, rows are added and removed as needed
+const recurse = (node, query, maxDistance, results, matrix, m, n, prefix) => {
+    const offset = m * n;
+    key: for (const key of node.keys()) {
+        if (key === LEAF) {
+            // We've reached a leaf node. Check if the edit distance acceptable and
+            // store the result if it is.
+            const distance = matrix[offset - 1];
+            if (distance <= maxDistance) {
+                results.set(prefix, [node.get(key), distance]);
+            }
+        }
+        else {
+            // Iterate over all characters in the key. Update the Levenshtein matrix
+            // and check if the minimum distance in the last row is still within the
+            // maximum edit distance. If it is, we can recurse over all child nodes.
+            let i = m;
+            for (let pos = 0; pos < key.length; ++pos, ++i) {
+                const char = key[pos];
+                const thisRowOffset = n * i;
+                const prevRowOffset = thisRowOffset - n;
+                // Set the first column based on the previous row, and initialize the
+                // minimum distance in the current row.
+                let minDistance = matrix[thisRowOffset];
+                const jmin = Math.max(0, i - maxDistance - 1);
+                const jmax = Math.min(n - 1, i + maxDistance);
+                // Iterate over remaining columns (characters in the query).
+                for (let j = jmin; j < jmax; ++j) {
+                    const different = char !== query[j];
+                    // It might make sense to only read the matrix positions used for
+                    // deletion/insertion if the characters are different. But we want to
+                    // avoid conditional reads for performance reasons.
+                    const rpl = matrix[prevRowOffset + j] + +different;
+                    const del = matrix[prevRowOffset + j + 1] + 1;
+                    const ins = matrix[thisRowOffset + j] + 1;
+                    const dist = matrix[thisRowOffset + j + 1] = Math.min(rpl, del, ins);
+                    if (dist < minDistance)
+                        minDistance = dist;
+                }
+                // Because distance will never decrease, we can stop. There will be no
+                // matching child nodes.
+                if (minDistance > maxDistance) {
+                    continue key;
+                }
+            }
+            recurse(node.get(key), query, maxDistance, results, matrix, i, n, prefix + key);
+        }
+    }
+};
+
+/* eslint-disable no-labels */
+/**
+ * A class implementing the same interface as a standard JavaScript
+ * [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+ * with string keys, but adding support for efficiently searching entries with
+ * prefix or fuzzy search. This class is used internally by {@link MiniSearch}
+ * as the inverted index data structure. The implementation is a radix tree
+ * (compressed prefix tree).
+ *
+ * Since this class can be of general utility beyond _MiniSearch_, it is
+ * exported by the `minisearch` package and can be imported (or required) as
+ * `minisearch/SearchableMap`.
+ *
+ * @typeParam T  The type of the values stored in the map.
+ */
+class SearchableMap {
+    /**
+     * The constructor is normally called without arguments, creating an empty
+     * map. In order to create a {@link SearchableMap} from an iterable or from an
+     * object, check {@link SearchableMap.from} and {@link
+     * SearchableMap.fromObject}.
+     *
+     * The constructor arguments are for internal use, when creating derived
+     * mutable views of a map at a prefix.
+     */
+    constructor(tree = new Map(), prefix = '') {
+        this._size = undefined;
+        this._tree = tree;
+        this._prefix = prefix;
+    }
+    /**
+     * Creates and returns a mutable view of this {@link SearchableMap},
+     * containing only entries that share the given prefix.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * let map = new SearchableMap()
+     * map.set("unicorn", 1)
+     * map.set("universe", 2)
+     * map.set("university", 3)
+     * map.set("unique", 4)
+     * map.set("hello", 5)
+     *
+     * let uni = map.atPrefix("uni")
+     * uni.get("unique") // => 4
+     * uni.get("unicorn") // => 1
+     * uni.get("hello") // => undefined
+     *
+     * let univer = map.atPrefix("univer")
+     * univer.get("unique") // => undefined
+     * univer.get("universe") // => 2
+     * univer.get("university") // => 3
+     * ```
+     *
+     * @param prefix  The prefix
+     * @return A {@link SearchableMap} representing a mutable view of the original
+     * Map at the given prefix
+     */
+    atPrefix(prefix) {
+        if (!prefix.startsWith(this._prefix)) {
+            throw new Error('Mismatched prefix');
+        }
+        const [node, path] = trackDown(this._tree, prefix.slice(this._prefix.length));
+        if (node === undefined) {
+            const [parentNode, key] = last(path);
+            for (const k of parentNode.keys()) {
+                if (k !== LEAF && k.startsWith(key)) {
+                    const node = new Map();
+                    node.set(k.slice(key.length), parentNode.get(k));
+                    return new SearchableMap(node, prefix);
+                }
+            }
+        }
+        return new SearchableMap(node, prefix);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
+     */
+    clear() {
+        this._size = undefined;
+        this._tree.clear();
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
+     * @param key  Key to delete
+     */
+    delete(key) {
+        this._size = undefined;
+        return remove(this._tree, key);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
+     * @return An iterator iterating through `[key, value]` entries.
+     */
+    entries() {
+        return new TreeIterator(this, ENTRIES);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach
+     * @param fn  Iteration function
+     */
+    forEach(fn) {
+        for (const [key, value] of this) {
+            fn(key, value, this);
+        }
+    }
+    /**
+     * Returns a Map of all the entries that have a key within the given edit
+     * distance from the search key. The keys of the returned Map are the matching
+     * keys, while the values are two-element arrays where the first element is
+     * the value associated to the key, and the second is the edit distance of the
+     * key to the search key.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * let map = new SearchableMap()
+     * map.set('hello', 'world')
+     * map.set('hell', 'yeah')
+     * map.set('ciao', 'mondo')
+     *
+     * // Get all entries that match the key 'hallo' with a maximum edit distance of 2
+     * map.fuzzyGet('hallo', 2)
+     * // => Map(2) { 'hello' => ['world', 1], 'hell' => ['yeah', 2] }
+     *
+     * // In the example, the "hello" key has value "world" and edit distance of 1
+     * // (change "e" to "a"), the key "hell" has value "yeah" and edit distance of 2
+     * // (change "e" to "a", delete "o")
+     * ```
+     *
+     * @param key  The search key
+     * @param maxEditDistance  The maximum edit distance (Levenshtein)
+     * @return A Map of the matching keys to their value and edit distance
+     */
+    fuzzyGet(key, maxEditDistance) {
+        return fuzzySearch(this._tree, key, maxEditDistance);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
+     * @param key  Key to get
+     * @return Value associated to the key, or `undefined` if the key is not
+     * found.
+     */
+    get(key) {
+        const node = lookup(this._tree, key);
+        return node !== undefined ? node.get(LEAF) : undefined;
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
+     * @param key  Key
+     * @return True if the key is in the map, false otherwise
+     */
+    has(key) {
+        const node = lookup(this._tree, key);
+        return node !== undefined && node.has(LEAF);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
+     * @return An `Iterable` iterating through keys
+     */
+    keys() {
+        return new TreeIterator(this, KEYS);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
+     * @param key  Key to set
+     * @param value  Value to associate to the key
+     * @return The {@link SearchableMap} itself, to allow chaining
+     */
+    set(key, value) {
+        if (typeof key !== 'string') {
+            throw new Error('key must be a string');
+        }
+        this._size = undefined;
+        const node = createPath(this._tree, key);
+        node.set(LEAF, value);
+        return this;
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size
+     */
+    get size() {
+        if (this._size) {
+            return this._size;
+        }
+        /** @ignore */
+        this._size = 0;
+        const iter = this.entries();
+        while (!iter.next().done)
+            this._size += 1;
+        return this._size;
+    }
+    /**
+     * Updates the value at the given key using the provided function. The function
+     * is called with the current value at the key, and its return value is used as
+     * the new value to be set.
+     *
+     * ### Example:
+     *
+     * ```javascript
+     * // Increment the current value by one
+     * searchableMap.update('somekey', (currentValue) => currentValue == null ? 0 : currentValue + 1)
+     * ```
+     *
+     * If the value at the given key is or will be an object, it might not require
+     * re-assignment. In that case it is better to use `fetch()`, because it is
+     * faster.
+     *
+     * @param key  The key to update
+     * @param fn  The function used to compute the new value from the current one
+     * @return The {@link SearchableMap} itself, to allow chaining
+     */
+    update(key, fn) {
+        if (typeof key !== 'string') {
+            throw new Error('key must be a string');
+        }
+        this._size = undefined;
+        const node = createPath(this._tree, key);
+        node.set(LEAF, fn(node.get(LEAF)));
+        return this;
+    }
+    /**
+     * Fetches the value of the given key. If the value does not exist, calls the
+     * given function to create a new value, which is inserted at the given key
+     * and subsequently returned.
+     *
+     * ### Example:
+     *
+     * ```javascript
+     * const map = searchableMap.fetch('somekey', () => new Map())
+     * map.set('foo', 'bar')
+     * ```
+     *
+     * @param key  The key to update
+     * @param initial  A function that creates a new value if the key does not exist
+     * @return The existing or new value at the given key
+     */
+    fetch(key, initial) {
+        if (typeof key !== 'string') {
+            throw new Error('key must be a string');
+        }
+        this._size = undefined;
+        const node = createPath(this._tree, key);
+        let value = node.get(LEAF);
+        if (value === undefined) {
+            node.set(LEAF, value = initial());
+        }
+        return value;
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values
+     * @return An `Iterable` iterating through values.
+     */
+    values() {
+        return new TreeIterator(this, VALUES);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator
+     */
+    [Symbol.iterator]() {
+        return this.entries();
+    }
+    /**
+     * Creates a {@link SearchableMap} from an `Iterable` of entries
+     *
+     * @param entries  Entries to be inserted in the {@link SearchableMap}
+     * @return A new {@link SearchableMap} with the given entries
+     */
+    static from(entries) {
+        const tree = new SearchableMap();
+        for (const [key, value] of entries) {
+            tree.set(key, value);
+        }
+        return tree;
+    }
+    /**
+     * Creates a {@link SearchableMap} from the iterable properties of a JavaScript object
+     *
+     * @param object  Object of entries for the {@link SearchableMap}
+     * @return A new {@link SearchableMap} with the given entries
+     */
+    static fromObject(object) {
+        return SearchableMap.from(Object.entries(object));
+    }
+}
+const trackDown = (tree, key, path = []) => {
+    if (key.length === 0 || tree == null) {
+        return [tree, path];
+    }
+    for (const k of tree.keys()) {
+        if (k !== LEAF && key.startsWith(k)) {
+            path.push([tree, k]); // performance: update in place
+            return trackDown(tree.get(k), key.slice(k.length), path);
+        }
+    }
+    path.push([tree, key]); // performance: update in place
+    return trackDown(undefined, '', path);
+};
+const lookup = (tree, key) => {
+    if (key.length === 0 || tree == null) {
+        return tree;
+    }
+    for (const k of tree.keys()) {
+        if (k !== LEAF && key.startsWith(k)) {
+            return lookup(tree.get(k), key.slice(k.length));
+        }
+    }
+};
+// Create a path in the radix tree for the given key, and returns the deepest
+// node. This function is in the hot path for indexing. It avoids unnecessary
+// string operations and recursion for performance.
+const createPath = (node, key) => {
+    const keyLength = key.length;
+    outer: for (let pos = 0; node && pos < keyLength;) {
+        for (const k of node.keys()) {
+            // Check whether this key is a candidate: the first characters must match.
+            if (k !== LEAF && key[pos] === k[0]) {
+                const len = Math.min(keyLength - pos, k.length);
+                // Advance offset to the point where key and k no longer match.
+                let offset = 1;
+                while (offset < len && key[pos + offset] === k[offset])
+                    ++offset;
+                const child = node.get(k);
+                if (offset === k.length) {
+                    // The existing key is shorter than the key we need to create.
+                    node = child;
+                }
+                else {
+                    // Partial match: we need to insert an intermediate node to contain
+                    // both the existing subtree and the new node.
+                    const intermediate = new Map();
+                    intermediate.set(k.slice(offset), child);
+                    node.set(key.slice(pos, pos + offset), intermediate);
+                    node.delete(k);
+                    node = intermediate;
+                }
+                pos += offset;
+                continue outer;
+            }
+        }
+        // Create a final child node to contain the final suffix of the key.
+        const child = new Map();
+        node.set(key.slice(pos), child);
+        return child;
+    }
+    return node;
+};
+const remove = (tree, key) => {
+    const [node, path] = trackDown(tree, key);
+    if (node === undefined) {
+        return;
+    }
+    node.delete(LEAF);
+    if (node.size === 0) {
+        cleanup(path);
+    }
+    else if (node.size === 1) {
+        const [key, value] = node.entries().next().value;
+        merge(path, key, value);
+    }
+};
+const cleanup = (path) => {
+    if (path.length === 0) {
+        return;
+    }
+    const [node, key] = last(path);
+    node.delete(key);
+    if (node.size === 0) {
+        cleanup(path.slice(0, -1));
+    }
+    else if (node.size === 1) {
+        const [key, value] = node.entries().next().value;
+        if (key !== LEAF) {
+            merge(path.slice(0, -1), key, value);
+        }
+    }
+};
+const merge = (path, key, value) => {
+    if (path.length === 0) {
+        return;
+    }
+    const [node, nodeKey] = last(path);
+    node.set(nodeKey + key, value);
+    node.delete(nodeKey);
+};
+const last = (array) => {
+    return array[array.length - 1];
+};
+
+const OR = 'or';
+const AND = 'and';
+const AND_NOT = 'and_not';
+/**
+ * {@link MiniSearch} is the main entrypoint class, implementing a full-text
+ * search engine in memory.
+ *
+ * @typeParam T  The type of the documents being indexed.
+ *
+ * ### Basic example:
+ *
+ * ```javascript
+ * const documents = [
+ *   {
+ *     id: 1,
+ *     title: 'Moby Dick',
+ *     text: 'Call me Ishmael. Some years ago...',
+ *     category: 'fiction'
+ *   },
+ *   {
+ *     id: 2,
+ *     title: 'Zen and the Art of Motorcycle Maintenance',
+ *     text: 'I can see by my watch...',
+ *     category: 'fiction'
+ *   },
+ *   {
+ *     id: 3,
+ *     title: 'Neuromancer',
+ *     text: 'The sky above the port was...',
+ *     category: 'fiction'
+ *   },
+ *   {
+ *     id: 4,
+ *     title: 'Zen and the Art of Archery',
+ *     text: 'At first sight it must seem...',
+ *     category: 'non-fiction'
+ *   },
+ *   // ...and more
+ * ]
+ *
+ * // Create a search engine that indexes the 'title' and 'text' fields for
+ * // full-text search. Search results will include 'title' and 'category' (plus the
+ * // id field, that is always stored and returned)
+ * const miniSearch = new MiniSearch({
+ *   fields: ['title', 'text'],
+ *   storeFields: ['title', 'category']
+ * })
+ *
+ * // Add documents to the index
+ * miniSearch.addAll(documents)
+ *
+ * // Search for documents:
+ * let results = miniSearch.search('zen art motorcycle')
+ * // => [
+ * //   { id: 2, title: 'Zen and the Art of Motorcycle Maintenance', category: 'fiction', score: 2.77258 },
+ * //   { id: 4, title: 'Zen and the Art of Archery', category: 'non-fiction', score: 1.38629 }
+ * // ]
+ * ```
+ */
+class MiniSearch {
+    /**
+     * @param options  Configuration options
+     *
+     * ### Examples:
+     *
+     * ```javascript
+     * // Create a search engine that indexes the 'title' and 'text' fields of your
+     * // documents:
+     * const miniSearch = new MiniSearch({ fields: ['title', 'text'] })
+     * ```
+     *
+     * ### ID Field:
+     *
+     * ```javascript
+     * // Your documents are assumed to include a unique 'id' field, but if you want
+     * // to use a different field for document identification, you can set the
+     * // 'idField' option:
+     * const miniSearch = new MiniSearch({ idField: 'key', fields: ['title', 'text'] })
+     * ```
+     *
+     * ### Options and defaults:
+     *
+     * ```javascript
+     * // The full set of options (here with their default value) is:
+     * const miniSearch = new MiniSearch({
+     *   // idField: field that uniquely identifies a document
+     *   idField: 'id',
+     *
+     *   // extractField: function used to get the value of a field in a document.
+     *   // By default, it assumes the document is a flat object with field names as
+     *   // property keys and field values as string property values, but custom logic
+     *   // can be implemented by setting this option to a custom extractor function.
+     *   extractField: (document, fieldName) => document[fieldName],
+     *
+     *   // tokenize: function used to split fields into individual terms. By
+     *   // default, it is also used to tokenize search queries, unless a specific
+     *   // `tokenize` search option is supplied. When tokenizing an indexed field,
+     *   // the field name is passed as the second argument.
+     *   tokenize: (string, _fieldName) => string.split(SPACE_OR_PUNCTUATION),
+     *
+     *   // processTerm: function used to process each tokenized term before
+     *   // indexing. It can be used for stemming and normalization. Return a falsy
+     *   // value in order to discard a term. By default, it is also used to process
+     *   // search queries, unless a specific `processTerm` option is supplied as a
+     *   // search option. When processing a term from a indexed field, the field
+     *   // name is passed as the second argument.
+     *   processTerm: (term, _fieldName) => term.toLowerCase(),
+     *
+     *   // searchOptions: default search options, see the `search` method for
+     *   // details
+     *   searchOptions: undefined,
+     *
+     *   // fields: document fields to be indexed. Mandatory, but not set by default
+     *   fields: undefined
+     *
+     *   // storeFields: document fields to be stored and returned as part of the
+     *   // search results.
+     *   storeFields: []
+     * })
+     * ```
+     */
+    constructor(options) {
+        if ((options === null || options === void 0 ? void 0 : options.fields) == null) {
+            throw new Error('MiniSearch: option "fields" must be provided');
+        }
+        const autoVacuum = (options.autoVacuum == null || options.autoVacuum === true) ? defaultAutoVacuumOptions : options.autoVacuum;
+        this._options = {
+            ...defaultOptions,
+            ...options,
+            autoVacuum,
+            searchOptions: { ...defaultSearchOptions, ...(options.searchOptions || {}) },
+            autoSuggestOptions: { ...defaultAutoSuggestOptions, ...(options.autoSuggestOptions || {}) }
+        };
+        this._index = new SearchableMap();
+        this._documentCount = 0;
+        this._documentIds = new Map();
+        this._idToShortId = new Map();
+        // Fields are defined during initialization, don't change, are few in
+        // number, rarely need iterating over, and have string keys. Therefore in
+        // this case an object is a better candidate than a Map to store the mapping
+        // from field key to ID.
+        this._fieldIds = {};
+        this._fieldLength = new Map();
+        this._avgFieldLength = [];
+        this._nextId = 0;
+        this._storedFields = new Map();
+        this._dirtCount = 0;
+        this._currentVacuum = null;
+        this._enqueuedVacuum = null;
+        this._enqueuedVacuumConditions = defaultVacuumConditions;
+        this.addFields(this._options.fields);
+    }
+    /**
+     * Adds a document to the index
+     *
+     * @param document  The document to be indexed
+     */
+    add(document) {
+        const { extractField, stringifyField, tokenize, processTerm, fields, idField } = this._options;
+        const id = extractField(document, idField);
+        if (id == null) {
+            throw new Error(`MiniSearch: document does not have ID field "${idField}"`);
+        }
+        if (this._idToShortId.has(id)) {
+            throw new Error(`MiniSearch: duplicate ID ${id}`);
+        }
+        const shortDocumentId = this.addDocumentId(id);
+        this.saveStoredFields(shortDocumentId, document);
+        for (const field of fields) {
+            const fieldValue = extractField(document, field);
+            if (fieldValue == null)
+                continue;
+            const tokens = tokenize(stringifyField(fieldValue, field), field);
+            const fieldId = this._fieldIds[field];
+            const uniqueTerms = new Set(tokens).size;
+            this.addFieldLength(shortDocumentId, fieldId, this._documentCount - 1, uniqueTerms);
+            for (const term of tokens) {
+                const processedTerm = processTerm(term, field);
+                if (Array.isArray(processedTerm)) {
+                    for (const t of processedTerm) {
+                        this.addTerm(fieldId, shortDocumentId, t);
+                    }
+                }
+                else if (processedTerm) {
+                    this.addTerm(fieldId, shortDocumentId, processedTerm);
+                }
+            }
+        }
+    }
+    /**
+     * Adds all the given documents to the index
+     *
+     * @param documents  An array of documents to be indexed
+     */
+    addAll(documents) {
+        for (const document of documents)
+            this.add(document);
+    }
+    /**
+     * Adds all the given documents to the index asynchronously.
+     *
+     * Returns a promise that resolves (to `undefined`) when the indexing is done.
+     * This method is useful when index many documents, to avoid blocking the main
+     * thread. The indexing is performed asynchronously and in chunks.
+     *
+     * @param documents  An array of documents to be indexed
+     * @param options  Configuration options
+     * @return A promise resolving to `undefined` when the indexing is done
+     */
+    addAllAsync(documents, options = {}) {
+        const { chunkSize = 10 } = options;
+        const acc = { chunk: [], promise: Promise.resolve() };
+        const { chunk, promise } = documents.reduce(({ chunk, promise }, document, i) => {
+            chunk.push(document);
+            if ((i + 1) % chunkSize === 0) {
+                return {
+                    chunk: [],
+                    promise: promise
+                        .then(() => new Promise(resolve => setTimeout(resolve, 0)))
+                        .then(() => this.addAll(chunk))
+                };
+            }
+            else {
+                return { chunk, promise };
+            }
+        }, acc);
+        return promise.then(() => this.addAll(chunk));
+    }
+    /**
+     * Removes the given document from the index.
+     *
+     * The document to remove must NOT have changed between indexing and removal,
+     * otherwise the index will be corrupted.
+     *
+     * This method requires passing the full document to be removed (not just the
+     * ID), and immediately removes the document from the inverted index, allowing
+     * memory to be released. A convenient alternative is {@link
+     * MiniSearch#discard}, which needs only the document ID, and has the same
+     * visible effect, but delays cleaning up the index until the next vacuuming.
+     *
+     * @param document  The document to be removed
+     */
+    remove(document) {
+        const { tokenize, processTerm, extractField, stringifyField, fields, idField } = this._options;
+        const id = extractField(document, idField);
+        if (id == null) {
+            throw new Error(`MiniSearch: document does not have ID field "${idField}"`);
+        }
+        const shortId = this._idToShortId.get(id);
+        if (shortId == null) {
+            throw new Error(`MiniSearch: cannot remove document with ID ${id}: it is not in the index`);
+        }
+        for (const field of fields) {
+            const fieldValue = extractField(document, field);
+            if (fieldValue == null)
+                continue;
+            const tokens = tokenize(stringifyField(fieldValue, field), field);
+            const fieldId = this._fieldIds[field];
+            const uniqueTerms = new Set(tokens).size;
+            this.removeFieldLength(shortId, fieldId, this._documentCount, uniqueTerms);
+            for (const term of tokens) {
+                const processedTerm = processTerm(term, field);
+                if (Array.isArray(processedTerm)) {
+                    for (const t of processedTerm) {
+                        this.removeTerm(fieldId, shortId, t);
+                    }
+                }
+                else if (processedTerm) {
+                    this.removeTerm(fieldId, shortId, processedTerm);
+                }
+            }
+        }
+        this._storedFields.delete(shortId);
+        this._documentIds.delete(shortId);
+        this._idToShortId.delete(id);
+        this._fieldLength.delete(shortId);
+        this._documentCount -= 1;
+    }
+    /**
+     * Removes all the given documents from the index. If called with no arguments,
+     * it removes _all_ documents from the index.
+     *
+     * @param documents  The documents to be removed. If this argument is omitted,
+     * all documents are removed. Note that, for removing all documents, it is
+     * more efficient to call this method with no arguments than to pass all
+     * documents.
+     */
+    removeAll(documents) {
+        if (documents) {
+            for (const document of documents)
+                this.remove(document);
+        }
+        else if (arguments.length > 0) {
+            throw new Error('Expected documents to be present. Omit the argument to remove all documents.');
+        }
+        else {
+            this._index = new SearchableMap();
+            this._documentCount = 0;
+            this._documentIds = new Map();
+            this._idToShortId = new Map();
+            this._fieldLength = new Map();
+            this._avgFieldLength = [];
+            this._storedFields = new Map();
+            this._nextId = 0;
+        }
+    }
+    /**
+     * Discards the document with the given ID, so it won't appear in search results
+     *
+     * It has the same visible effect of {@link MiniSearch.remove} (both cause the
+     * document to stop appearing in searches), but a different effect on the
+     * internal data structures:
+     *
+     *   - {@link MiniSearch#remove} requires passing the full document to be
+     *   removed as argument, and removes it from the inverted index immediately.
+     *
+     *   - {@link MiniSearch#discard} instead only needs the document ID, and
+     *   works by marking the current version of the document as discarded, so it
+     *   is immediately ignored by searches. This is faster and more convenient
+     *   than {@link MiniSearch#remove}, but the index is not immediately
+     *   modified. To take care of that, vacuuming is performed after a certain
+     *   number of documents are discarded, cleaning up the index and allowing
+     *   memory to be released.
+     *
+     * After discarding a document, it is possible to re-add a new version, and
+     * only the new version will appear in searches. In other words, discarding
+     * and re-adding a document works exactly like removing and re-adding it. The
+     * {@link MiniSearch.replace} method can also be used to replace a document
+     * with a new version.
+     *
+     * #### Details about vacuuming
+     *
+     * Repetite calls to this method would leave obsolete document references in
+     * the index, invisible to searches. Two mechanisms take care of cleaning up:
+     * clean up during search, and vacuuming.
+     *
+     *   - Upon search, whenever a discarded ID is found (and ignored for the
+     *   results), references to the discarded document are removed from the
+     *   inverted index entries for the search terms. This ensures that subsequent
+     *   searches for the same terms do not need to skip these obsolete references
+     *   again.
+     *
+     *   - In addition, vacuuming is performed automatically by default (see the
+     *   `autoVacuum` field in {@link Options}) after a certain number of
+     *   documents are discarded. Vacuuming traverses all terms in the index,
+     *   cleaning up all references to discarded documents. Vacuuming can also be
+     *   triggered manually by calling {@link MiniSearch#vacuum}.
+     *
+     * @param id  The ID of the document to be discarded
+     */
+    discard(id) {
+        const shortId = this._idToShortId.get(id);
+        if (shortId == null) {
+            throw new Error(`MiniSearch: cannot discard document with ID ${id}: it is not in the index`);
+        }
+        this._idToShortId.delete(id);
+        this._documentIds.delete(shortId);
+        this._storedFields.delete(shortId);
+        (this._fieldLength.get(shortId) || []).forEach((fieldLength, fieldId) => {
+            this.removeFieldLength(shortId, fieldId, this._documentCount, fieldLength);
+        });
+        this._fieldLength.delete(shortId);
+        this._documentCount -= 1;
+        this._dirtCount += 1;
+        this.maybeAutoVacuum();
+    }
+    maybeAutoVacuum() {
+        if (this._options.autoVacuum === false) {
+            return;
+        }
+        const { minDirtFactor, minDirtCount, batchSize, batchWait } = this._options.autoVacuum;
+        this.conditionalVacuum({ batchSize, batchWait }, { minDirtCount, minDirtFactor });
+    }
+    /**
+     * Discards the documents with the given IDs, so they won't appear in search
+     * results
+     *
+     * It is equivalent to calling {@link MiniSearch#discard} for all the given
+     * IDs, but with the optimization of triggering at most one automatic
+     * vacuuming at the end.
+     *
+     * Note: to remove all documents from the index, it is faster and more
+     * convenient to call {@link MiniSearch.removeAll} with no argument, instead
+     * of passing all IDs to this method.
+     */
+    discardAll(ids) {
+        const autoVacuum = this._options.autoVacuum;
+        try {
+            this._options.autoVacuum = false;
+            for (const id of ids) {
+                this.discard(id);
+            }
+        }
+        finally {
+            this._options.autoVacuum = autoVacuum;
+        }
+        this.maybeAutoVacuum();
+    }
+    /**
+     * It replaces an existing document with the given updated version
+     *
+     * It works by discarding the current version and adding the updated one, so
+     * it is functionally equivalent to calling {@link MiniSearch#discard}
+     * followed by {@link MiniSearch#add}. The ID of the updated document should
+     * be the same as the original one.
+     *
+     * Since it uses {@link MiniSearch#discard} internally, this method relies on
+     * vacuuming to clean up obsolete document references from the index, allowing
+     * memory to be released (see {@link MiniSearch#discard}).
+     *
+     * @param updatedDocument  The updated document to replace the old version
+     * with
+     */
+    replace(updatedDocument) {
+        const { idField, extractField } = this._options;
+        const id = extractField(updatedDocument, idField);
+        this.discard(id);
+        this.add(updatedDocument);
+    }
+    /**
+     * Triggers a manual vacuuming, cleaning up references to discarded documents
+     * from the inverted index
+     *
+     * Vacuuming is only useful for applications that use the {@link
+     * MiniSearch#discard} or {@link MiniSearch#replace} methods.
+     *
+     * By default, vacuuming is performed automatically when needed (controlled by
+     * the `autoVacuum` field in {@link Options}), so there is usually no need to
+     * call this method, unless one wants to make sure to perform vacuuming at a
+     * specific moment.
+     *
+     * Vacuuming traverses all terms in the inverted index in batches, and cleans
+     * up references to discarded documents from the posting list, allowing memory
+     * to be released.
+     *
+     * The method takes an optional object as argument with the following keys:
+     *
+     *   - `batchSize`: the size of each batch (1000 by default)
+     *
+     *   - `batchWait`: the number of milliseconds to wait between batches (10 by
+     *   default)
+     *
+     * On large indexes, vacuuming could have a non-negligible cost: batching
+     * avoids blocking the thread for long, diluting this cost so that it is not
+     * negatively affecting the application. Nonetheless, this method should only
+     * be called when necessary, and relying on automatic vacuuming is usually
+     * better.
+     *
+     * It returns a promise that resolves (to undefined) when the clean up is
+     * completed. If vacuuming is already ongoing at the time this method is
+     * called, a new one is enqueued immediately after the ongoing one, and a
+     * corresponding promise is returned. However, no more than one vacuuming is
+     * enqueued on top of the ongoing one, even if this method is called more
+     * times (enqueuing multiple ones would be useless).
+     *
+     * @param options  Configuration options for the batch size and delay. See
+     * {@link VacuumOptions}.
+     */
+    vacuum(options = {}) {
+        return this.conditionalVacuum(options);
+    }
+    conditionalVacuum(options, conditions) {
+        // If a vacuum is already ongoing, schedule another as soon as it finishes,
+        // unless there's already one enqueued. If one was already enqueued, do not
+        // enqueue another on top, but make sure that the conditions are the
+        // broadest.
+        if (this._currentVacuum) {
+            this._enqueuedVacuumConditions = this._enqueuedVacuumConditions && conditions;
+            if (this._enqueuedVacuum != null) {
+                return this._enqueuedVacuum;
+            }
+            this._enqueuedVacuum = this._currentVacuum.then(() => {
+                const conditions = this._enqueuedVacuumConditions;
+                this._enqueuedVacuumConditions = defaultVacuumConditions;
+                return this.performVacuuming(options, conditions);
+            });
+            return this._enqueuedVacuum;
+        }
+        if (this.vacuumConditionsMet(conditions) === false) {
+            return Promise.resolve();
+        }
+        this._currentVacuum = this.performVacuuming(options);
+        return this._currentVacuum;
+    }
+    async performVacuuming(options, conditions) {
+        const initialDirtCount = this._dirtCount;
+        if (this.vacuumConditionsMet(conditions)) {
+            const batchSize = options.batchSize || defaultVacuumOptions.batchSize;
+            const batchWait = options.batchWait || defaultVacuumOptions.batchWait;
+            let i = 1;
+            for (const [term, fieldsData] of this._index) {
+                for (const [fieldId, fieldIndex] of fieldsData) {
+                    for (const [shortId] of fieldIndex) {
+                        if (this._documentIds.has(shortId)) {
+                            continue;
+                        }
+                        if (fieldIndex.size <= 1) {
+                            fieldsData.delete(fieldId);
+                        }
+                        else {
+                            fieldIndex.delete(shortId);
+                        }
+                    }
+                }
+                if (this._index.get(term).size === 0) {
+                    this._index.delete(term);
+                }
+                if (i % batchSize === 0) {
+                    await new Promise((resolve) => setTimeout(resolve, batchWait));
+                }
+                i += 1;
+            }
+            this._dirtCount -= initialDirtCount;
+        }
+        // Make the next lines always async, so they execute after this function returns
+        await null;
+        this._currentVacuum = this._enqueuedVacuum;
+        this._enqueuedVacuum = null;
+    }
+    vacuumConditionsMet(conditions) {
+        if (conditions == null) {
+            return true;
+        }
+        let { minDirtCount, minDirtFactor } = conditions;
+        minDirtCount = minDirtCount || defaultAutoVacuumOptions.minDirtCount;
+        minDirtFactor = minDirtFactor || defaultAutoVacuumOptions.minDirtFactor;
+        return this.dirtCount >= minDirtCount && this.dirtFactor >= minDirtFactor;
+    }
+    /**
+     * Is `true` if a vacuuming operation is ongoing, `false` otherwise
+     */
+    get isVacuuming() {
+        return this._currentVacuum != null;
+    }
+    /**
+     * The number of documents discarded since the most recent vacuuming
+     */
+    get dirtCount() {
+        return this._dirtCount;
+    }
+    /**
+     * A number between 0 and 1 giving an indication about the proportion of
+     * documents that are discarded, and can therefore be cleaned up by vacuuming.
+     * A value close to 0 means that the index is relatively clean, while a higher
+     * value means that the index is relatively dirty, and vacuuming could release
+     * memory.
+     */
+    get dirtFactor() {
+        return this._dirtCount / (1 + this._documentCount + this._dirtCount);
+    }
+    /**
+     * Returns `true` if a document with the given ID is present in the index and
+     * available for search, `false` otherwise
+     *
+     * @param id  The document ID
+     */
+    has(id) {
+        return this._idToShortId.has(id);
+    }
+    /**
+     * Returns the stored fields (as configured in the `storeFields` constructor
+     * option) for the given document ID. Returns `undefined` if the document is
+     * not present in the index.
+     *
+     * @param id  The document ID
+     */
+    getStoredFields(id) {
+        const shortId = this._idToShortId.get(id);
+        if (shortId == null) {
+            return undefined;
+        }
+        return this._storedFields.get(shortId);
+    }
+    /**
+     * Search for documents matching the given search query.
+     *
+     * The result is a list of scored document IDs matching the query, sorted by
+     * descending score, and each including data about which terms were matched and
+     * in which fields.
+     *
+     * ### Basic usage:
+     *
+     * ```javascript
+     * // Search for "zen art motorcycle" with default options: terms have to match
+     * // exactly, and individual terms are joined with OR
+     * miniSearch.search('zen art motorcycle')
+     * // => [ { id: 2, score: 2.77258, match: { ... } }, { id: 4, score: 1.38629, match: { ... } } ]
+     * ```
+     *
+     * ### Restrict search to specific fields:
+     *
+     * ```javascript
+     * // Search only in the 'title' field
+     * miniSearch.search('zen', { fields: ['title'] })
+     * ```
+     *
+     * ### Field boosting:
+     *
+     * ```javascript
+     * // Boost a field
+     * miniSearch.search('zen', { boost: { title: 2 } })
+     * ```
+     *
+     * ### Prefix search:
+     *
+     * ```javascript
+     * // Search for "moto" with prefix search (it will match documents
+     * // containing terms that start with "moto" or "neuro")
+     * miniSearch.search('moto neuro', { prefix: true })
+     * ```
+     *
+     * ### Fuzzy search:
+     *
+     * ```javascript
+     * // Search for "ismael" with fuzzy search (it will match documents containing
+     * // terms similar to "ismael", with a maximum edit distance of 0.2 term.length
+     * // (rounded to nearest integer)
+     * miniSearch.search('ismael', { fuzzy: 0.2 })
+     * ```
+     *
+     * ### Combining strategies:
+     *
+     * ```javascript
+     * // Mix of exact match, prefix search, and fuzzy search
+     * miniSearch.search('ismael mob', {
+     *  prefix: true,
+     *  fuzzy: 0.2
+     * })
+     * ```
+     *
+     * ### Advanced prefix and fuzzy search:
+     *
+     * ```javascript
+     * // Perform fuzzy and prefix search depending on the search term. Here
+     * // performing prefix and fuzzy search only on terms longer than 3 characters
+     * miniSearch.search('ismael mob', {
+     *  prefix: term => term.length > 3
+     *  fuzzy: term => term.length > 3 ? 0.2 : null
+     * })
+     * ```
+     *
+     * ### Combine with AND:
+     *
+     * ```javascript
+     * // Combine search terms with AND (to match only documents that contain both
+     * // "motorcycle" and "art")
+     * miniSearch.search('motorcycle art', { combineWith: 'AND' })
+     * ```
+     *
+     * ### Combine with AND_NOT:
+     *
+     * There is also an AND_NOT combinator, that finds documents that match the
+     * first term, but do not match any of the other terms. This combinator is
+     * rarely useful with simple queries, and is meant to be used with advanced
+     * query combinations (see later for more details).
+     *
+     * ### Filtering results:
+     *
+     * ```javascript
+     * // Filter only results in the 'fiction' category (assuming that 'category'
+     * // is a stored field)
+     * miniSearch.search('motorcycle art', {
+     *   filter: (result) => result.category === 'fiction'
+     * })
+     * ```
+     *
+     * ### Wildcard query
+     *
+     * Searching for an empty string (assuming the default tokenizer) returns no
+     * results. Sometimes though, one needs to match all documents, like in a
+     * "wildcard" search. This is possible by passing the special value
+     * {@link MiniSearch.wildcard} as the query:
+     *
+     * ```javascript
+     * // Return search results for all documents
+     * miniSearch.search(MiniSearch.wildcard)
+     * ```
+     *
+     * Note that search options such as `filter` and `boostDocument` are still
+     * applied, influencing which results are returned, and their order:
+     *
+     * ```javascript
+     * // Return search results for all documents in the 'fiction' category
+     * miniSearch.search(MiniSearch.wildcard, {
+     *   filter: (result) => result.category === 'fiction'
+     * })
+     * ```
+     *
+     * ### Advanced combination of queries:
+     *
+     * It is possible to combine different subqueries with OR, AND, and AND_NOT,
+     * and even with different search options, by passing a query expression
+     * tree object as the first argument, instead of a string.
+     *
+     * ```javascript
+     * // Search for documents that contain "zen" and ("motorcycle" or "archery")
+     * miniSearch.search({
+     *   combineWith: 'AND',
+     *   queries: [
+     *     'zen',
+     *     {
+     *       combineWith: 'OR',
+     *       queries: ['motorcycle', 'archery']
+     *     }
+     *   ]
+     * })
+     *
+     * // Search for documents that contain ("apple" or "pear") but not "juice" and
+     * // not "tree"
+     * miniSearch.search({
+     *   combineWith: 'AND_NOT',
+     *   queries: [
+     *     {
+     *       combineWith: 'OR',
+     *       queries: ['apple', 'pear']
+     *     },
+     *     'juice',
+     *     'tree'
+     *   ]
+     * })
+     * ```
+     *
+     * Each node in the expression tree can be either a string, or an object that
+     * supports all {@link SearchOptions} fields, plus a `queries` array field for
+     * subqueries.
+     *
+     * Note that, while this can become complicated to do by hand for complex or
+     * deeply nested queries, it provides a formalized expression tree API for
+     * external libraries that implement a parser for custom query languages.
+     *
+     * @param query  Search query
+     * @param searchOptions  Search options. Each option, if not given, defaults to the corresponding value of `searchOptions` given to the constructor, or to the library default.
+     */
+    search(query, searchOptions = {}) {
+        const { searchOptions: globalSearchOptions } = this._options;
+        const searchOptionsWithDefaults = { ...globalSearchOptions, ...searchOptions };
+        const rawResults = this.executeQuery(query, searchOptions);
+        const results = [];
+        for (const [docId, { score, terms, match }] of rawResults) {
+            // terms are the matched query terms, which will be returned to the user
+            // as queryTerms. The quality is calculated based on them, as opposed to
+            // the matched terms in the document (which can be different due to
+            // prefix and fuzzy match)
+            const quality = terms.length || 1;
+            const result = {
+                id: this._documentIds.get(docId),
+                score: score * quality,
+                terms: Object.keys(match),
+                queryTerms: terms,
+                match
+            };
+            Object.assign(result, this._storedFields.get(docId));
+            if (searchOptionsWithDefaults.filter == null || searchOptionsWithDefaults.filter(result)) {
+                results.push(result);
+            }
+        }
+        // If it's a wildcard query, and no document boost is applied, skip sorting
+        // the results, as all results have the same score of 1
+        if (query === MiniSearch.wildcard && searchOptionsWithDefaults.boostDocument == null) {
+            return results;
+        }
+        results.sort(byScore);
+        return results;
+    }
+    /**
+     * Provide suggestions for the given search query
+     *
+     * The result is a list of suggested modified search queries, derived from the
+     * given search query, each with a relevance score, sorted by descending score.
+     *
+     * By default, it uses the same options used for search, except that by
+     * default it performs prefix search on the last term of the query, and
+     * combine terms with `'AND'` (requiring all query terms to match). Custom
+     * options can be passed as a second argument. Defaults can be changed upon
+     * calling the {@link MiniSearch} constructor, by passing a
+     * `autoSuggestOptions` option.
+     *
+     * ### Basic usage:
+     *
+     * ```javascript
+     * // Get suggestions for 'neuro':
+     * miniSearch.autoSuggest('neuro')
+     * // => [ { suggestion: 'neuromancer', terms: [ 'neuromancer' ], score: 0.46240 } ]
+     * ```
+     *
+     * ### Multiple words:
+     *
+     * ```javascript
+     * // Get suggestions for 'zen ar':
+     * miniSearch.autoSuggest('zen ar')
+     * // => [
+     * //  { suggestion: 'zen archery art', terms: [ 'zen', 'archery', 'art' ], score: 1.73332 },
+     * //  { suggestion: 'zen art', terms: [ 'zen', 'art' ], score: 1.21313 }
+     * // ]
+     * ```
+     *
+     * ### Fuzzy suggestions:
+     *
+     * ```javascript
+     * // Correct spelling mistakes using fuzzy search:
+     * miniSearch.autoSuggest('neromancer', { fuzzy: 0.2 })
+     * // => [ { suggestion: 'neuromancer', terms: [ 'neuromancer' ], score: 1.03998 } ]
+     * ```
+     *
+     * ### Filtering:
+     *
+     * ```javascript
+     * // Get suggestions for 'zen ar', but only within the 'fiction' category
+     * // (assuming that 'category' is a stored field):
+     * miniSearch.autoSuggest('zen ar', {
+     *   filter: (result) => result.category === 'fiction'
+     * })
+     * // => [
+     * //  { suggestion: 'zen archery art', terms: [ 'zen', 'archery', 'art' ], score: 1.73332 },
+     * //  { suggestion: 'zen art', terms: [ 'zen', 'art' ], score: 1.21313 }
+     * // ]
+     * ```
+     *
+     * @param queryString  Query string to be expanded into suggestions
+     * @param options  Search options. The supported options and default values
+     * are the same as for the {@link MiniSearch#search} method, except that by
+     * default prefix search is performed on the last term in the query, and terms
+     * are combined with `'AND'`.
+     * @return  A sorted array of suggestions sorted by relevance score.
+     */
+    autoSuggest(queryString, options = {}) {
+        options = { ...this._options.autoSuggestOptions, ...options };
+        const suggestions = new Map();
+        for (const { score, terms } of this.search(queryString, options)) {
+            const phrase = terms.join(' ');
+            const suggestion = suggestions.get(phrase);
+            if (suggestion != null) {
+                suggestion.score += score;
+                suggestion.count += 1;
+            }
+            else {
+                suggestions.set(phrase, { score, terms, count: 1 });
+            }
+        }
+        const results = [];
+        for (const [suggestion, { score, terms, count }] of suggestions) {
+            results.push({ suggestion, terms, score: score / count });
+        }
+        results.sort(byScore);
+        return results;
+    }
+    /**
+     * Total number of documents available to search
+     */
+    get documentCount() {
+        return this._documentCount;
+    }
+    /**
+     * Number of terms in the index
+     */
+    get termCount() {
+        return this._index.size;
+    }
+    /**
+     * Deserializes a JSON index (serialized with `JSON.stringify(miniSearch)`)
+     * and instantiates a MiniSearch instance. It should be given the same options
+     * originally used when serializing the index.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * // If the index was serialized with:
+     * let miniSearch = new MiniSearch({ fields: ['title', 'text'] })
+     * miniSearch.addAll(documents)
+     *
+     * const json = JSON.stringify(miniSearch)
+     * // It can later be deserialized like this:
+     * miniSearch = MiniSearch.loadJSON(json, { fields: ['title', 'text'] })
+     * ```
+     *
+     * @param json  JSON-serialized index
+     * @param options  configuration options, same as the constructor
+     * @return An instance of MiniSearch deserialized from the given JSON.
+     */
+    static loadJSON(json, options) {
+        if (options == null) {
+            throw new Error('MiniSearch: loadJSON should be given the same options used when serializing the index');
+        }
+        return this.loadJS(JSON.parse(json), options);
+    }
+    /**
+     * Async equivalent of {@link MiniSearch.loadJSON}
+     *
+     * This function is an alternative to {@link MiniSearch.loadJSON} that returns
+     * a promise, and loads the index in batches, leaving pauses between them to avoid
+     * blocking the main thread. It tends to be slower than the synchronous
+     * version, but does not block the main thread, so it can be a better choice
+     * when deserializing very large indexes.
+     *
+     * @param json  JSON-serialized index
+     * @param options  configuration options, same as the constructor
+     * @return A Promise that will resolve to an instance of MiniSearch deserialized from the given JSON.
+     */
+    static async loadJSONAsync(json, options) {
+        if (options == null) {
+            throw new Error('MiniSearch: loadJSON should be given the same options used when serializing the index');
+        }
+        return this.loadJSAsync(JSON.parse(json), options);
+    }
+    /**
+     * Returns the default value of an option. It will throw an error if no option
+     * with the given name exists.
+     *
+     * @param optionName  Name of the option
+     * @return The default value of the given option
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * // Get default tokenizer
+     * MiniSearch.getDefault('tokenize')
+     *
+     * // Get default term processor
+     * MiniSearch.getDefault('processTerm')
+     *
+     * // Unknown options will throw an error
+     * MiniSearch.getDefault('notExisting')
+     * // => throws 'MiniSearch: unknown option "notExisting"'
+     * ```
+     */
+    static getDefault(optionName) {
+        if (defaultOptions.hasOwnProperty(optionName)) {
+            return getOwnProperty(defaultOptions, optionName);
+        }
+        else {
+            throw new Error(`MiniSearch: unknown option "${optionName}"`);
+        }
+    }
+    /**
+     * @ignore
+     */
+    static loadJS(js, options) {
+        const { index, documentIds, fieldLength, storedFields, serializationVersion } = js;
+        const miniSearch = this.instantiateMiniSearch(js, options);
+        miniSearch._documentIds = objectToNumericMap(documentIds);
+        miniSearch._fieldLength = objectToNumericMap(fieldLength);
+        miniSearch._storedFields = objectToNumericMap(storedFields);
+        for (const [shortId, id] of miniSearch._documentIds) {
+            miniSearch._idToShortId.set(id, shortId);
+        }
+        for (const [term, data] of index) {
+            const dataMap = new Map();
+            for (const fieldId of Object.keys(data)) {
+                let indexEntry = data[fieldId];
+                // Version 1 used to nest the index entry inside a field called ds
+                if (serializationVersion === 1) {
+                    indexEntry = indexEntry.ds;
+                }
+                dataMap.set(parseInt(fieldId, 10), objectToNumericMap(indexEntry));
+            }
+            miniSearch._index.set(term, dataMap);
+        }
+        return miniSearch;
+    }
+    /**
+     * @ignore
+     */
+    static async loadJSAsync(js, options) {
+        const { index, documentIds, fieldLength, storedFields, serializationVersion } = js;
+        const miniSearch = this.instantiateMiniSearch(js, options);
+        miniSearch._documentIds = await objectToNumericMapAsync(documentIds);
+        miniSearch._fieldLength = await objectToNumericMapAsync(fieldLength);
+        miniSearch._storedFields = await objectToNumericMapAsync(storedFields);
+        for (const [shortId, id] of miniSearch._documentIds) {
+            miniSearch._idToShortId.set(id, shortId);
+        }
+        let count = 0;
+        for (const [term, data] of index) {
+            const dataMap = new Map();
+            for (const fieldId of Object.keys(data)) {
+                let indexEntry = data[fieldId];
+                // Version 1 used to nest the index entry inside a field called ds
+                if (serializationVersion === 1) {
+                    indexEntry = indexEntry.ds;
+                }
+                dataMap.set(parseInt(fieldId, 10), await objectToNumericMapAsync(indexEntry));
+            }
+            if (++count % 1000 === 0)
+                await wait(0);
+            miniSearch._index.set(term, dataMap);
+        }
+        return miniSearch;
+    }
+    /**
+     * @ignore
+     */
+    static instantiateMiniSearch(js, options) {
+        const { documentCount, nextId, fieldIds, averageFieldLength, dirtCount, serializationVersion } = js;
+        if (serializationVersion !== 1 && serializationVersion !== 2) {
+            throw new Error('MiniSearch: cannot deserialize an index created with an incompatible version');
+        }
+        const miniSearch = new MiniSearch(options);
+        miniSearch._documentCount = documentCount;
+        miniSearch._nextId = nextId;
+        miniSearch._idToShortId = new Map();
+        miniSearch._fieldIds = fieldIds;
+        miniSearch._avgFieldLength = averageFieldLength;
+        miniSearch._dirtCount = dirtCount || 0;
+        miniSearch._index = new SearchableMap();
+        return miniSearch;
+    }
+    /**
+     * @ignore
+     */
+    executeQuery(query, searchOptions = {}) {
+        if (query === MiniSearch.wildcard) {
+            return this.executeWildcardQuery(searchOptions);
+        }
+        if (typeof query !== 'string') {
+            const options = { ...searchOptions, ...query, queries: undefined };
+            const results = query.queries.map((subquery) => this.executeQuery(subquery, options));
+            return this.combineResults(results, options.combineWith);
+        }
+        const { tokenize, processTerm, searchOptions: globalSearchOptions } = this._options;
+        const options = { tokenize, processTerm, ...globalSearchOptions, ...searchOptions };
+        const { tokenize: searchTokenize, processTerm: searchProcessTerm } = options;
+        const terms = searchTokenize(query)
+            .flatMap((term) => searchProcessTerm(term))
+            .filter((term) => !!term);
+        const queries = terms.map(termToQuerySpec(options));
+        const results = queries.map(query => this.executeQuerySpec(query, options));
+        return this.combineResults(results, options.combineWith);
+    }
+    /**
+     * @ignore
+     */
+    executeQuerySpec(query, searchOptions) {
+        const options = { ...this._options.searchOptions, ...searchOptions };
+        const boosts = (options.fields || this._options.fields).reduce((boosts, field) => ({ ...boosts, [field]: getOwnProperty(options.boost, field) || 1 }), {});
+        const { boostDocument, weights, maxFuzzy, bm25: bm25params } = options;
+        const { fuzzy: fuzzyWeight, prefix: prefixWeight } = { ...defaultSearchOptions.weights, ...weights };
+        const data = this._index.get(query.term);
+        const results = this.termResults(query.term, query.term, 1, query.termBoost, data, boosts, boostDocument, bm25params);
+        let prefixMatches;
+        let fuzzyMatches;
+        if (query.prefix) {
+            prefixMatches = this._index.atPrefix(query.term);
+        }
+        if (query.fuzzy) {
+            const fuzzy = (query.fuzzy === true) ? 0.2 : query.fuzzy;
+            const maxDistance = fuzzy < 1 ? Math.min(maxFuzzy, Math.round(query.term.length * fuzzy)) : fuzzy;
+            if (maxDistance)
+                fuzzyMatches = this._index.fuzzyGet(query.term, maxDistance);
+        }
+        if (prefixMatches) {
+            for (const [term, data] of prefixMatches) {
+                const distance = term.length - query.term.length;
+                if (!distance) {
+                    continue;
+                } // Skip exact match.
+                // Delete the term from fuzzy results (if present) if it is also a
+                // prefix result. This entry will always be scored as a prefix result.
+                fuzzyMatches === null || fuzzyMatches === void 0 ? void 0 : fuzzyMatches.delete(term);
+                // Weight gradually approaches 0 as distance goes to infinity, with the
+                // weight for the hypothetical distance 0 being equal to prefixWeight.
+                // The rate of change is much lower than that of fuzzy matches to
+                // account for the fact that prefix matches stay more relevant than
+                // fuzzy matches for longer distances.
+                const weight = prefixWeight * term.length / (term.length + 0.3 * distance);
+                this.termResults(query.term, term, weight, query.termBoost, data, boosts, boostDocument, bm25params, results);
+            }
+        }
+        if (fuzzyMatches) {
+            for (const term of fuzzyMatches.keys()) {
+                const [data, distance] = fuzzyMatches.get(term);
+                if (!distance) {
+                    continue;
+                } // Skip exact match.
+                // Weight gradually approaches 0 as distance goes to infinity, with the
+                // weight for the hypothetical distance 0 being equal to fuzzyWeight.
+                const weight = fuzzyWeight * term.length / (term.length + distance);
+                this.termResults(query.term, term, weight, query.termBoost, data, boosts, boostDocument, bm25params, results);
+            }
+        }
+        return results;
+    }
+    /**
+     * @ignore
+     */
+    executeWildcardQuery(searchOptions) {
+        const results = new Map();
+        const options = { ...this._options.searchOptions, ...searchOptions };
+        for (const [shortId, id] of this._documentIds) {
+            const score = options.boostDocument ? options.boostDocument(id, '', this._storedFields.get(shortId)) : 1;
+            results.set(shortId, {
+                score,
+                terms: [],
+                match: {}
+            });
+        }
+        return results;
+    }
+    /**
+     * @ignore
+     */
+    combineResults(results, combineWith = OR) {
+        if (results.length === 0) {
+            return new Map();
+        }
+        const operator = combineWith.toLowerCase();
+        const combinator = combinators[operator];
+        if (!combinator) {
+            throw new Error(`Invalid combination operator: ${combineWith}`);
+        }
+        return results.reduce(combinator) || new Map();
+    }
+    /**
+     * Allows serialization of the index to JSON, to possibly store it and later
+     * deserialize it with {@link MiniSearch.loadJSON}.
+     *
+     * Normally one does not directly call this method, but rather call the
+     * standard JavaScript `JSON.stringify()` passing the {@link MiniSearch}
+     * instance, and JavaScript will internally call this method. Upon
+     * deserialization, one must pass to {@link MiniSearch.loadJSON} the same
+     * options used to create the original instance that was serialized.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * // Serialize the index:
+     * let miniSearch = new MiniSearch({ fields: ['title', 'text'] })
+     * miniSearch.addAll(documents)
+     * const json = JSON.stringify(miniSearch)
+     *
+     * // Later, to deserialize it:
+     * miniSearch = MiniSearch.loadJSON(json, { fields: ['title', 'text'] })
+     * ```
+     *
+     * @return A plain-object serializable representation of the search index.
+     */
+    toJSON() {
+        const index = [];
+        for (const [term, fieldIndex] of this._index) {
+            const data = {};
+            for (const [fieldId, freqs] of fieldIndex) {
+                data[fieldId] = Object.fromEntries(freqs);
+            }
+            index.push([term, data]);
+        }
+        return {
+            documentCount: this._documentCount,
+            nextId: this._nextId,
+            documentIds: Object.fromEntries(this._documentIds),
+            fieldIds: this._fieldIds,
+            fieldLength: Object.fromEntries(this._fieldLength),
+            averageFieldLength: this._avgFieldLength,
+            storedFields: Object.fromEntries(this._storedFields),
+            dirtCount: this._dirtCount,
+            index,
+            serializationVersion: 2
+        };
+    }
+    /**
+     * @ignore
+     */
+    termResults(sourceTerm, derivedTerm, termWeight, termBoost, fieldTermData, fieldBoosts, boostDocumentFn, bm25params, results = new Map()) {
+        if (fieldTermData == null)
+            return results;
+        for (const field of Object.keys(fieldBoosts)) {
+            const fieldBoost = fieldBoosts[field];
+            const fieldId = this._fieldIds[field];
+            const fieldTermFreqs = fieldTermData.get(fieldId);
+            if (fieldTermFreqs == null)
+                continue;
+            let matchingFields = fieldTermFreqs.size;
+            const avgFieldLength = this._avgFieldLength[fieldId];
+            for (const docId of fieldTermFreqs.keys()) {
+                if (!this._documentIds.has(docId)) {
+                    this.removeTerm(fieldId, docId, derivedTerm);
+                    matchingFields -= 1;
+                    continue;
+                }
+                const docBoost = boostDocumentFn ? boostDocumentFn(this._documentIds.get(docId), derivedTerm, this._storedFields.get(docId)) : 1;
+                if (!docBoost)
+                    continue;
+                const termFreq = fieldTermFreqs.get(docId);
+                const fieldLength = this._fieldLength.get(docId)[fieldId];
+                // NOTE: The total number of fields is set to the number of documents
+                // `this._documentCount`. It could also make sense to use the number of
+                // documents where the current field is non-blank as a normalization
+                // factor. This will make a difference in scoring if the field is rarely
+                // present. This is currently not supported, and may require further
+                // analysis to see if it is a valid use case.
+                const rawScore = calcBM25Score(termFreq, matchingFields, this._documentCount, fieldLength, avgFieldLength, bm25params);
+                const weightedScore = termWeight * termBoost * fieldBoost * docBoost * rawScore;
+                const result = results.get(docId);
+                if (result) {
+                    result.score += weightedScore;
+                    assignUniqueTerm(result.terms, sourceTerm);
+                    const match = getOwnProperty(result.match, derivedTerm);
+                    if (match) {
+                        match.push(field);
+                    }
+                    else {
+                        result.match[derivedTerm] = [field];
+                    }
+                }
+                else {
+                    results.set(docId, {
+                        score: weightedScore,
+                        terms: [sourceTerm],
+                        match: { [derivedTerm]: [field] }
+                    });
+                }
+            }
+        }
+        return results;
+    }
+    /**
+     * @ignore
+     */
+    addTerm(fieldId, documentId, term) {
+        const indexData = this._index.fetch(term, createMap);
+        let fieldIndex = indexData.get(fieldId);
+        if (fieldIndex == null) {
+            fieldIndex = new Map();
+            fieldIndex.set(documentId, 1);
+            indexData.set(fieldId, fieldIndex);
+        }
+        else {
+            const docs = fieldIndex.get(documentId);
+            fieldIndex.set(documentId, (docs || 0) + 1);
+        }
+    }
+    /**
+     * @ignore
+     */
+    removeTerm(fieldId, documentId, term) {
+        if (!this._index.has(term)) {
+            this.warnDocumentChanged(documentId, fieldId, term);
+            return;
+        }
+        const indexData = this._index.fetch(term, createMap);
+        const fieldIndex = indexData.get(fieldId);
+        if (fieldIndex == null || fieldIndex.get(documentId) == null) {
+            this.warnDocumentChanged(documentId, fieldId, term);
+        }
+        else if (fieldIndex.get(documentId) <= 1) {
+            if (fieldIndex.size <= 1) {
+                indexData.delete(fieldId);
+            }
+            else {
+                fieldIndex.delete(documentId);
+            }
+        }
+        else {
+            fieldIndex.set(documentId, fieldIndex.get(documentId) - 1);
+        }
+        if (this._index.get(term).size === 0) {
+            this._index.delete(term);
+        }
+    }
+    /**
+     * @ignore
+     */
+    warnDocumentChanged(shortDocumentId, fieldId, term) {
+        for (const fieldName of Object.keys(this._fieldIds)) {
+            if (this._fieldIds[fieldName] === fieldId) {
+                this._options.logger('warn', `MiniSearch: document with ID ${this._documentIds.get(shortDocumentId)} has changed before removal: term "${term}" was not present in field "${fieldName}". Removing a document after it has changed can corrupt the index!`, 'version_conflict');
+                return;
+            }
+        }
+    }
+    /**
+     * @ignore
+     */
+    addDocumentId(documentId) {
+        const shortDocumentId = this._nextId;
+        this._idToShortId.set(documentId, shortDocumentId);
+        this._documentIds.set(shortDocumentId, documentId);
+        this._documentCount += 1;
+        this._nextId += 1;
+        return shortDocumentId;
+    }
+    /**
+     * @ignore
+     */
+    addFields(fields) {
+        for (let i = 0; i < fields.length; i++) {
+            this._fieldIds[fields[i]] = i;
+        }
+    }
+    /**
+     * @ignore
+     */
+    addFieldLength(documentId, fieldId, count, length) {
+        let fieldLengths = this._fieldLength.get(documentId);
+        if (fieldLengths == null)
+            this._fieldLength.set(documentId, fieldLengths = []);
+        fieldLengths[fieldId] = length;
+        const averageFieldLength = this._avgFieldLength[fieldId] || 0;
+        const totalFieldLength = (averageFieldLength * count) + length;
+        this._avgFieldLength[fieldId] = totalFieldLength / (count + 1);
+    }
+    /**
+     * @ignore
+     */
+    removeFieldLength(documentId, fieldId, count, length) {
+        if (count === 1) {
+            this._avgFieldLength[fieldId] = 0;
+            return;
+        }
+        const totalFieldLength = (this._avgFieldLength[fieldId] * count) - length;
+        this._avgFieldLength[fieldId] = totalFieldLength / (count - 1);
+    }
+    /**
+     * @ignore
+     */
+    saveStoredFields(documentId, doc) {
+        const { storeFields, extractField } = this._options;
+        if (storeFields == null || storeFields.length === 0) {
+            return;
+        }
+        let documentFields = this._storedFields.get(documentId);
+        if (documentFields == null)
+            this._storedFields.set(documentId, documentFields = {});
+        for (const fieldName of storeFields) {
+            const fieldValue = extractField(doc, fieldName);
+            if (fieldValue !== undefined)
+                documentFields[fieldName] = fieldValue;
+        }
+    }
+}
+/**
+ * The special wildcard symbol that can be passed to {@link MiniSearch#search}
+ * to match all documents
+ */
+MiniSearch.wildcard = Symbol('*');
+const getOwnProperty = (object, property) => Object.prototype.hasOwnProperty.call(object, property) ? object[property] : undefined;
+const combinators = {
+    [OR]: (a, b) => {
+        for (const docId of b.keys()) {
+            const existing = a.get(docId);
+            if (existing == null) {
+                a.set(docId, b.get(docId));
+            }
+            else {
+                const { score, terms, match } = b.get(docId);
+                existing.score = existing.score + score;
+                existing.match = Object.assign(existing.match, match);
+                assignUniqueTerms(existing.terms, terms);
+            }
+        }
+        return a;
+    },
+    [AND]: (a, b) => {
+        const combined = new Map();
+        for (const docId of b.keys()) {
+            const existing = a.get(docId);
+            if (existing == null)
+                continue;
+            const { score, terms, match } = b.get(docId);
+            assignUniqueTerms(existing.terms, terms);
+            combined.set(docId, {
+                score: existing.score + score,
+                terms: existing.terms,
+                match: Object.assign(existing.match, match)
+            });
+        }
+        return combined;
+    },
+    [AND_NOT]: (a, b) => {
+        for (const docId of b.keys())
+            a.delete(docId);
+        return a;
+    }
+};
+const defaultBM25params = { k: 1.2, b: 0.7, d: 0.5 };
+const calcBM25Score = (termFreq, matchingCount, totalCount, fieldLength, avgFieldLength, bm25params) => {
+    const { k, b, d } = bm25params;
+    const invDocFreq = Math.log(1 + (totalCount - matchingCount + 0.5) / (matchingCount + 0.5));
+    return invDocFreq * (d + termFreq * (k + 1) / (termFreq + k * (1 - b + b * fieldLength / avgFieldLength)));
+};
+const termToQuerySpec = (options) => (term, i, terms) => {
+    const fuzzy = (typeof options.fuzzy === 'function')
+        ? options.fuzzy(term, i, terms)
+        : (options.fuzzy || false);
+    const prefix = (typeof options.prefix === 'function')
+        ? options.prefix(term, i, terms)
+        : (options.prefix === true);
+    const termBoost = (typeof options.boostTerm === 'function')
+        ? options.boostTerm(term, i, terms)
+        : 1;
+    return { term, fuzzy, prefix, termBoost };
+};
+const defaultOptions = {
+    idField: 'id',
+    extractField: (document, fieldName) => document[fieldName],
+    stringifyField: (fieldValue, fieldName) => fieldValue.toString(),
+    tokenize: (text) => text.split(SPACE_OR_PUNCTUATION),
+    processTerm: (term) => term.toLowerCase(),
+    fields: undefined,
+    searchOptions: undefined,
+    storeFields: [],
+    logger: (level, message) => {
+        if (typeof (console === null || console === void 0 ? void 0 : console[level]) === 'function')
+            console[level](message);
+    },
+    autoVacuum: true
+};
+const defaultSearchOptions = {
+    combineWith: OR,
+    prefix: false,
+    fuzzy: false,
+    maxFuzzy: 6,
+    boost: {},
+    weights: { fuzzy: 0.45, prefix: 0.375 },
+    bm25: defaultBM25params
+};
+const defaultAutoSuggestOptions = {
+    combineWith: AND,
+    prefix: (term, i, terms) => i === terms.length - 1
+};
+const defaultVacuumOptions = { batchSize: 1000, batchWait: 10 };
+const defaultVacuumConditions = { minDirtFactor: 0.1, minDirtCount: 20 };
+const defaultAutoVacuumOptions = { ...defaultVacuumOptions, ...defaultVacuumConditions };
+const assignUniqueTerm = (target, term) => {
+    // Avoid adding duplicate terms.
+    if (!target.includes(term))
+        target.push(term);
+};
+const assignUniqueTerms = (target, source) => {
+    for (const term of source) {
+        // Avoid adding duplicate terms.
+        if (!target.includes(term))
+            target.push(term);
+    }
+};
+const byScore = ({ score: a }, { score: b }) => b - a;
+const createMap = () => new Map();
+const objectToNumericMap = (object) => {
+    const map = new Map();
+    for (const key of Object.keys(object)) {
+        map.set(parseInt(key, 10), object[key]);
+    }
+    return map;
+};
+const objectToNumericMapAsync = async (object) => {
+    const map = new Map();
+    let count = 0;
+    for (const key of Object.keys(object)) {
+        map.set(parseInt(key, 10), object[key]);
+        if (++count % 1000 === 0) {
+            await wait(0);
+        }
+    }
+    return map;
+};
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+// This regular expression matches any Unicode space, newline, or punctuation
+// character
+const SPACE_OR_PUNCTUATION = /[\n\r\p{Z}\p{P}]+/u;
+
+export { MiniSearch as default };
+//# sourceMappingURL=index.js.map

--- a/public/mc/media.html
+++ b/public/mc/media.html
@@ -10,7 +10,7 @@
   <style>
     .md-shell { padding: 0 56px 64px; position: relative; z-index: 3; }
     .md-filterbar { display: flex; align-items: center; gap: 10px; padding: 18px 0; flex-wrap: wrap; }
-    .md-pill { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; color: var(--text-3); background: var(--surface); border: 1px solid var(--border); padding: 8px 14px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; text-transform: uppercase; }
+    .md-pill { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; color: var(--text-3); background: var(--surface); border: 1px solid var(--border); padding: 8px 14px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; text-transform: uppercase; user-select: none; }
     .md-pill .ic { width: 9px; height: 9px; background: var(--text-3); display: inline-block; }
     .md-pill.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.10); box-shadow: 0 0 14px rgba(242,166,35,0.18); }
     .md-pill .n { color: var(--text-4); margin-left: 4px; font-size: 9px; }
@@ -18,11 +18,24 @@
     .md-pill.photo .ic { background: #6EE7B7; }
     .md-pill.diagram .ic { background: #B280FF; }
     .md-pill.map .ic { background: #F472B6; }
+
+    /* Secondary row — event dropdown + sort + placeholder toggle + search */
+    .md-row2 { display: flex; align-items: center; gap: 12px; padding: 4px 0 18px; flex-wrap: wrap; }
+    .md-input { background: var(--surface-3); border: 1px solid var(--border-strong); padding: 8px 14px; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.04em; min-width: 220px; }
+    .md-input::placeholder { color: var(--text-4); }
+    .md-select { background: var(--surface); border: 1px solid var(--border); color: var(--text-2); font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.10em; padding: 8px 12px; cursor: pointer; }
+    .md-toggle { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; color: var(--text-3); padding: 6px 10px; border: 1px solid var(--border); background: var(--surface); cursor: pointer; user-select: none; display: inline-flex; align-items: center; gap: 6px; }
+    .md-toggle .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-4); }
+    .md-toggle.on { color: var(--cyan); border-color: rgba(97,215,240,0.55); background: rgba(97,215,240,0.08); }
+    .md-toggle.on .dot { background: var(--cyan); box-shadow: 0 0 6px rgba(97,215,240,0.6); }
+    .md-stat { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.16em; margin-left: auto; }
+    .md-stat .v { color: var(--amber); font-weight: 600; }
+
     .md-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 14px; }
     .tile { background: var(--surface); border: 1px solid var(--border); aspect-ratio: 1; padding: 0; backdrop-filter: blur(10px); cursor: pointer; transition: all .2s; position: relative; overflow: hidden; display: flex; flex-direction: column; }
     .tile:hover { border-color: var(--border-strong); transform: translateY(-2px); }
     .tile .thumb { flex: 1; background: linear-gradient(135deg, rgba(242,166,35,0.08), rgba(8,12,20,0.7)); position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; }
-    .tile .thumb::after { content: ''; position: absolute; inset: 0; background-image: linear-gradient(rgba(242,166,35,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(242,166,35,0.06) 1px, transparent 1px); background-size: 18px 18px; opacity: 0.4; }
+    .tile .thumb::after { content: ''; position: absolute; inset: 0; background-image: linear-gradient(rgba(242,166,35,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(242,166,35,0.06) 1px, transparent 1px); background-size: 18px 18px; opacity: 0.4; pointer-events: none; }
     .tile.video .thumb { background: radial-gradient(circle at center, rgba(97,215,240,0.18), rgba(8,14,22,0.7)); }
     .tile.photo .thumb { background: radial-gradient(circle at center, rgba(110,231,183,0.16), rgba(8,14,22,0.7)); }
     .tile.diagram .thumb { background: linear-gradient(135deg, rgba(178,128,255,0.14), rgba(8,14,22,0.7)); }
@@ -32,13 +45,35 @@
     .tile.photo .icon { color: #6EE7B7; border-color: rgba(110,231,183,0.5); }
     .tile.diagram .icon { color: #B280FF; border-color: rgba(178,128,255,0.5); }
     .tile.map .icon { color: #F472B6; border-color: rgba(244,114,182,0.5); }
-    .tile .ribbon { position: absolute; left: 6px; top: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.14em; color: var(--text-3); background: rgba(0,0,0,0.6); padding: 2px 6px; border: 1px solid var(--hairline); text-transform: uppercase; }
-    .tile .views { position: absolute; right: 6px; top: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.1em; color: var(--text-3); background: rgba(0,0,0,0.6); padding: 2px 6px; border: 1px solid var(--hairline); }
+    .tile .ribbon { position: absolute; left: 6px; top: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.14em; color: var(--text-3); background: rgba(0,0,0,0.6); padding: 2px 6px; border: 1px solid var(--hairline); text-transform: uppercase; z-index: 2; }
+    .tile .views { position: absolute; right: 6px; top: 6px; font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.1em; color: var(--text-3); background: rgba(0,0,0,0.6); padding: 2px 6px; border: 1px solid var(--hairline); z-index: 2; }
     .tile .views::before { content: '◉ '; color: var(--amber); }
     .tile .footer { padding: 10px 12px; border-top: 1px solid var(--hairline); background: rgba(0,0,0,0.4); }
     .tile .kind { font-family: 'JetBrains Mono', monospace; font-size: 8px; letter-spacing: 0.18em; color: var(--text-3); text-transform: uppercase; margin-bottom: 3px; }
     .tile .title { font-size: 11px; color: var(--text); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
     .tile .ev { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); margin-top: 4px; letter-spacing: 0.06em; }
+
+    /* Focus modal */
+    .md-modal { position: fixed; inset: 0; background: rgba(0,0,0,0.85); z-index: 1000; display: none; align-items: center; justify-content: center; padding: 56px; backdrop-filter: blur(8px); }
+    .md-modal.on { display: flex; }
+    .md-modal .panel { background: var(--surface); border: 1px solid var(--border-strong); max-width: 1100px; width: 100%; max-height: 90vh; overflow-y: auto; display: grid; grid-template-columns: minmax(0, 1.4fr) 360px; gap: 0; backdrop-filter: blur(14px); }
+    .md-modal .visual { background: #000; min-height: 480px; display: flex; align-items: center; justify-content: center; position: relative; }
+    .md-modal .visual img { max-width: 100%; max-height: 80vh; object-fit: contain; }
+    .md-modal .visual iframe { width: 100%; height: 60vh; border: 0; }
+    .md-modal .visual .icon-big { width: 96px; height: 96px; border: 1px solid var(--border-strong); display: flex; align-items: center; justify-content: center; font-family: 'JetBrains Mono', monospace; font-size: 36px; color: var(--text); }
+    .md-modal .meta { padding: 28px 30px; display: flex; flex-direction: column; gap: 14px; }
+    .md-modal .meta .eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.22em; color: var(--text-3); text-transform: uppercase; }
+    .md-modal .meta h2 { font-family: 'Space Grotesk', sans-serif; font-size: 22px; color: var(--text); font-weight: 600; margin: 0; line-height: 1.25; letter-spacing: -0.01em; }
+    .md-modal .meta p { font-family: 'Inter', sans-serif; font-size: 13px; color: var(--text-2); line-height: 1.6; margin: 0; max-height: 32vh; overflow-y: auto; }
+    .md-modal .meta .kv { display: grid; grid-template-columns: 90px 1fr; gap: 6px 12px; font-family: 'JetBrains Mono', monospace; font-size: 10px; padding-top: 14px; border-top: 1px solid var(--hairline); }
+    .md-modal .meta .kv .k { color: var(--text-4); letter-spacing: 0.18em; text-transform: uppercase; }
+    .md-modal .meta .kv .v { color: var(--text-2); }
+    .md-modal .meta .ctas { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 6px; }
+    .md-modal .meta .cta { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.16em; padding: 8px 14px; border: 1px solid var(--border-strong); color: var(--text); background: var(--surface-2); text-decoration: none; }
+    .md-modal .meta .cta.primary { color: var(--amber); border-color: var(--amber); background: rgba(242,166,35,0.10); }
+    .md-modal .meta .cta:hover { color: var(--amber); border-color: var(--amber); }
+    .md-modal .close { position: absolute; top: 16px; right: 16px; font-family: 'JetBrains Mono', monospace; font-size: 14px; color: var(--text-2); cursor: pointer; padding: 6px 10px; background: rgba(0,0,0,0.4); border: 1px solid var(--border); z-index: 2; }
+    .md-modal .close:hover { color: var(--amber); border-color: var(--amber); }
   </style>
 </head>
 <body data-view="media">
@@ -46,138 +81,290 @@
 <main>
   <section class="page-title">
     <div class="eyebrow"><span class="div"></span>SURFACE · 06 — visual library</div>
-    <h1>362 tiles. <em>Every diagram, every video, every page worth seeing.</em></h1>
-    <p class="sub">Photos · DVIDS sensor footage · diagrams · maps · sketches · scanned negatives. Tap any tile to open it; video tiles play inline via the DVIDS embed iframe.</p>
+    <h1><span data-mc="mediaTotal">362</span> tiles. <em>Every diagram, every video, every page worth seeing.</em></h1>
+    <p class="sub">Photos · DVIDS sensor footage · diagrams · maps · sketches · scanned negatives. Click any tile for the full description and a deep-link to the source page in DOSSIER. Video tiles play inline via the DVIDS embed iframe.</p>
   </section>
 
   <section class="md-shell">
-    <div class="md-filterbar">
-      <span class="md-pill active"><span class="ic"></span>ALL <span class="n" data-mc="mediaTotal">324</span></span>
-      <span class="md-pill video"><span class="ic"></span>VIDEO <span class="n" data-mc="media.byKind.video">106</span></span>
-      <span class="md-pill photo"><span class="ic"></span>PHOTO <span class="n" data-mc="media.byKind.photograph">113</span></span>
-      <span class="md-pill"><span class="ic" style="background:#FFD93D"></span>HAND-DRAWING <span class="n" data-mc="media.byKind.hand-drawing">42</span></span>
-      <span class="md-pill diagram"><span class="ic"></span>DIAGRAM <span class="n" data-mc="media.byKind.diagram">16</span></span>
-      <span class="md-pill map"><span class="ic"></span>MAP <span class="n" data-mc="media.byKind.map">8</span></span>
-      <span class="md-pill"><span class="ic" style="background:#94A3B8"></span>NEGATIVE <span class="n" data-mc="media.byKind.photocopied-negative">6</span></span>
-      <span style="margin-left:auto;font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.18em">SORT · DVIDS VIEWS DESC · <span data-mc="mediaEvents">133</span> EVENTS · media.json</span>
+    <div class="md-filterbar" id="md-pills">
+      <span class="md-pill active" data-kind="ALL"><span class="ic"></span>ALL <span class="n" id="n-all">324</span></span>
+      <span class="md-pill video" data-kind="video"><span class="ic"></span>VIDEO <span class="n" id="n-video">106</span></span>
+      <span class="md-pill photo" data-kind="photograph"><span class="ic"></span>PHOTO <span class="n" id="n-photograph">113</span></span>
+      <span class="md-pill" data-kind="hand-drawing"><span class="ic" style="background:#FFD93D"></span>HAND-DRAWING <span class="n" id="n-hand-drawing">42</span></span>
+      <span class="md-pill diagram" data-kind="diagram"><span class="ic"></span>DIAGRAM <span class="n" id="n-diagram">16</span></span>
+      <span class="md-pill map" data-kind="map"><span class="ic"></span>MAP <span class="n" id="n-map">8</span></span>
+      <span class="md-pill" data-kind="photocopied-negative"><span class="ic" style="background:#94A3B8"></span>NEGATIVE <span class="n" id="n-photocopied-negative">6</span></span>
+      <span class="md-pill" data-kind="newspaper-clipping"><span class="ic" style="background:#6EE7B7"></span>CLIPPING <span class="n" id="n-newspaper-clipping">0</span></span>
+      <span class="md-pill" data-kind="table"><span class="ic" style="background:#7FB6FF"></span>TABLE <span class="n" id="n-table">0</span></span>
+    </div>
+    <div class="md-row2">
+      <input class="md-input" id="md-q" placeholder="search · title / description / event…" autocomplete="off"/>
+      <select class="md-select" id="md-event"><option value="all">ALL EVENTS</option></select>
+      <span class="md-toggle" id="sort-recent"><span class="dot"></span>SORT · RECENT</span>
+      <span class="md-toggle" id="sort-popular"><span class="dot"></span>SORT · POPULAR</span>
+      <span class="md-toggle" id="t-placeholders"><span class="dot"></span>INCLUDE PLACEHOLDERS</span>
+      <span class="md-stat"><span class="v" id="md-shown">0</span> SHOWN · <span class="v" id="md-total">0</span> AFTER FILTER</span>
     </div>
 
     <div class="md-grid" id="grid"></div>
   </section>
+
+  <div class="md-modal" id="modal" role="dialog" aria-hidden="true">
+    <div class="panel">
+      <div class="visual" id="md-visual">
+        <span class="close" id="md-close">✕ CLOSE</span>
+      </div>
+      <div class="meta">
+        <div class="eyebrow" id="md-eyebrow">PHOTOGRAPH · PAGE 01</div>
+        <h2 id="md-title">—</h2>
+        <p id="md-desc">—</p>
+        <div class="kv" id="md-kv"></div>
+        <div class="ctas">
+          <a class="cta primary" id="md-dossier-link" href="dossier.html">→ OPEN DOSSIER</a>
+          <a class="cta" id="md-source-link" href="#" target="_blank" rel="noopener" style="display:none">↗ SOURCE</a>
+        </div>
+      </div>
+    </div>
+  </div>
 </main>
 
 <script src="data.js"></script>
-
 <script src="chrome.js" defer></script>
 <script>
-  const data = [
-    {k:'video', t:'F/A-18 IR sensor pass · Pacific 2019', e:'pacific-2019', v:'1.2M'},
-    {k:'video', t:'Drone footage · CONUS sighting Mar 2020', e:'south-us-2020', v:'847K'},
-    {k:'photo', t:'Roswell incident debris field, 1947', e:'fbi-62hq-83894', v:'612K'},
-    {k:'diagram', t:'Atlas IIAS ship-hit contour A=3.00', e:'dow-uap-d48 · p63', v:''},
-    {k:'video', t:'Tic-tac sensor recording, 2004', e:'tic-tac-2004', v:'2.4M'},
-    {k:'photo', t:'Witness sketch — orange orb formation', e:'fbi-sept-2023-s3', v:''},
-    {k:'map', t:'Eastern Range impact contours', e:'dow-uap-d48 · p21', v:''},
-    {k:'photo', t:'USPER recreation drawing — "Dark Kite"', e:'western-us-2023', v:''},
-    {k:'video', t:'Range Fouler debrief footage, 2020', e:'dow-uap-pr36', v:'412K'},
-    {k:'diagram', t:'Mode-5 density-function curves', e:'dow-uap-d48 · p51', v:''},
-    {k:'photo', t:'Vandenberg Launch Summary cover', e:'dow-uap-d49 · p1', v:''},
-    {k:'video', t:'CENTCOM ISR mission audio + IR', e:'uae-june-2024', v:'298K'},
-    {k:'map', t:'Coverage map of impact dispersion', e:'dow-uap-d48 · p48', v:''},
-    {k:'photo', t:'1949 radar scope diagram', e:'1949-discs · p50', v:''},
-    {k:'video', t:'Apollo 17 onboard audio + photo', e:'nasa-apollo17', v:'89K'},
-    {k:'diagram', t:'LLV1 simulation results B=1,000', e:'dow-uap-d48 · p79', v:''},
-    {k:'photo', t:'Witness photograph — alleged craft', e:'fbi-photos-2025', v:''},
-    {k:'video', t:'DVIDS clip · Gen Patel briefing', e:'dow-uap-2026-05-08', v:'1.8M'},
-    {k:'map', t:'Atlas IIAS risk contours, A=3.5', e:'dow-uap-d48 · p21', v:''},
-    {k:'photo', t:'30th Space Wing patch — Vandenberg', e:'dow-uap-d49 · p1', v:''},
-  ];
-  const ICONS = { video: '▶', photo: '◫', photograph: '◫', diagram: '◬', map: '◐', sketch: '✎', 'hand-drawing': '✎', 'newspaper-clipping': '▤', 'photocopied-negative': '▦' };
-  const KIND_NAMES = { video: 'VIDEO', photo: 'PHOTOGRAPH', diagram: 'DIAGRAM', map: 'MAP' };
-  const grid = document.getElementById('grid');
-  const MAX_TILES = 30;
+(function(){
+  if (!window.MC || !MC.ready) return;
 
-  // map a real media kind → the CSS modifier class the tile styling expects.
-  function kindClass(kind) {
-    if (kind === 'video') return 'video';
-    if (kind === 'photograph') return 'photo';
-    if (kind === 'diagram') return 'diagram';
-    if (kind === 'map') return 'map';
-    return ''; // hand-drawing, newspaper-clipping, photocopied-negative → generic
+  var ICONS = { video: '▶', photograph: '◫', diagram: '◬', map: '◐', 'hand-drawing': '✎', 'newspaper-clipping': '▤', 'photocopied-negative': '▦', table: '▦' };
+  var KIND_CLS = { video:'video', photograph:'photo', diagram:'diagram', map:'map' };
+
+  function esc(s){ return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
+  function fmtViews(n){
+    if (typeof n !== 'number' || !isFinite(n)) return n != null ? String(n) : '';
+    var a = Math.abs(n);
+    if (a >= 1e6) return (n/1e6).toFixed(1).replace(/\.0$/,'') + 'M';
+    if (a >= 1e3) return (n/1e3).toFixed(1).replace(/\.0$/,'') + 'K';
+    return String(n);
   }
-  const esc = (s) => String(s == null ? '' : s)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 
-  // ── Static fallback render (kept so something shows before MC loads / if it fails) ──
-  function renderFallback() {
-    grid.innerHTML = '';
-    data.forEach((d, i) => {
-      const t = document.createElement('div');
-      t.className = 'tile ' + d.k;
-      t.innerHTML = `
-        <div class="thumb">
-          <span class="ribbon">${KIND_NAMES[d.k] || d.k.toUpperCase()}</span>
-          ${d.v ? `<span class="views">${d.v}</span>` : ''}
-          <span class="icon">${ICONS[d.k] || '?'}</span>
-        </div>
-        <div class="footer">
-          <div class="kind">${KIND_NAMES[d.k] || d.k}</div>
-          <div class="title">${d.t}</div>
-          <div class="ev">${d.e}</div>
-        </div>`;
-      t.style.opacity = '0';
-      t.style.animation = `rise 0.5s ${300 + i * 35}ms cubic-bezier(.2,.7,.2,1) forwards`;
-      grid.appendChild(t);
+  // ─── State ───
+  var activeKinds  = new Set(['ALL']);          // ALL means no kind filter
+  var activeEvent  = 'all';
+  var query        = '';
+  var sortMode     = 'RECENT';                  // RECENT | POPULAR
+  var inclPlace    = false;
+  var allItems     = [];
+
+  // DOM
+  var pills    = document.getElementById('md-pills');
+  var grid     = document.getElementById('grid');
+  var inp      = document.getElementById('md-q');
+  var selEvent = document.getElementById('md-event');
+  var btnRecent= document.getElementById('sort-recent');
+  var btnPop   = document.getElementById('sort-popular');
+  var btnPlace = document.getElementById('t-placeholders');
+  var statShown= document.getElementById('md-shown');
+  var statTotal= document.getElementById('md-total');
+
+  // Modal
+  var modal      = document.getElementById('modal');
+  var mdVisual   = document.getElementById('md-visual');
+  var mdEyebrow  = document.getElementById('md-eyebrow');
+  var mdTitle    = document.getElementById('md-title');
+  var mdDesc     = document.getElementById('md-desc');
+  var mdKv       = document.getElementById('md-kv');
+  var mdDossier  = document.getElementById('md-dossier-link');
+  var mdSource   = document.getElementById('md-source-link');
+  var mdClose    = document.getElementById('md-close');
+
+  function setSortBtns(){
+    btnRecent.classList.toggle('on', sortMode === 'RECENT');
+    btnPop.classList.toggle('on', sortMode === 'POPULAR');
+  }
+  function setPlaceBtn(){ btnPlace.classList.toggle('on', inclPlace); }
+  function setActivePill(){
+    pills.querySelectorAll('.md-pill').forEach(function(p){
+      var k = p.dataset.kind;
+      p.classList.toggle('active', activeKinds.has(k));
     });
   }
-  renderFallback();
 
-  // ── Live render from the shared data layer ──
-  function renderLive(MC) {
-    const items = (MC.derive && MC.derive.mediaItems) || [];
-    if (!items.length) return; // keep the static fallback on-screen
-    const slice = items.slice(0, MAX_TILES);
-    grid.innerHTML = '';
-    slice.forEach((m, i) => {
-      const cls = kindClass(m.kind);
-      const label = (m.kind || '').toUpperCase();
-      const hasViews = m.views != null && m.views !== '';
-      const t = document.createElement('div');
-      t.className = 'tile' + (cls ? ' ' + cls : '');
+  function updateCounts(items){
+    var c = { ALL: 0, video: 0, photograph: 0, 'hand-drawing': 0, diagram: 0, map: 0, 'photocopied-negative': 0, 'newspaper-clipping': 0, table: 0 };
+    items.forEach(function(it){
+      c.ALL++;
+      if (c[it.kind] != null) c[it.kind]++;
+    });
+    for (var k in c){ var el = document.getElementById('n-' + k); if (el) el.textContent = c[k]; }
+  }
 
-      let thumbInner;
-      if (m.imagePath) {
-        // imagePath is relative to the site root; /mc/ pages need a "../" prefix.
-        thumbInner = `<img src="../${esc(m.imagePath)}" alt="${esc(m.title)}" loading="lazy"
-          style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:1">`;
-      } else {
-        thumbInner = `<span class="icon">${ICONS[m.kind] || '?'}</span>`;
+  function populateEventFilter(items){
+    var seen = {}, evs = [];
+    items.forEach(function(it){
+      if (it.eventId && !seen[it.eventId]){ seen[it.eventId] = true; evs.push({ id: it.eventId, title: it.eventTitle || it.eventId }); }
+    });
+    evs.sort(function(a,b){ return a.title.localeCompare(b.title); });
+    selEvent.innerHTML = '<option value="all">ALL EVENTS · ' + evs.length + '</option>' +
+      evs.map(function(e){ return '<option value="' + esc(e.id) + '">' + esc(e.title) + '</option>'; }).join('');
+  }
+
+  function filterAndSort(){
+    var q = query.trim().toLowerCase();
+    var out = allItems.filter(function(it){
+      // Placeholder gating (only when no image and not video).
+      if (it.kind !== 'video' && !it.imagePath && !inclPlace) return false;
+      // Kind filter.
+      if (!activeKinds.has('ALL') && !activeKinds.has(it.kind)) return false;
+      // Event filter.
+      if (activeEvent !== 'all' && it.eventId !== activeEvent) return false;
+      // Query — title + description + event title.
+      if (q){
+        var hay = ((it.title || '') + ' ' + (it.description || '') + ' ' + (it.eventTitle || '')).toLowerCase();
+        if (hay.indexOf(q) === -1) return false;
       }
-      const viewsBadge = hasViews ? `<span class="views">${esc(m.views)}</span>` : '';
-      const evLine = esc(m.eventTitle || m.eventId || '');
+      return true;
+    });
+    if (sortMode === 'POPULAR'){
+      out.sort(function(a, b){
+        var av = typeof a.views === 'number' ? a.views : -Infinity;
+        var bv = typeof b.views === 'number' ? b.views : -Infinity;
+        return bv - av;
+      });
+    }
+    return out;
+  }
 
-      t.innerHTML = `
-        <div class="thumb">
-          <span class="ribbon">${esc(label)}</span>
-          ${viewsBadge}
-          ${thumbInner}
-        </div>
-        <div class="footer">
-          <div class="kind">${esc(label)}</div>
-          <div class="title">${esc(m.title)}</div>
-          <div class="ev">${evLine}</div>
-        </div>`;
-      t.style.opacity = '0';
-      t.style.animation = `rise 0.5s ${300 + i * 35}ms cubic-bezier(.2,.7,.2,1) forwards`;
-      grid.appendChild(t);
+  function renderGrid(){
+    var rows = filterAndSort();
+    statTotal.textContent = rows.length;
+    var shown = rows.slice(0, 200); // cap for perf; the React app shows all
+    statShown.textContent = shown.length;
+    var html = shown.map(function(m, i){
+      var cls = KIND_CLS[m.kind] || '';
+      var label = (m.kind || '').toUpperCase();
+      var hasViews = typeof m.views === 'number';
+      var thumb = m.imagePath
+        ? '<img src="../' + esc(m.imagePath) + '" alt="' + esc(m.title) + '" loading="lazy" style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:1">'
+        : '<span class="icon">' + (ICONS[m.kind] || '?') + '</span>';
+      return '<div class="tile' + (cls ? ' ' + cls : '') + '" data-idx="' + i + '">' +
+        '<div class="thumb">' +
+          '<span class="ribbon">' + esc(label) + '</span>' +
+          (hasViews ? '<span class="views">' + fmtViews(m.views) + '</span>' : '') +
+          thumb +
+        '</div>' +
+        '<div class="footer">' +
+          '<div class="kind">' + esc(label) + '</div>' +
+          '<div class="title">' + esc(m.title || '—') + '</div>' +
+          '<div class="ev">' + esc(m.eventTitle || m.eventId || '') + '</div>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+    grid.innerHTML = html;
+    // Wire click → open modal
+    grid.querySelectorAll('.tile').forEach(function(t){
+      t.addEventListener('click', function(){
+        var idx = parseInt(t.dataset.idx, 10);
+        openModal(shown[idx]);
+      });
     });
   }
 
-  if (window.MC) {
-    MC.ready().then(renderLive);
-    MC.onUpdate(renderLive);
+  function openModal(m){
+    if (!m) return;
+    mdTitle.textContent = m.title || m.eventTitle || '—';
+    mdDesc.textContent  = m.description || 'No description recorded.';
+    mdEyebrow.textContent = (m.kind || 'MEDIA').toUpperCase() + (m.page ? ' · PAGE ' + String(m.page).padStart(3, '0') : '');
+    var visual = '';
+    // DVIDS iframe embed for videos that have one. The dvidsUrl field on
+    // media.json items is the public DVIDS player URL; embedding that URL
+    // directly works as a standalone iframe.
+    var dvids = m.dvidsUrl || m.iframeUrl || m.embedUrl || null;
+    if (m.kind === 'video' && dvids){
+      visual = '<iframe src="' + esc(dvids) + '" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>';
+    } else if (m.imagePath){
+      visual = '<img src="../' + esc(m.imagePath) + '" alt="' + esc(m.title) + '">';
+    } else if (m.thumbnailPath && /^https?:/.test(m.thumbnailPath)){
+      visual = '<img src="' + esc(m.thumbnailPath) + '" alt="' + esc(m.title) + '">';
+    } else {
+      visual = '<span class="icon-big">' + (ICONS[m.kind] || '?') + '</span>';
+    }
+    // Close button is appended via DOM so the inner HTML can be reset safely.
+    mdVisual.innerHTML = visual + '<span class="close" id="md-close-i">✕ CLOSE</span>';
+    document.getElementById('md-close-i').addEventListener('click', closeModal);
+    var rec = m.eventId ? MC.byEid(m.eventId) : null;
+    var kv = [];
+    if (m.eventId)            kv.push(['EVENT', m.eventId]);
+    if (rec && rec.agency)    kv.push(['AGENCY', rec.agency]);
+    if (rec && rec.date)      kv.push(['DATE', rec.date]);
+    if (m.kind)               kv.push(['KIND', m.kind]);
+    if (m.page != null)       kv.push(['PAGE', String(m.page)]);
+    if (m.incidentDate)       kv.push(['INCIDENT', m.incidentDate]);
+    if (m.incidentLocation)   kv.push(['LOCATION', m.incidentLocation]);
+    if (typeof m.views === 'number') kv.push(['VIEWS', fmtViews(m.views)]);
+    if (m.classifier)         kv.push(['CLASSIFIER', m.classifier]);
+    mdKv.innerHTML = kv.map(function(p){ return '<span class="k">' + esc(p[0]) + '</span><span class="v">' + esc(p[1]) + '</span>'; }).join('');
+    mdDossier.href = m.eventId ? MC.url.dossier(m.eventId) : 'dossier.html';
+    var sourceUrl = m.dvidsUrl || m.url || null;
+    if (sourceUrl){
+      mdSource.style.display = '';
+      mdSource.href = /^https?:/i.test(sourceUrl) ? sourceUrl : ('../' + sourceUrl);
+    } else {
+      mdSource.style.display = 'none';
+    }
+    modal.classList.add('on');
+    modal.setAttribute('aria-hidden', 'false');
   }
+
+  function closeModal(){
+    modal.classList.remove('on');
+    modal.setAttribute('aria-hidden', 'true');
+    // Stop any iframe playback by clearing it.
+    mdVisual.innerHTML = '<span class="close" id="md-close">✕ CLOSE</span>';
+    document.getElementById('md-close').addEventListener('click', closeModal);
+  }
+  mdClose.addEventListener('click', closeModal);
+  modal.addEventListener('click', function(e){ if (e.target === modal) closeModal(); });
+  document.addEventListener('keydown', function(e){ if (e.key === 'Escape') closeModal(); });
+
+  // ─── Wire pills ───
+  pills.querySelectorAll('.md-pill').forEach(function(p){
+    p.addEventListener('click', function(){
+      var k = p.dataset.kind;
+      if (k === 'ALL'){
+        activeKinds = new Set(['ALL']);
+      } else {
+        activeKinds.delete('ALL');
+        if (activeKinds.has(k)) activeKinds.delete(k); else activeKinds.add(k);
+        if (!activeKinds.size) activeKinds = new Set(['ALL']);
+      }
+      setActivePill();
+      renderGrid();
+    });
+  });
+  inp.addEventListener('input', function(){ query = inp.value; renderGrid(); });
+  selEvent.addEventListener('change', function(){ activeEvent = selEvent.value; renderGrid(); });
+  btnRecent.addEventListener('click', function(){ sortMode = 'RECENT'; setSortBtns(); renderGrid(); });
+  btnPop.addEventListener('click', function(){ sortMode = 'POPULAR'; setSortBtns(); renderGrid(); });
+  btnPlace.addEventListener('click', function(){ inclPlace = !inclPlace; setPlaceBtn(); renderGrid(); });
+
+  setSortBtns();
+  setPlaceBtn();
+  setActivePill();
+
+  // ─── Hydrate from MC ───
+  function hydrate(){
+    allItems = (MC.derive && MC.derive.mediaItems) || [];
+    if (!allItems.length){
+      // Keep the page usable even with zero data.
+      grid.innerHTML = '<div style="font-family:\'JetBrains Mono\',monospace;font-size:12px;color:var(--text-4);grid-column:1/-1;padding:40px 0;text-align:center">media.json loading…</div>';
+      return;
+    }
+    updateCounts(allItems);
+    populateEventFilter(allItems);
+    renderGrid();
+  }
+  MC.ready().then(hydrate);
+  MC.onUpdate(hydrate);
+})();
 </script>
 </body>
 </html>

--- a/public/mc/network.html
+++ b/public/mc/network.html
@@ -8,33 +8,48 @@
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="styles.css" rel="stylesheet">
   <style>
-    .nw-shell { padding: 0 56px 64px; display: grid; grid-template-columns: 280px minmax(0,1fr); gap: 24px; position: relative; z-index: 3; align-items: start; }
-    .nw-card { background: var(--surface); border: 1px solid var(--border); padding: 28px; backdrop-filter: blur(10px); position: relative; overflow: hidden; }
-    .nw-h { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 18px; margin-bottom: 18px; border-bottom: 1px solid var(--hairline); }
+    .nw-shell { padding: 0 56px 64px; display: grid; grid-template-columns: 300px minmax(0,1fr); gap: 24px; position: relative; z-index: 3; align-items: start; }
+    .nw-card { background: var(--surface); border: 1px solid var(--border); padding: 26px 28px; backdrop-filter: blur(10px); position: relative; overflow: hidden; }
+    .nw-h { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 16px; margin-bottom: 18px; border-bottom: 1px solid var(--hairline); }
     .nw-h .t { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.30em; color: var(--text-2); text-transform: uppercase; }
     .nw-h .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.16em; }
-    .nw-svg { width: 100%; height: 720px; display: block; }
-    .nw-edge { stroke: rgba(242,166,35,0.18); stroke-width: 0.6; }
-    .nw-edge.strong { stroke: rgba(242,166,35,0.55); stroke-width: 1.4; }
-    .nw-edge.weak { stroke: rgba(110,138,124,0.10); stroke-width: 0.3; }
-    .nw-node text { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.06em; }
-    .nw-node circle { transition: all .15s; cursor: pointer; }
-    .nw-node:hover circle { stroke-width: 2; }
 
-    .nw-ctl { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; color: var(--text-3); }
-    .nw-ctl .row { display: flex; align-items: center; gap: 10px; padding: 9px 0; border-bottom: 1px solid var(--hairline); text-transform: uppercase; }
+    .nw-svg { width: 100%; height: 720px; display: block; background: radial-gradient(ellipse at center, rgba(20,28,38,0.30), rgba(8,14,22,0.65) 75%); border: 1px solid var(--hairline); }
+    .nw-edge { stroke: rgba(242,166,35,0.18); stroke-width: 0.6; fill: none; pointer-events: none; }
+    .nw-edge.strong { stroke: rgba(242,166,35,0.55); stroke-width: 1.4; }
+    .nw-edge.weak   { stroke: rgba(110,138,124,0.10); stroke-width: 0.3; }
+    .nw-edge.pattern{ stroke: rgba(178,128,255,0.28); stroke-dasharray: 3 3; }
+    .nw-edge.hilite { stroke: var(--amber); stroke-width: 2; }
+
+    .nw-node { cursor: pointer; }
+    .nw-node circle { transition: stroke-width .12s; }
+    .nw-node:hover circle { stroke: var(--amber); stroke-width: 2.5; filter: drop-shadow(0 0 4px var(--amber-glow)); }
+    .nw-node.pinned circle { stroke: var(--amber); stroke-width: 2.5; filter: drop-shadow(0 0 6px var(--amber-glow)); }
+    .nw-node text { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 0.06em; pointer-events: none; }
+
+    .nw-mode { display: flex; gap: 6px; margin: 0 0 14px; padding-bottom: 14px; border-bottom: 1px solid var(--hairline); flex-wrap: wrap; }
+    .nw-mode .m { padding: 6px 10px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; cursor: pointer; text-transform: uppercase; user-select: none; }
+    .nw-mode .m.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.10); box-shadow: 0 0 12px rgba(242,166,35,0.20); }
+
+    .nw-ctl .row { display: flex; align-items: center; gap: 10px; padding: 9px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.14em; color: var(--text-3); text-transform: uppercase; }
     .nw-ctl .row:last-child { border-bottom: none; }
     .nw-ctl .row .label { flex: 1; }
     .nw-ctl .row .v { color: var(--text); font-family: 'Space Grotesk', sans-serif; font-size: 14px; font-weight: 600; }
-    .nw-ctl .slider { width: 60px; height: 2px; background: var(--hairline); position: relative; }
-    .nw-ctl .slider .knob { position: absolute; width: 40%; height: 100%; background: var(--amber); box-shadow: 0 0 6px var(--amber-glow); }
-    .nw-mode { display: flex; gap: 8px; margin: 0 0 14px; padding-bottom: 14px; border-bottom: 1px solid var(--hairline); }
-    .nw-mode .m { padding: 7px 11px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.16em; cursor: pointer; text-transform: uppercase; }
-    .nw-mode .m.active { color: var(--amber); border-color: var(--border-strong); background: rgba(242,166,35,0.10); box-shadow: 0 0 12px rgba(242,166,35,0.20); }
+    .nw-ctl input[type="range"] { width: 92px; accent-color: var(--amber); cursor: pointer; }
+    .nw-ctl input[type="range"]::-webkit-slider-thumb { background: var(--amber); }
 
-    .nw-key { display: flex; flex-direction: column; gap: 9px; margin-top: 14px; }
+    .nw-key { display: flex; flex-direction: column; gap: 8px; }
     .nw-key .k { display: flex; align-items: center; gap: 9px; font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-3); letter-spacing: 0.10em; text-transform: uppercase; }
     .nw-key .k .d { width: 10px; height: 10px; border-radius: 50%; }
+
+    .nw-detail { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); }
+    .nw-detail h4 { font-family: 'Space Grotesk', sans-serif; font-size: 18px; color: var(--text); margin: 0 0 6px; line-height: 1.25; font-weight: 600; letter-spacing: -0.01em; }
+    .nw-detail .sub { color: var(--text-4); font-size: 10px; letter-spacing: 0.16em; margin-bottom: 12px; text-transform: uppercase; }
+    .nw-detail .nb { display: flex; align-items: baseline; justify-content: space-between; padding: 5px 0; border-bottom: 1px solid var(--hairline); font-size: 10px; color: var(--text-2); }
+    .nw-detail .nb:last-child { border-bottom: none; }
+    .nw-detail .nb .cos { color: var(--cyan); font-family: 'Space Grotesk', sans-serif; font-size: 11px; font-weight: 600; }
+    .nw-detail a { color: var(--cyan); text-decoration: none; border-bottom: 1px dashed var(--cyan); padding-bottom: 1px; }
+    .nw-detail a:hover { color: var(--amber); border-color: var(--amber); }
   </style>
 </head>
 <body data-view="network">
@@ -43,208 +58,354 @@
   <section class="page-title">
     <div class="eyebrow"><span class="div"></span>SURFACE · 11 — entity graph</div>
     <h1>Force-directed clustering. <em>Where the corpus actually connects.</em></h1>
-    <p class="sub">Nodes are events; edges are semantic similarity (cosine ≥ 0.55). Tightest cluster: FBI 62HQ-83894 sections. Second cluster: modern USCENTCOM Middle-East mission reports. Drag, pan, tune the similarity threshold.</p>
+    <p class="sub">Nodes are events; edges are semantic cosine similarity from <code>event-similarity.json</code>. Tune the cosine threshold; hover a node for its top neighbors; click to open the dossier.</p>
   </section>
 
   <section class="nw-shell">
-    <div class="panel">
-      <div class="panel-head"><span><span class="icon-sq"></span>CONTROLS</span><span class="right">tune</span></div>
+    <div class="nw-card">
+      <div class="nw-h"><span class="t">CONTROLS</span><span class="meta">tune</span></div>
 
       <div class="nw-mode">
-        <span class="m active">ALL</span>
-        <span class="m">EVENTS</span>
-        <span class="m">PATTERNS</span>
+        <span class="m active" data-mode="semantic">SEMANTIC</span>
+        <span class="m" data-mode="patterns">PATTERNS</span>
+        <span class="m" data-mode="all">ALL</span>
       </div>
 
       <div class="nw-ctl">
-        <div class="row"><span class="label">MIN COSINE</span><span class="slider"><span class="knob" style="left:20%"></span></span><span class="v">0.55</span></div>
-        <div class="row"><span class="label">REPULSION</span><span class="slider"><span class="knob" style="left:50%"></span></span><span class="v">3.2</span></div>
-        <div class="row"><span class="label">ITERATIONS</span><span class="slider"><span class="knob" style="left:65%"></span></span><span class="v">320</span></div>
-        <div class="row"><span class="label">NODES</span><span class="v" id="nw-nodes">75 / 220</span></div>
-        <div class="row"><span class="label">EDGES</span><span class="v">142</span></div>
-        <div class="row"><span class="label">CLUSTERS</span><span class="v">2 dominant</span></div>
+        <div class="row">
+          <span class="label">MIN COSINE</span>
+          <input type="range" id="ctl-cos" min="0.30" max="0.95" step="0.01" value="0.55">
+          <span class="v" id="v-cos">0.55</span>
+        </div>
+        <div class="row">
+          <span class="label">ITERATIONS</span>
+          <input type="range" id="ctl-iter" min="80" max="500" step="20" value="240">
+          <span class="v" id="v-iter">240</span>
+        </div>
+        <div class="row"><span class="label">NODES</span><span class="v" id="v-nodes">0</span></div>
+        <div class="row"><span class="label">EDGES</span><span class="v" id="v-edges">0</span></div>
       </div>
 
       <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline)">
         <div style="font-family:'JetBrains Mono',monospace;font-size:10px;letter-spacing:0.18em;color:var(--text-3);text-transform:uppercase;font-weight:700;margin-bottom:10px">LEGEND</div>
         <div class="nw-key">
-          <div class="k"><span class="d" style="background:var(--amber);box-shadow:0 0 6px var(--amber-glow)"></span>DoW · USCENTCOM cluster</div>
-          <div class="k"><span class="d" style="background:var(--cyan);box-shadow:0 0 6px rgba(97,215,240,0.6)"></span>FBI · 1947 case file</div>
-          <div class="k"><span class="d" style="background:var(--emerald);box-shadow:0 0 6px rgba(74,222,128,0.6)"></span>NASA · orbital</div>
+          <div class="k"><span class="d" style="background:var(--amber);box-shadow:0 0 6px var(--amber-glow)"></span>DoW · DEPT/WAR</div>
+          <div class="k"><span class="d" style="background:var(--cyan);box-shadow:0 0 6px rgba(97,215,240,0.6)"></span>FBI</div>
+          <div class="k"><span class="d" style="background:var(--emerald);box-shadow:0 0 6px rgba(74,222,128,0.6)"></span>NASA</div>
           <div class="k"><span class="d" style="background:var(--rose);box-shadow:0 0 6px rgba(224,73,104,0.6)"></span>Anchor event</div>
+          <div class="k"><span class="d" style="background:#B280FF"></span>Pattern term</div>
           <div class="k"><span class="d" style="background:var(--text-3)"></span>Other / unclassified</div>
         </div>
       </div>
 
-      <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;line-height:1.6;color:var(--text-3);letter-spacing:0.06em">
-        <strong style="color:var(--text);letter-spacing:0.14em">CLUSTER 1 — FBI 62HQ.</strong> 11 internal-section neighbors at cos 0.94-0.98. Tight intra-document.<br><br>
-        <strong style="color:var(--text);letter-spacing:0.14em">CLUSTER 2 — CENTCOM/ME.</strong> 18 events anchored on USCENTCOM (<span data-entity="USCENTCOM"><span data-entity-mentions>202</span> mentions / <span data-entity-docs>18</span> docs</span>).
+      <div id="detail" class="nw-detail" style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline)">
+        <div style="color:var(--text-4);font-size:10px;letter-spacing:0.18em">HOVER OR CLICK A NODE</div>
       </div>
     </div>
 
     <div class="nw-card">
       <div class="nw-h">
-        <div class="t">▣ &nbsp; SEMANTIC GRAPH</div>
-        <div class="meta"><span id="nw-eventcount">220</span> events · <span id="nw-entitycount">199</span> entities · cosine ≥ 0.55</div>
+        <div class="t">▣ &nbsp; <span id="nw-mode-label">SEMANTIC</span> GRAPH</div>
+        <div class="meta"><span id="v-evcount">220</span> events · <span id="v-cosabove">0</span> above threshold</div>
       </div>
 
-      <svg class="nw-svg" viewBox="0 0 1000 720" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <radialGradient id="nodeGlow"><stop offset="0%" stop-color="rgba(242,166,35,0.35)"/><stop offset="100%" stop-color="rgba(242,166,35,0)"/></radialGradient>
-        </defs>
-
-        <!-- Edges first (drawn behind) -->
-        <g>
-          <!-- FBI 62HQ tight cluster (top-left) -->
-          <line class="nw-edge strong" x1="180" y1="150" x2="240" y2="120"/>
-          <line class="nw-edge strong" x1="180" y1="150" x2="280" y2="190"/>
-          <line class="nw-edge strong" x1="240" y1="120" x2="280" y2="190"/>
-          <line class="nw-edge strong" x1="240" y1="120" x2="320" y2="140"/>
-          <line class="nw-edge strong" x1="180" y1="150" x2="220" y2="220"/>
-          <line class="nw-edge strong" x1="280" y1="190" x2="320" y2="140"/>
-          <line class="nw-edge strong" x1="280" y1="190" x2="220" y2="220"/>
-          <line class="nw-edge" x1="240" y1="120" x2="380" y2="180"/>
-          <line class="nw-edge" x1="320" y1="140" x2="380" y2="180"/>
-          <line class="nw-edge" x1="320" y1="140" x2="400" y2="100"/>
-
-          <!-- CENTCOM/ME cluster (center-right) -->
-          <line class="nw-edge strong" x1="680" y1="320" x2="740" y2="280"/>
-          <line class="nw-edge strong" x1="680" y1="320" x2="720" y2="380"/>
-          <line class="nw-edge strong" x1="740" y1="280" x2="800" y2="320"/>
-          <line class="nw-edge strong" x1="720" y1="380" x2="800" y2="320"/>
-          <line class="nw-edge strong" x1="680" y1="320" x2="620" y2="280"/>
-          <line class="nw-edge strong" x1="680" y1="320" x2="640" y2="380"/>
-          <line class="nw-edge" x1="620" y1="280" x2="540" y2="260"/>
-          <line class="nw-edge" x1="640" y1="380" x2="600" y2="440"/>
-          <line class="nw-edge" x1="740" y1="280" x2="820" y2="240"/>
-          <line class="nw-edge" x1="800" y1="320" x2="870" y2="290"/>
-          <line class="nw-edge" x1="720" y1="380" x2="780" y2="440"/>
-
-          <!-- USPER bridge -->
-          <line class="nw-edge strong" x1="540" y1="260" x2="500" y2="500"/>
-          <line class="nw-edge" x1="500" y1="500" x2="640" y2="380"/>
-          <line class="nw-edge" x1="500" y1="500" x2="600" y2="440"/>
-
-          <!-- NASA cluster (top right) -->
-          <line class="nw-edge" x1="820" y1="120" x2="880" y2="180"/>
-          <line class="nw-edge" x1="820" y1="120" x2="780" y2="80"/>
-
-          <!-- Weak cross-cluster -->
-          <line class="nw-edge weak" x1="380" y1="180" x2="500" y2="500"/>
-          <line class="nw-edge weak" x1="540" y1="260" x2="220" y2="220"/>
-          <line class="nw-edge weak" x1="820" y1="120" x2="540" y2="260"/>
-
-          <!-- Outliers -->
-          <line class="nw-edge weak" x1="150" y1="520" x2="380" y2="180"/>
-          <line class="nw-edge weak" x1="900" y1="580" x2="800" y2="320"/>
-        </g>
-
-        <!-- Nodes -->
-        <g>
-          <!-- FBI 62HQ section nodes (cyan) -->
-          <g class="nw-node"><circle cx="180" cy="150" r="10" fill="#61D7F0" stroke="rgba(97,215,240,0.5)" stroke-width="1"/><text x="194" y="154" fill="rgba(155,213,232,0.9)">62hq-s2</text></g>
-          <g class="nw-node"><circle cx="240" cy="120" r="9" fill="#61D7F0" stroke="rgba(97,215,240,0.5)" stroke-width="1"/><text x="254" y="124" fill="rgba(155,213,232,0.85)">62hq-s5</text></g>
-          <g class="nw-node"><circle cx="280" cy="190" r="8" fill="#61D7F0" stroke="rgba(97,215,240,0.5)" stroke-width="1"/><text x="294" y="194" fill="rgba(155,213,232,0.85)">62hq-s4</text></g>
-          <g class="nw-node"><circle cx="320" cy="140" r="7" fill="#61D7F0"/></g>
-          <g class="nw-node"><circle cx="220" cy="220" r="6" fill="#61D7F0"/></g>
-          <g class="nw-node"><circle cx="380" cy="180" r="6" fill="#61D7F0"/></g>
-          <g class="nw-node"><circle cx="400" cy="100" r="5" fill="#61D7F0"/></g>
-
-          <!-- CENTCOM/ME amber cluster -->
-          <g class="nw-node"><circle cx="680" cy="320" r="13" fill="#F2A623" stroke="#FFB840" stroke-width="1.5" filter="url(#nodeGlow)"/><text x="697" y="324" fill="rgba(242,166,35,0.95)" font-weight="600">USCENTCOM</text></g>
-          <g class="nw-node"><circle cx="740" cy="280" r="9" fill="#F2A623"/><text x="754" y="284" fill="rgba(242,166,35,0.85)">uae-jun-2024</text></g>
-          <g class="nw-node"><circle cx="720" cy="380" r="8" fill="#F2A623"/><text x="734" y="384" fill="rgba(242,166,35,0.85)">uae-oct-2023</text></g>
-          <g class="nw-node"><circle cx="800" cy="320" r="8" fill="#F2A623"/><text x="814" y="324" fill="rgba(242,166,35,0.85)">d62 hormuz</text></g>
-          <g class="nw-node"><circle cx="620" cy="280" r="7" fill="#F2A623"/></g>
-          <g class="nw-node"><circle cx="640" cy="380" r="7" fill="#F2A623"/></g>
-          <g class="nw-node"><circle cx="820" cy="240" r="6" fill="#F2A623"/></g>
-          <g class="nw-node"><circle cx="870" cy="290" r="6" fill="#F2A623"/></g>
-          <g class="nw-node"><circle cx="780" cy="440" r="6" fill="#F2A623"/></g>
-          <g class="nw-node"><circle cx="600" cy="440" r="5" fill="#F2A623"/></g>
-
-          <!-- Middle East range fouler bridge -->
-          <g class="nw-node"><circle cx="540" cy="260" r="8" fill="#F2A623"/><text x="554" y="264" fill="rgba(242,166,35,0.85)">d38 me-2020</text></g>
-
-          <!-- ANCHOR: USPER-2025 (rose, prominent) -->
-          <g class="nw-node">
-            <circle cx="500" cy="500" r="16" fill="none" stroke="rgba(224,73,104,0.5)" stroke-width="1" opacity="0.7"/>
-            <circle cx="500" cy="500" r="11" fill="#E04968" stroke="#FF8B9D" stroke-width="1.5"/>
-            <text x="517" y="504" fill="rgba(255,139,157,0.95)" font-weight="600">USPER-2025</text>
-            <text x="517" y="516" fill="rgba(224,73,104,0.65)" font-size="9">ANCHOR</text>
-          </g>
-
-          <!-- NASA orbital (emerald, small cluster) -->
-          <g class="nw-node"><circle cx="820" cy="120" r="9" fill="#4ADE80"/><text x="834" y="124" fill="rgba(134,239,172,0.85)">apollo-17</text></g>
-          <g class="nw-node"><circle cx="880" cy="180" r="6" fill="#4ADE80"/></g>
-          <g class="nw-node"><circle cx="780" cy="80" r="6" fill="#4ADE80"/></g>
-          <g class="nw-node"><circle cx="930" cy="120" r="5" fill="#4ADE80"/></g>
-
-          <!-- Outliers (gray) -->
-          <g class="nw-node"><circle cx="150" cy="520" r="5" fill="#75664A"/><text x="160" y="540" fill="rgba(117,102,74,0.7)">netherlands-1948</text></g>
-          <g class="nw-node"><circle cx="900" cy="580" r="5" fill="#75664A"/></g>
-          <g class="nw-node"><circle cx="200" cy="600" r="4" fill="#75664A"/></g>
-          <g class="nw-node"><circle cx="350" cy="600" r="4" fill="#75664A"/></g>
-
-          <!-- DoW d48/d49 sub-cluster -->
-          <g class="nw-node"><circle cx="440" cy="640" r="7" fill="#F2A623"/><text x="454" y="644" fill="rgba(242,166,35,0.85)">d48 1996</text></g>
-          <g class="nw-node"><circle cx="500" cy="660" r="6" fill="#F2A623"/></g>
-        </g>
-
+      <svg class="nw-svg" id="graph" viewBox="0 0 1000 720" preserveAspectRatio="xMidYMid meet">
+        <g id="edges"></g>
+        <g id="nodes"></g>
       </svg>
     </div>
   </section>
 </main>
 
 <script src="data.js"></script>
-
-<script>
-  (function () {
-    function setText(id, val) {
-      var el = document.getElementById(id);
-      if (el && val != null) el.textContent = val;
-    }
-
-    // Update an entity reference (mentions / docs) from topEntities,
-    // matched by the term in data-entity. If no match, leave as-is.
-    function renderEntities(topEntities) {
-      if (!topEntities || !topEntities.length) return;
-      var byTerm = {};
-      topEntities.forEach(function (e) { byTerm[e.term] = e; });
-      var hosts = document.querySelectorAll('[data-entity]');
-      for (var i = 0; i < hosts.length; i++) {
-        var host = hosts[i];
-        var ent = byTerm[host.getAttribute('data-entity')];
-        if (!ent) continue; // no matching term → leave hardcoded fallback
-        var m = host.querySelector('[data-entity-mentions]');
-        var dc = host.querySelector('[data-entity-docs]');
-        if (m && ent.mentions != null) m.textContent = ent.mentions;
-        if (dc && ent.docs != null) dc.textContent = ent.docs;
-      }
-    }
-
-    function renderFromMC() {
-      var D = window.MC && window.MC.derive;
-      if (!D) return false;
-      // NODES "75 / 220" — similarity node count / total events.
-      var nodes = D.similarity ? Object.keys(D.similarity).length : null;
-      if (nodes != null && D.eventCount != null) {
-        setText('nw-nodes', nodes + ' / ' + D.eventCount);
-      }
-      // EDGES / iterations stay static (graph-layout params).
-      setText('nw-eventcount', D.eventCount);
-      setText('nw-entitycount', D.entityCount);
-      renderEntities(D.topEntities);
-      return true;
-    }
-
-    if (window.MC && typeof window.MC.ready === 'function') {
-      window.MC.ready().then(renderFromMC);
-      window.MC.onUpdate(renderFromMC);
-    }
-    // If MC never loads, the baked-in markup remains as the fallback.
-  })();
-</script>
-
 <script src="chrome.js" defer></script>
+<script>
+(function(){
+  if (!window.MC || !MC.ready) return;
+
+  var W = 1000, H = 720;
+  var svg     = document.getElementById('graph');
+  var gEdges  = document.getElementById('edges');
+  var gNodes  = document.getElementById('nodes');
+  var detail  = document.getElementById('detail');
+  var modeBar = document.querySelector('.nw-mode');
+  var cosInp  = document.getElementById('ctl-cos');
+  var iterInp = document.getElementById('ctl-iter');
+  var vCos    = document.getElementById('v-cos');
+  var vIter   = document.getElementById('v-iter');
+  var vNodes  = document.getElementById('v-nodes');
+  var vEdges  = document.getElementById('v-edges');
+  var vCosAbove = document.getElementById('v-cosabove');
+  var vEvCount= document.getElementById('v-evcount');
+  var modeLbl = document.getElementById('nw-mode-label');
+
+  var minCos = 0.55, iters = 240, mode = 'semantic';
+  var pinnedId = null;
+
+  function esc(s){ return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+  // Agency → color
+  function agencyColor(rec){
+    if (!rec) return '#7CFFB2';
+    if (rec.flag === 'anchor') return '#E04968';
+    var a = (rec.agency || '').toLowerCase();
+    if (a === 'fbi') return '#61D7F0';
+    if (a === 'nasa') return '#7CFFB2';
+    if (a.indexOf('department of war') >= 0 || a === 'dow') return '#F2A623';
+    if (a.indexOf('central intelligence') >= 0 || a === 'cia') return '#94A3B8';
+    return '#7CFFB2';
+  }
+
+  // Build {nodes, links}. Nodes: events (and pattern-term nodes in pattern/all modes).
+  // Links: semantic event↔event from event-similarity, pattern↔event from patterns.byKind.
+  function buildGraph(){
+    var sim = (MC.derive && MC.derive.similarity) || {};
+    var events = (MC.derive && MC.derive.events) || [];
+    var byEid = {}; events.forEach(function(e){ byEid[e.id] = e; });
+    var nodes = [], links = [];
+    var seenLink = {};
+
+    if (mode === 'semantic' || mode === 'all'){
+      // Only include events that appear in the similarity index (the 75-event cohort).
+      Object.keys(sim).forEach(function(eid){
+        if (!byEid[eid]) return;
+        nodes.push({ id: 'e:' + eid, kind: 'event', ref: byEid[eid] });
+      });
+      // Edges (dedup undirected pairs).
+      Object.keys(sim).forEach(function(eid){
+        var ns = (sim[eid] && sim[eid].neighbors) || [];
+        for (var i = 0; i < ns.length; i++){
+          var n = ns[i];
+          if (n.cos < minCos) continue;
+          if (!byEid[n.eid] || !sim[n.eid]) continue;
+          var key = eid < n.eid ? (eid + '|' + n.eid) : (n.eid + '|' + eid);
+          if (seenLink[key]) continue;
+          seenLink[key] = true;
+          links.push({ a: 'e:' + eid, b: 'e:' + n.eid, kind: 'semantic', weight: n.cos });
+        }
+      });
+    }
+
+    if (mode === 'patterns' || mode === 'all'){
+      var data = MC.data || {};
+      var pk = (data.patterns && data.patterns.byKind) || {};
+      ['shape','behavior','sensor'].forEach(function(kind){
+        var top = (pk[kind] || []).slice(0, 6); // top 6 per kind
+        top.forEach(function(row){
+          var linked = (row.events || []).filter(function(e){ return byEid[e.eid]; });
+          if (!linked.length) return;
+          var nid = 'p:' + kind + ':' + row.term;
+          nodes.push({ id: nid, kind: 'pattern', ref: { name: row.term, sub: kind, docs: row.docCount, total: row.total } });
+          // Make sure each linked event is in the node set even if SEMANTIC mode didn't pick it.
+          linked.forEach(function(e){
+            if (!nodes.some(function(n){ return n.id === 'e:' + e.eid; })){
+              nodes.push({ id: 'e:' + e.eid, kind: 'event', ref: byEid[e.eid] });
+            }
+            links.push({ a: nid, b: 'e:' + e.eid, kind: 'pattern', weight: Math.min(1, e.count / 50) });
+          });
+        });
+      });
+    }
+
+    // Drop isolated nodes (no edges) so the canvas stays informative.
+    var deg = {};
+    links.forEach(function(l){ deg[l.a] = (deg[l.a]||0)+1; deg[l.b] = (deg[l.b]||0)+1; });
+    nodes = nodes.filter(function(n){ return deg[n.id]; });
+
+    return { nodes: nodes, links: links };
+  }
+
+  // Simple force-directed layout — repel each pair, spring along links, center pull, damp.
+  // O(N^2 * iter); N ≤ 75 events + ≤ 18 pattern nodes → fast in vanilla JS.
+  function layout(nodes, links, iterations){
+    var cx = W / 2, cy = H / 2;
+    var idx = {}, N = nodes.map(function(n, i){
+      idx[n.id] = i;
+      var ang = (i / nodes.length) * Math.PI * 2;
+      return { id: n.id, kind: n.kind, ref: n.ref,
+        x: cx + Math.cos(ang) * 220 + (Math.random() - 0.5) * 12,
+        y: cy + Math.sin(ang) * 220 + (Math.random() - 0.5) * 12,
+        vx: 0, vy: 0 };
+    });
+    var L = links.map(function(l){ return { a: idx[l.a], b: idx[l.b], kind: l.kind, w: l.weight }; })
+      .filter(function(l){ return l.a != null && l.b != null; });
+    var alpha = 1;
+    for (var it = 0; it < iterations; it++){
+      alpha = Math.max(0.05, 1 - it / iterations);
+      // Repel
+      for (var i = 0; i < N.length; i++){
+        var a = N[i];
+        for (var j = i + 1; j < N.length; j++){
+          var b = N[j];
+          var dx = b.x - a.x, dy = b.y - a.y;
+          var d2 = dx*dx + dy*dy + 0.01;
+          var d = Math.sqrt(d2);
+          var force = 220 / d2;
+          if (force > 1.2) force = 1.2;
+          var fx = (dx/d) * force, fy = (dy/d) * force;
+          a.vx -= fx; a.vy -= fy;
+          b.vx += fx; b.vy += fy;
+        }
+      }
+      // Spring along links
+      for (var k = 0; k < L.length; k++){
+        var aN = N[L[k].a], bN = N[L[k].b];
+        var dx2 = bN.x - aN.x, dy2 = bN.y - aN.y;
+        var dd = Math.sqrt(dx2*dx2 + dy2*dy2) + 0.01;
+        var target = 90;
+        var spring = (dd - target) * 0.04;
+        var sfx = (dx2/dd) * spring, sfy = (dy2/dd) * spring;
+        aN.vx += sfx; aN.vy += sfy;
+        bN.vx -= sfx; bN.vy -= sfy;
+      }
+      // Center pull + damping + integrate
+      for (var p = 0; p < N.length; p++){
+        N[p].vx += (cx - N[p].x) * 0.003;
+        N[p].vy += (cy - N[p].y) * 0.003;
+        N[p].vx *= 0.82; N[p].vy *= 0.82;
+        N[p].x += N[p].vx * alpha;
+        N[p].y += N[p].vy * alpha;
+        N[p].x = Math.max(20, Math.min(W - 20, N[p].x));
+        N[p].y = Math.max(20, Math.min(H - 20, N[p].y));
+      }
+    }
+    var posById = {};
+    N.forEach(function(n){ posById[n.id] = n; });
+    return { positioned: N, posById: posById };
+  }
+
+  function nodeSize(n, posById, links){
+    if (n.kind === 'pattern') return 5;
+    // Degree-aware sizing for events.
+    var d = 0;
+    for (var k = 0; k < links.length; k++){
+      if (links[k].a === n.id || links[k].b === n.id) d++;
+    }
+    return 5 + Math.min(8, d * 0.6);
+  }
+  function nodeColor(n){
+    if (n.kind === 'pattern') return '#B280FF';
+    return agencyColor(n.ref);
+  }
+  function nodeLabel(n){
+    if (n.kind === 'pattern') return (n.ref && n.ref.name) || '';
+    var ref = n.ref || {};
+    var id = (ref.id || '').toString();
+    return id.length > 14 ? id.slice(0, 14) + '…' : id;
+  }
+
+  function paint(){
+    var built = buildGraph();
+    if (vNodes) vNodes.textContent = built.nodes.length;
+    if (vEdges) vEdges.textContent = built.links.length;
+    if (vCosAbove) vCosAbove.textContent = built.links.filter(function(l){ return l.kind === 'semantic'; }).length;
+    if (vEvCount) vEvCount.textContent = ((MC.derive && MC.derive.events) || []).length;
+    if (modeLbl) modeLbl.textContent = mode.toUpperCase();
+    if (!built.nodes.length){
+      gEdges.innerHTML = ''; gNodes.innerHTML = '';
+      return;
+    }
+    var out = layout(built.nodes, built.links, iters);
+    // Edges
+    var edgeHtml = built.links.map(function(l){
+      var a = out.posById[l.a], b = out.posById[l.b];
+      if (!a || !b) return '';
+      var cls = 'nw-edge';
+      if (l.kind === 'pattern') cls += ' pattern';
+      else if (l.weight >= 0.75) cls += ' strong';
+      else if (l.weight < 0.50)  cls += ' weak';
+      return '<line class="' + cls + '" x1="' + a.x.toFixed(1) + '" y1="' + a.y.toFixed(1) + '" x2="' + b.x.toFixed(1) + '" y2="' + b.y.toFixed(1) + '" data-a="' + esc(l.a) + '" data-b="' + esc(l.b) + '"/>';
+    }).join('');
+    gEdges.innerHTML = edgeHtml;
+
+    // Nodes
+    var nodeHtml = out.positioned.map(function(n){
+      var size = nodeSize(n, out.posById, built.links);
+      var fill = nodeColor(n);
+      var lbl  = nodeLabel(n);
+      return '<g class="nw-node' + (n.id === pinnedId ? ' pinned' : '') + '" data-id="' + esc(n.id) + '" transform="translate(' + n.x.toFixed(1) + ',' + n.y.toFixed(1) + ')">' +
+        '<circle r="' + size + '" fill="' + fill + '" stroke="rgba(0,0,0,0.5)" stroke-width="1"/>' +
+        '<text x="' + (size + 4) + '" y="3" fill="rgba(220,220,220,0.85)">' + esc(lbl) + '</text>' +
+      '</g>';
+    }).join('');
+    gNodes.innerHTML = nodeHtml;
+
+    // Bind hover / click
+    gNodes.querySelectorAll('.nw-node').forEach(function(g){
+      var id = g.dataset.id;
+      g.addEventListener('mouseenter', function(){ showDetail(id, built.links); highlightEdges(id); });
+      g.addEventListener('mouseleave', function(){ if (!pinnedId) clearHighlight(); });
+      g.addEventListener('click', function(){
+        if (id.indexOf('e:') === 0){
+          var eid = id.slice(2);
+          window.location.href = MC.url.dossier(eid);
+        }
+      });
+    });
+  }
+
+  function highlightEdges(nodeId){
+    gEdges.querySelectorAll('line').forEach(function(ln){
+      if (ln.dataset.a === nodeId || ln.dataset.b === nodeId){
+        ln.classList.add('hilite');
+      } else {
+        ln.classList.remove('hilite');
+      }
+    });
+  }
+  function clearHighlight(){
+    gEdges.querySelectorAll('line.hilite').forEach(function(ln){ ln.classList.remove('hilite'); });
+  }
+
+  function showDetail(nodeId, links){
+    if (nodeId.indexOf('e:') === 0){
+      var eid = nodeId.slice(2);
+      var rec = MC.byEid(eid);
+      if (!rec){ detail.innerHTML = '<div style="color:var(--text-4)">' + esc(eid) + '</div>'; return; }
+      var neighbors = MC.neighbors(eid, 6);
+      var nbHTML = neighbors.length ? neighbors.map(function(nb){
+        var nbRec = MC.byEid(nb.eid);
+        return '<div class="nb"><a href="' + esc(MC.url.dossier(nb.eid)) + '">' + esc((nbRec && nbRec.id) || nb.eid) + '</a><span class="cos">' + nb.cos.toFixed(2) + '</span></div>';
+      }).join('') : '<div style="color:var(--text-4);font-size:10px">no neighbors at this threshold</div>';
+      detail.innerHTML =
+        '<h4>' + esc(rec.title || rec.id) + '</h4>' +
+        '<div class="sub">' + esc(rec.id) + ' · ' + esc(rec.agency || '') + ' · ' + esc(rec.date || '') + '</div>' +
+        '<div style="font-family:\'JetBrains Mono\',monospace;font-size:9px;letter-spacing:0.18em;color:var(--text-4);margin-bottom:8px;text-transform:uppercase">TOP NEIGHBORS</div>' +
+        nbHTML +
+        '<div style="margin-top:12px"><a href="' + esc(MC.url.dossier(eid)) + '">→ OPEN DOSSIER</a></div>';
+    } else if (nodeId.indexOf('p:') === 0){
+      var parts = nodeId.split(':');
+      var kind = parts[1], term = parts.slice(2).join(':');
+      detail.innerHTML =
+        '<h4>' + esc(term) + '</h4>' +
+        '<div class="sub">PATTERN · ' + esc(kind) + '</div>' +
+        '<div style="color:var(--text-4);font-size:10px;line-height:1.5">Mined from corpus pages. Edges connect to every event whose vision/OCR text mentions this term.</div>';
+    }
+  }
+
+  // ─── Wire controls ───
+  modeBar.querySelectorAll('.m').forEach(function(m){
+    m.addEventListener('click', function(){
+      modeBar.querySelectorAll('.m').forEach(function(o){ o.classList.remove('active'); });
+      m.classList.add('active');
+      mode = m.dataset.mode;
+      paint();
+    });
+  });
+  cosInp.addEventListener('input', function(){
+    minCos = parseFloat(cosInp.value);
+    vCos.textContent = minCos.toFixed(2);
+    paint();
+  });
+  iterInp.addEventListener('input', function(){
+    iters = parseInt(iterInp.value, 10);
+    vIter.textContent = iters;
+  });
+  iterInp.addEventListener('change', paint);
+
+  MC.ready().then(paint);
+  MC.onUpdate(function(){ if (!gNodes.children.length) paint(); });
+})();
+</script>
 </body>
 </html>

--- a/public/mc/review.html
+++ b/public/mc/review.html
@@ -75,10 +75,18 @@
       </div></a>
       </div>
 
-      <div style="margin-top:24px;padding-top:18px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.14em">
-        <div style="margin-bottom:8px">FILTER · all agencies</div>
-        <div style="margin-bottom:8px">SORT · worst agreement first</div>
-        <div style="color:var(--text-3);margin-top:14px">Pages graded ≥0.85 are auto-accepted as canonical and never enter this queue. Threshold tunable in <span style="color:var(--amber)">corpus-stats.json</span>.</div>
+      <div style="margin-top:24px;padding-top:18px;border-top:1px solid var(--hairline)">
+        <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-3);letter-spacing:0.22em;font-weight:700;margin-bottom:10px">GRADED EXAMPLES</div>
+        <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.10em;margin-bottom:8px;line-height:1.5">Pick an event with completed extracts to see what graded page text looks like.</div>
+        <select id="rv-graded" class="md-select" style="width:100%;background:var(--surface);border:1px solid var(--border);color:var(--text-2);font-family:'JetBrains Mono',monospace;font-size:11px;padding:8px 10px;cursor:pointer">
+          <option value="">— pick an event —</option>
+        </select>
+      </div>
+
+      <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--hairline);font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-4);letter-spacing:0.14em">
+        <div style="margin-bottom:6px">FILTER · all agencies</div>
+        <div style="margin-bottom:6px">SORT · worst agreement first</div>
+        <div style="color:var(--text-3);margin-top:12px;line-height:1.55">Pages graded ≥0.85 are auto-accepted as canonical and never enter this queue. Threshold tunable in <span style="color:var(--amber)">corpus-stats.json</span>.</div>
       </div>
     </div>
 
@@ -86,29 +94,29 @@
       <div class="rv-head">
         <div>
           <h2 id="rv-pane-title">usper-2025 · page 03</h2>
-          <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-3);letter-spacing:0.14em;margin-top:6px">FBI · 2025-10 · SECRET//NOFORN · 4 SOURCES · LAST UPDATED 14h ago</div>
+          <div id="rv-pane-sub" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-3);letter-spacing:0.14em;margin-top:6px">FBI · 2025-10 · SECRET//NOFORN · 4 SOURCES</div>
         </div>
-        <div class="meta">AGREEMENT <span class="score">0.21</span></div>
+        <div class="meta">EXTRACTS <span class="score" id="rv-score" style="background:rgba(97,215,240,0.10);color:var(--cyan);border-color:rgba(97,215,240,0.4)">live</span></div>
       </div>
 
-      <div class="diff-grid">
+      <div class="diff-grid" id="rv-diff">
         <div class="diff-col">
-          <h4><span class="src-tag g">VISION</span><span>GEMINI · 2.0 Flash</span><span class="conf">0.94 conf</span></h4>
-          <p>"On <span class="del">[redacted]</span> 2025, at approximately 1700 hours [redacted] (a senior US intelligence official), [FEDERAL PARTNER 1] and [FEDERAL PARTNER 2], accompanied by [WITNESS 2 (a senior US intelligence official)], and two pilots from [STATE PARTNER ORGANIZATION] departed [<span class="add">SITE CODE NAME</span>] to conduct a search…"</p>
+          <h4><span class="src-tag g">VISION</span><span>loading extracts…</span></h4>
+          <p style="color:var(--text-4)">Pick a row in the queue to see the page's top-scoring extracts.</p>
         </div>
         <div class="diff-col">
-          <h4><span class="src-tag o">OCR</span><span>Tesseract 5.4</span><span class="conf">0.62 conf</span></h4>
-          <p>"On <span class="add">[reducted]</span> 2025, at approxlmately 1700 hours [reducted] (a senior US lntelligence offlcial), [FEDERAL PARTNER 1] and [FEDERAL PARTNER 2], accompanled by [WITNESS 2 (a sentior US Intelligence offlclal)], and two pllots from [STATE PARTNER ORGANIZATION] departed [<span class="del">unknown</span>] to conduct a search…"</p>
+          <h4><span class="src-tag o">CONTEXT</span><span>event metadata</span></h4>
+          <p style="color:var(--text-4)">The event summary and provenance will appear here once the queue row is selected.</p>
         </div>
       </div>
 
       <div class="merge-pane">
-        <h4><span>▣ MERGED TEXT — REVIEWER PROPOSAL</span><span style="margin-left:auto;color:var(--text-3);font-weight:400">edit freely · saves on submit</span></h4>
-        <textarea>On [redacted] 2025, at approximately 1700 hours [redacted] (a senior US intelligence official), [FEDERAL PARTNER 1] and [FEDERAL PARTNER 2], accompanied by [WITNESS 2 (a senior US intelligence official)], and two pilots from [STATE PARTNER ORGANIZATION] departed [SITE CODE NAME] to conduct a search…</textarea>
+        <h4><span>▣ MERGED TEXT — REVIEWER PROPOSAL</span><span style="margin-left:auto;color:var(--text-3);font-weight:400">edit freely · saved to the GitHub issue on submit</span></h4>
+        <textarea id="rv-merge" placeholder="Top extracts auto-seed here when you pick a queue row. Edit freely before opening the prefilled GitHub issue."></textarea>
       </div>
 
       <div class="actions-bar">
-        <span class="meta">SUBMISSION · opens pre-filled PR · reviewer credit: anonymous OK</span>
+        <span class="meta">SUBMISSION · opens pre-filled GitHub issue · reviewer credit: anonymous OK</span>
         <button class="ab-btn ghost" style="cursor:default">SKIP — next page</button>
         <a id="rv-submit-btn" class="ab-btn primary" href="#" target="_blank" rel="noopener" style="text-decoration:none;display:inline-block">▣ SUBMIT MERGED TEXT →</a>
       </div>
@@ -120,35 +128,97 @@
 
 <script src="chrome.js" defer></script>
 <script>
-  // Active-state toggle via delegation so it survives live re-render.
-  const rvList = document.getElementById('rv-queue-list');
-  if (rvList) rvList.addEventListener('click', (e) => {
-    const row = e.target.closest('.rv-row');
-    if (!row || !rvList.contains(row)) return;
-    rvList.querySelectorAll('.rv-row').forEach(x => x.classList.remove('active'));
-    row.classList.add('active');
-  });
-
   // ── Live data layer ──
-  // The real review queue (pages where engines disagree) may be empty —
-  // MC.derive.reviewCount can be 0. The actionable list is the transcription
-  // queue (MC.derive.queue: next-missing pages). Drive the UI off that, and
-  // reword the header so it stays grammatical. Static rows remain the fallback.
   function esc(v){ const d=document.createElement('div'); d.textContent=(v==null?'':String(v)); return d.innerHTML; }
+
+  // Lazy-loaded once: public/dossier-extracts.json (~570KB) — per-event
+  // per-page top extracts with flag annotations + source. We use it to
+  // populate the diff pane when a queue row is clicked.
+  let _extracts = null;
+  function loadExtracts(){
+    if (_extracts) return _extracts;
+    _extracts = fetch('../dossier-extracts.json?t=' + Date.now())
+      .then(r => r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)))
+      .catch(e => { console.warn('extracts load failed:', e); return null; });
+    return _extracts;
+  }
+
+  // Render the diff pane with REAL data for {eid, page}. Uses the
+  // top extracts from dossier-extracts.json on the left ("raw") and the
+  // page's text concatenated as a starting merged proposal on the right.
+  async function renderDetail(item){
+    if (!item) return;
+    const pane = document.getElementById('rv-pane-title');
+    const eid = item.eid, page = item.page;
+    if (pane) pane.textContent = (eid || '—') + (page != null ? ' · page ' + page : '');
+
+    const rec = MC.byEid(eid);
+    document.getElementById('rv-pane-sub').innerHTML = rec
+      ? esc(rec.agency || '—') + ' · ' + esc(rec.date || '—') + ' · ' + esc((rec.type || '').toUpperCase())
+      : esc(eid);
+
+    // Bind SUBMIT MERGED TEXT — pre-fill GitHub issue for THIS item.
+    const submitBtn = document.getElementById('rv-submit-btn');
+    if (submitBtn && MC.url && MC.url.claim) submitBtn.href = MC.url.claim(eid, page);
+
+    const ex = await loadExtracts();
+    const grid = document.getElementById('rv-diff');
+    const merge = document.getElementById('rv-merge');
+    if (!ex || !ex[eid] || !ex[eid].excerptsByPage){
+      grid.innerHTML = '<div class="diff-col"><h4><span class="src-tag g">VISION</span><span>no excerpts for this event</span></h4>' +
+        '<p style="color:var(--text-4)">Page-level extracts are produced by the corpus build (scripts/build-dossier-extracts.mjs). When this event has been processed, the top sentences for the requested page will appear here.</p></div>' +
+        '<div class="diff-col"><h4><span class="src-tag o">OCR</span><span>raw text not bundled</span></h4>' +
+        '<p style="color:var(--text-4)">Multi-source raw text lives in the per-source corpus DB and is not bundled to /mc/. Click <a href="' + esc(MC.url.dossier(eid)) + '" style="color:var(--cyan)">OPEN DOSSIER</a> to view this event in context.</p></div>';
+      merge.value = '';
+      return;
+    }
+    const pgKey = String(page);
+    const pageEntry = ex[eid].excerptsByPage[pgKey];
+    if (!pageEntry){
+      // Pick the closest page that DOES have extracts.
+      const available = Object.keys(ex[eid].excerptsByPage || {}).sort(function(a,b){ return Math.abs(+a - +page) - Math.abs(+b - +page); });
+      grid.innerHTML = '<div class="diff-col"><h4><span class="src-tag g">VISION</span><span>page ' + esc(page) + ' has no graded excerpts</span></h4>' +
+        '<p style="color:var(--text-4)">' + (available.length ? 'Nearest graded pages: ' + available.slice(0, 6).join(', ') + '.' : 'No graded pages for this event.') + '</p></div>' +
+        '<div class="diff-col"><h4><span class="src-tag o">OCR</span><span>raw text not bundled</span></h4>' +
+        '<p style="color:var(--text-4)">The transcription queue surfaces pages waiting for ANY engine to land. When vision or OCR completes this page, it shows up here.</p></div>';
+      merge.value = '';
+      return;
+    }
+    const top = (pageEntry.top || []).slice(0, 6);
+    const source = pageEntry.source || 'vision';
+    // Left column — raw top sentences with flag chips
+    grid.innerHTML = '<div class="diff-col">' +
+      '<h4><span class="src-tag ' + (source === 'vision' ? 'g' : 'o') + '">' + esc(source.toUpperCase()) + '</span><span>top extracts</span><span class="conf">' + top.length + ' sentences</span></h4>' +
+      top.map(function(s){
+        var flags = [];
+        Object.keys(s.flags || {}).forEach(function(f){
+          if (s.flags[f] === true) flags.push(f);
+        });
+        var flagsHTML = flags.length ? '<span style="font-family:\'JetBrains Mono\',monospace;font-size:9px;color:var(--cyan);letter-spacing:0.12em;margin-right:8px">[' + flags.map(esc).join(' · ') + ']</span>' : '';
+        return '<p style="margin-bottom:10px">' + flagsHTML + esc(s.text) + ' <span style="color:var(--text-4);font-size:10px;margin-left:6px">· score ' + (s.score || 0).toFixed(1) + '</span></p>';
+      }).join('') +
+      '</div>' +
+      '<div class="diff-col">' +
+      '<h4><span class="src-tag o">CONTEXT</span><span>event metadata</span></h4>' +
+      '<p>' + esc((rec && rec.summary) || 'No summary recorded for this event.') + '</p>' +
+      '<p style="margin-top:14px;color:var(--text-4);font-size:11px">Source-of-truth raw page text is in the per-source corpus DB; only top-scoring sentences are bundled to /mc/. The reviewer task is to merge the engines\' page transcripts elsewhere; this surface routes contributors to the prefilled GitHub issue.</p>' +
+      '</div>';
+    // Seed the merge textarea with the concatenated top sentences.
+    merge.value = top.map(function(s){ return s.text; }).join('\n\n');
+  }
 
   function renderReview(MC){
     const D = MC && MC.derive; if (!D) return;
     const q = Array.isArray(D.queue) ? D.queue : [];
-    if (!q.length) return; // keep hardcoded fallback
+    if (!q.length) return;
 
     const n = q.length;
     const plural = n === 1 ? 'page' : 'pages';
 
-    // Header h1 — disputed-page wording only if there are disputes; otherwise
-    // drive off the transcription queue length.
+    // Header h1
     const title = document.getElementById('rv-title');
-    if (title) {
-      if (typeof D.reviewCount === 'number' && D.reviewCount > 0) {
+    if (title){
+      if (typeof D.reviewCount === 'number' && D.reviewCount > 0){
         const rc = D.reviewCount;
         title.innerHTML = rc + ' ' + (rc === 1 ? 'page' : 'pages')
           + ' where the engines disagree. <em>Pick the truth.</em>';
@@ -157,28 +227,26 @@
           + ' awaiting transcription. <em>Pick the truth.</em>';
       }
     }
-
-    // Queue header label + count
     const label = document.getElementById('rv-queue-label');
     if (label) label.textContent = (typeof D.reviewCount === 'number' && D.reviewCount > 0)
       ? 'QUEUE · WORST AGREEMENT' : 'QUEUE · NEXT MISSING';
     const count = document.getElementById('rv-queue-count');
     if (count) count.textContent = n;
 
-    // Queue list — top 12 from the transcription queue. Each row is wrapped
-    // in an anchor to MC.url.dossier(eid) so click → dossier.
+    // Queue rows — click handler routes to renderDetail(item) instead of
+    // hard-navigating to dossier. The anchor click is preventDefault'd in JS;
+    // ⌘/Ctrl-click still opens dossier in a new tab via the href.
     const list = document.getElementById('rv-queue-list');
-    if (list) {
+    if (list){
       list.innerHTML = q.slice(0, 12).map((item, i) => {
         const eid = item.eid || '';
         const pg = item.page != null ? 'p ' + item.page : '';
         const agency = item.agency || '';
         const flag = (item.flag || '').toString().toUpperCase();
         const reason = (item.reason || '').toString();
-        const meta = [reason, 'priority ' + (item.priority ?? '—')]
-          .filter(Boolean).join(' · ');
+        const meta = [reason, 'priority ' + (item.priority ?? '—')].filter(Boolean).join(' · ');
         const href = MC.url && MC.url.dossier ? MC.url.dossier(eid) : '#';
-        return '<a class="rv-row-link" href="' + esc(href) + '">'
+        return '<a class="rv-row-link" href="' + esc(href) + '" data-idx="' + i + '">'
           + '<div class="rv-row' + (i === 0 ? ' active' : '') + '">'
           + '<div class="top"><span>' + esc(agency) + '</span><span>·</span>'
           + '<span class="agree high">' + esc(flag || '—') + '</span></div>'
@@ -186,26 +254,51 @@
           + '<div class="meta">' + esc(meta) + '</div>'
           + '</div></a>';
       }).join('');
+      list.querySelectorAll('a.rv-row-link').forEach(function(a){
+        a.addEventListener('click', function(e){
+          if (e.metaKey || e.ctrlKey || e.shiftKey) return; // let modifier-click open dossier
+          e.preventDefault();
+          list.querySelectorAll('.rv-row').forEach(function(x){ x.classList.remove('active'); });
+          a.querySelector('.rv-row').classList.add('active');
+          renderDetail(q[parseInt(a.dataset.idx, 10)]);
+        });
+      });
     }
 
-    // Detail-pane title → first queued eid (demo diff stays as-is)
-    const pane = document.getElementById('rv-pane-title');
-    if (pane && q[0] && q[0].eid) {
-      pane.textContent = q[0].eid + (q[0].page != null ? ' · page ' + q[0].page : '');
-    }
-
-    // Bind the SUBMIT MERGED TEXT primary button → pre-filled GitHub issue
-    // for the first queued page (MC.url.claim(eid, page)).
-    const submitBtn = document.getElementById('rv-submit-btn');
-    if (submitBtn && q[0] && MC.url && MC.url.claim) {
-      submitBtn.href = MC.url.claim(q[0].eid, q[0].page);
-    }
+    // Initial detail = top of queue
+    renderDetail(q[0]);
   }
 
-  if (window.MC && typeof window.MC.ready === 'function') {
+  if (window.MC && typeof window.MC.ready === 'function'){
     window.MC.ready().then(() => renderReview(window.MC));
     window.MC.onUpdate(() => renderReview(window.MC));
   }
+
+  // Populate the GRADED EXAMPLES picker from dossier-extracts.json once it lands.
+  (async function(){
+    const ex = await loadExtracts();
+    if (!ex) return;
+    const sel = document.getElementById('rv-graded');
+    if (!sel) return;
+    const opts = Object.keys(ex).map(function(eid){
+      const rec = MC.byEid ? MC.byEid(eid) : null;
+      const label = rec && rec.title ? (eid + ' · ' + rec.title) : eid;
+      return { eid, label };
+    }).sort(function(a, b){ return a.label.localeCompare(b.label); });
+    opts.forEach(function(o){
+      const opt = document.createElement('option');
+      opt.value = o.eid;
+      opt.textContent = o.label.length > 60 ? o.label.slice(0, 60) + '…' : o.label;
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', function(){
+      const eid = sel.value;
+      if (!eid) return;
+      // Pick the first graded page for this event.
+      const firstPg = Object.keys(ex[eid].excerptsByPage || {})[0];
+      renderDetail({ eid, page: firstPg ? parseInt(firstPg, 10) : 1 });
+    });
+  })();
 </script>
 </body>
 </html>

--- a/public/mc/search.html
+++ b/public/mc/search.html
@@ -65,6 +65,24 @@
     .toggle-pill .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-4); }
     .toggle-pill.on { color: #B280FF; border-color: rgba(178,128,255,0.55); background: rgba(178,128,255,0.10); }
     .toggle-pill.on .dot { background: #B280FF; box-shadow: 0 0 8px rgba(178,128,255,0.6); }
+
+    /* Quick-query chips */
+    .qq-wrap { margin: 0 0 16px; }
+    .qq-label { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.22em; margin-bottom: 10px; text-transform: uppercase; }
+    .qq { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-2); background: var(--surface-2); border: 1px solid var(--border); padding: 3px 10px; margin: 0 6px 6px 0; cursor: pointer; letter-spacing: 0.04em; }
+    .qq:hover { color: var(--amber); border-color: var(--amber); }
+
+    /* Page-hit snippets nested inside a result card */
+    .rc-pages { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--hairline); display: flex; flex-direction: column; gap: 10px; }
+    .rc-pages .ph { padding-left: 10px; border-left: 1px solid rgba(97,215,240,0.35); font-family: 'Inter', sans-serif; font-size: 12px; line-height: 1.5; color: var(--text-2); }
+    .rc-pages .ph .lab { display: inline-block; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--amber); letter-spacing: 0.18em; margin-right: 8px; font-weight: 600; }
+    .rc-pages .ph mark { background: rgba(242,166,35,0.30); color: var(--amber-bright); padding: 0 3px; }
+    .rc-pages .more { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.10em; padding-left: 10px; }
+
+    /* Index-loading inline status */
+    .idx-status { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.18em; margin-left: 12px; }
+    .idx-status.ready { color: var(--emerald, #6EE7B7); }
+    .idx-status.error { color: var(--rose); }
   </style>
 </head>
 <body data-view="search">
@@ -109,9 +127,16 @@
 
     <div class="stats-row">
       <span><span class="v" id="stat-count">0</span> RESULTS</span><span>·</span>
-      <span id="stat-mode">EXACT MATCH · ⏱ <span id="stat-ms">0</span>ms</span><span>·</span>
-      <span style="color:var(--cyan);cursor:pointer" id="hint-meaning">↻ TRY MEANING FOR FUZZIER RESULTS</span>
+      <span id="stat-mode">EXACT MATCH · ⏱ <span id="stat-ms">0</span>ms</span>
+      <span class="idx-status" id="idx-status">· FULL-TEXT INDEX: loading 276 docs…</span>
       <span class="right" id="stat-sort">SORTED BY RELEVANCE</span>
+    </div>
+
+    <div class="qq-wrap" id="qq-wrap">
+      <div class="qq-label">TRY · QUICK QUERIES</div>
+      <div id="qq-list">
+        <span class="qq">borman</span><span class="qq">uap</span><span class="qq">cernan</span><span class="qq">centcom</span><span class="qq">swir</span><span class="qq">fvey</span><span class="qq">carol rosin</span><span class="qq">ellipsoid</span><span class="qq">bouncy ball</span><span class="qq">orb</span><span class="qq">diamond</span><span class="qq">bronze</span><span class="qq">saucer</span><span class="qq">pantex</span><span class="qq">aawsa</span><span class="qq">oak ridge</span>
+      </div>
     </div>
 
     <p class="browse-hint" id="browse-hint">BROWSE / SUGGESTED · top events by flag weight</p>
@@ -216,6 +241,56 @@
     return (q || '').toLowerCase().split(/\s+/).filter(Boolean);
   }
 
+  // ─────────── Full-text index (MiniSearch over public/search-index.json) ───────────
+  // Module-level cache — the index is 8.6MB; load + parse once per page.
+  var _miniPromise = null;
+  function loadFullTextIndex(){
+    if (_miniPromise) return _miniPromise;
+    _miniPromise = (async () => {
+      var MiniSearch = (await import('./lib/minisearch.js')).default;
+      var t = await fetch('../search-index.json').then(function(r){
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.text();
+      });
+      return MiniSearch.loadJSON(t, {
+        fields: ['title','body','agency'],
+        storeFields: ['eventId','page','kind','title','agency','date','flag','body'],
+        searchOptions: { boost: { title: 3, body: 1 }, prefix: true, fuzzy: 0.15 },
+        tokenize: function(s){ return s.toLowerCase().split(/[^a-z0-9']+/).filter(function(t){ return t.length >= 2 && t.length <= 30; }); }
+      });
+    })();
+    return _miniPromise;
+  }
+
+  // Pull a ~280-char snippet centered around the first token match.
+  function snippetAround(body, tokens, span){
+    if (!body) return '';
+    span = span || 140;
+    var lower = body.toLowerCase();
+    var bestPos = -1;
+    for (var i = 0; i < tokens.length; i++){
+      var p = lower.indexOf(tokens[i]);
+      if (p !== -1 && (bestPos === -1 || p < bestPos)) bestPos = p;
+    }
+    if (bestPos === -1) return body.slice(0, span * 2).replace(/\s+/g, ' ').trim();
+    var start = Math.max(0, bestPos - span);
+    var end   = Math.min(body.length, bestPos + span);
+    return (start > 0 ? '…' : '') + body.slice(start, end).replace(/\s+/g, ' ').trim() + (end < body.length ? '…' : '');
+  }
+
+  // Wrap each token in <mark>; safe-escapes the rest.
+  function highlightSnippet(text, tokens){
+    if (!text) return '';
+    if (!tokens || !tokens.length) return esc(text);
+    try {
+      var safe = tokens.map(function(t){ return t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }).join('|');
+      var re = new RegExp('(' + safe + ')', 'ig');
+      return text.split(re).map(function(s){
+        return re.test(s) ? '<mark>' + esc(s) + '</mark>' : esc(s);
+      }).join('');
+    } catch (e) { return esc(text); }
+  }
+
   // Evidence-type → badge spec (class, short label).
   var BADGE_SPEC = {
     'primary-source':  ['primary',  'PRIMARY'],
@@ -239,12 +314,24 @@
     return '<div class="badges">' + out.join('') + '</div>';
   }
 
-  // Card renderer.
-  function cardHTML(ev, score, MC){
+  // Card renderer. `pageHits` is optional — when present, each is a
+  // {page, body} object surfaced from the full-text index; we render up to
+  // 4 inline snippets with the query tokens marked.
+  function cardHTML(ev, score, MC, pageHits, tokens){
     var href = (MC && MC.url && MC.url.dossier) ? MC.url.dossier(ev.id) : ('dossier.html?eid=' + encodeURIComponent(ev.id));
     var dot = dotClass(ev.agency);
     var snippet = [ev.date, ev.region, ev.agency, ev.type].filter(Boolean).join(' · ');
     var scoreStr = (typeof score === 'number') ? score.toFixed(0) : '';
+    var pagesHTML = '';
+    if (pageHits && pageHits.length){
+      var shown = pageHits.slice(0, 4).map(function(h){
+        var snip = highlightSnippet(snippetAround(h.body || '', tokens || []), tokens || []);
+        var pg = (h.page != null) ? ('PAGE ' + String(h.page).padStart(3, '0')) : 'PAGE —';
+        return '<div class="ph"><span class="lab">' + esc(pg) + '</span>' + snip + '</div>';
+      }).join('');
+      var more = (pageHits.length > 4) ? '<div class="more">+ ' + (pageHits.length - 4) + ' more page' + (pageHits.length - 4 === 1 ? '' : 's') + '</div>' : '';
+      pagesHTML = '<div class="rc-pages">' + shown + more + '</div>';
+    }
     return '' +
       '<a class="rc" href="' + esc(href) + '">' +
         '<div class="top">' +
@@ -255,6 +342,7 @@
         badgesHTML(ev) +
         '<h3>' + esc(ev.title || ev.id) + '</h3>' +
         '<p>' + esc(snippet) + '</p>' +
+        pagesHTML +
         '<div class="bottom">' +
           '<span class="pg">' + esc((ev.agency || '—').toString().toUpperCase()) + '</span>' +
           '<span>' + esc(ev.date || ev.era || '') + '</span>' +
@@ -310,6 +398,34 @@
     var statSort   = document.getElementById('stat-sort');
     var browseHint = document.getElementById('browse-hint');
     var physicsPill= document.getElementById('filter-physics');
+    var idxStatus  = document.getElementById('idx-status');
+    var qqWrap     = document.getElementById('qq-wrap');
+    var qqList     = document.getElementById('qq-list');
+
+    // Module-level: the loaded MiniSearch instance (or null until ready).
+    var mini = null;
+    var eventById = {};
+    events.forEach(function(e){ eventById[e.id] = e; });
+
+    // Quick-query chips just fill the input.
+    if (qqList){
+      qqList.addEventListener('click', function(e){
+        if (e.target && e.target.classList.contains('qq')){
+          inp.value = e.target.textContent.trim();
+          render();
+          inp.focus();
+        }
+      });
+    }
+
+    // Kick the full-text index load. Render uses event-meta scoring meanwhile.
+    loadFullTextIndex().then(function(m){
+      mini = m;
+      if (idxStatus){ idxStatus.textContent = '· FULL-TEXT INDEX: 276 docs · fuzzy + prefix · ready'; idxStatus.classList.add('ready'); }
+      render();
+    }).catch(function(err){
+      if (idxStatus){ idxStatus.textContent = '· FULL-TEXT INDEX: ' + err.message + ' — falling back to event-meta search'; idxStatus.classList.add('error'); }
+    });
 
     function currentFilters(){
       return {
@@ -325,18 +441,57 @@
       var q = (inp.value || '').trim();
       var f = currentFilters();
       var base = applyFilters(events, f);
-      var out, isBrowse = false;
+      var allowed = {}; base.forEach(function(e){ allowed[e.id] = true; });
+      var out, isBrowse = false, pageHitsByEid = {};
+      var tokens = tokenize(q);
 
       if (!q){
         // BROWSE / SUGGESTED — top 12 by flag weight.
         isBrowse = true;
-        out = base.slice().sort(function(a, b){ return flagWeight(b.flag) - flagWeight(a.flag); }).slice(0, 12);
+        out = base.slice().sort(function(a, b){ return flagWeight(b.flag) - flagWeight(a.flag); }).slice(0, 12)
+          .map(function(ev){ return { ev: ev, score: null }; });
+      } else if (mini){
+        // FULL-TEXT — page-level hits via MiniSearch, grouped by event.
+        // boosts come from the field config (title 3, body 1), AND-combined,
+        // then we score-merge with the event-meta score so a strong title or
+        // tag/crossRef match outranks a one-page body hit on a junky event.
+        var raw = mini.search(q, { combineWith: 'AND' });
+        // Each raw hit is a page-doc; group by eventId.
+        var byEid = {};
+        var metaBoosted = {};
+        for (var i = 0; i < raw.length; i++){
+          var h = raw[i];
+          if (!allowed[h.eventId]) continue;
+          if (!byEid[h.eventId]){ byEid[h.eventId] = { ev: eventById[h.eventId], hits: [], topScore: 0 }; }
+          byEid[h.eventId].hits.push(h);
+          if (h.score > byEid[h.eventId].topScore) byEid[h.eventId].topScore = h.score;
+        }
+        out = Object.keys(byEid).map(function(eid){
+          var g = byEid[eid];
+          var metaScore = scoreEvent(g.ev, tokens);
+          // Combine: page-relevance + event-meta weight (sum), event-meta
+          // alone breaks ties from "only one fuzzy body hit" events.
+          var combined = g.topScore + (metaScore * 0.5) + (g.hits.length * 0.5);
+          metaBoosted[eid] = metaScore;
+          pageHitsByEid[eid] = g.hits;
+          return { ev: g.ev, score: combined };
+        });
+        // Add events with strong meta match but no body hits (e.g. id/tag/crossRef
+        // queries like "aawsa" — the literal string isn't in any page body).
+        for (var k = 0; k < base.length; k++){
+          var ev2 = base[k];
+          if (byEid[ev2.id]) continue;
+          var sMeta = scoreEvent(ev2, tokens);
+          if (sMeta >= 6){ out.push({ ev: ev2, score: sMeta }); }
+        }
+        out.sort(function(a, b){ return b.score - a.score; });
+        out = out.slice(0, 24);
       } else {
-        var tokens = tokenize(q);
+        // No index loaded yet — pure event-meta scoring (back-compat).
         var scored = [];
-        for (var i = 0; i < base.length; i++){
-          var s = scoreEvent(base[i], tokens);
-          if (s > 0) scored.push({ ev: base[i], score: s });
+        for (var i2 = 0; i2 < base.length; i2++){
+          var s = scoreEvent(base[i2], tokens);
+          if (s > 0) scored.push({ ev: base[i2], score: s });
         }
         scored.sort(function(a, b){ return b.score - a.score; });
         out = scored.slice(0, 24);
@@ -346,12 +501,17 @@
       var ms = Math.max(0, Math.round(t1 - t0));
 
       // Stats row.
-      statCount.textContent = out.length;
+      var pageCount = 0;
+      for (var pE in pageHitsByEid) pageCount += pageHitsByEid[pE].length;
+      statCount.textContent = out.length + (pageCount ? (' / ' + pageCount + ' pg') : '');
       statMs.textContent = ms;
-      statSort.textContent = isBrowse ? 'SORTED BY FLAG WEIGHT' : 'SORTED BY RELEVANCE';
+      statSort.textContent = isBrowse
+        ? 'SORTED BY FLAG WEIGHT'
+        : (mini ? 'PAGE-LEVEL · SORTED BY RELEVANCE' : 'EVENT-META · INDEX LOADING…');
 
-      // Browse hint vs. results.
+      // Browse hint + quick chips visible only on no-query.
       browseHint.style.display = isBrowse ? '' : 'none';
+      if (qqWrap) qqWrap.style.display = isBrowse ? '' : 'none';
 
       // Empty state — only when there's a query AND no hits.
       if (out.length === 0 && q){
@@ -363,10 +523,10 @@
 
       // Cap render at 24.
       var html = '';
-      var capped = out.slice(0, 24);
-      for (var j = 0; j < capped.length; j++){
-        var row = isBrowse ? { ev: capped[j], score: null } : capped[j];
-        html += cardHTML(row.ev, row.score, MC);
+      for (var j = 0; j < out.length; j++){
+        var row = out[j];
+        var hits = pageHitsByEid[row.ev.id] || null;
+        html += cardHTML(row.ev, row.score, MC, hits, tokens);
       }
       grid.innerHTML = html;
     }


### PR DESCRIPTION
## Summary

Brings the static `/mc/` surfaces up to React-app parity on the five views that were materially behind. Each surface is now a real working tool, not a styled mock.

| Surface | Before | After |
|---|---|---|
| **Search** | Event-meta only (title/id/agency/tags) | Real full-text via MiniSearch over `search-index.json` (276 page docs, 8.6MB), page-level results grouped by event with up to 4 highlighted snippets per card, hybrid scoring that combines body relevance with event-meta weight, fall-through for cross-ref-id queries (`aawsa`, `pantex`), 16 quick-query chips, falls back to event-meta if index 404s |
| **Media** | Inert filter pills, static grid | Multi-select kind filter pills, event dropdown, RECENT/POPULAR sort, placeholder toggle, inline text search, focus modal on click with full image / DVIDS iframe / metadata / dossier link |
| **Network** | Hardcoded SVG nodes | Real force-directed layout driven by `event-similarity.json` + `patterns.json`, three modes (SEMANTIC/PATTERNS/ALL), live MIN COSINE + ITERATIONS sliders, hover panel with top 6 neighbors, click → dossier |
| **Review** | Static demo diff | Click any queue row → real per-page graded extracts from `dossier-extracts.json` with flag tags + scores, merge textarea seeded with concatenated extracts, SUBMIT CTA prefills GitHub issue, **new GRADED EXAMPLES picker** in left rail (71 events) so reviewers can sample what graded text looks like even when the live queue is all uncatalogued |
| **Ask** | Hardcoded fake Q/A | Real PATTERN-mode intent classifier (port of `src/lib/askEngine.js`): agency / era / release / flag / priority / category filters with keyword-token fall-through over title/id/loc/tags/crossRefs; 8 suggested-query chips clickable; SMART mode surfaces a "requires local pursue-vision-mcp daemon" note |

## Why these were the right priorities

User explicitly called out Search; audit of `src/views/*.jsx` sizes confirmed Live, Media, Network, Review, Ask were the largest gaps. Semantic Search (`SemanticSearchView.jsx`, 867 lines) needs 25MB of MiniLM weights + transformers.js WASM and is intentionally left as "coming soon" in the existing UI — out of scope for the static surface.

## Vendor

- `public/mc/lib/minisearch.js` (78KB, MIT) — copied from `node_modules/minisearch/dist/es/index.js` so `/mc/` stays CDN-free at runtime.

## Test plan

Verified via Playwright against locally-served `public/`:

- [x] **Search**: index loads 276 docs in ~5s; `"borman"` returns 8 events / 9 pages with snippet highlights (BORMAN/Borman `<mark>`'d in Gemini-7 page 0); `"aawsa"` still returns DOE-UAP-D001 via cross-ref scoring; `"pantex"` returns 2 events / 4 pages with all 5 evidence badges on the top card
- [x] **Media**: 200 tiles rendered (capped), 9 kind pills, 134 events in dropdown; VIDEO filter drops to 106 tiles; click → modal with `dossier.html?eid=DOW-UAP-PR050`
- [x] **Network**: 67 event nodes / 443 semantic edges at cos≥0.55; raising to 0.75 → 44/199; hover populates detail panel with top 6 neighbors
- [x] **Review**: graded picker has 71 events; selecting `fbi-62hq83894` loads page-2 extracts with 3 graded sentences, merge textarea seeded with 428 chars
- [x] **Ask**: initial `"show me the physics-relevant events"` returns 5 events (first FBI-62HQ83894); `"NASA events"` returns 22 (first GEMINI-7); `"oak ridge"` returns 1 via keyword scoring
- [x] All inline JS parses on every modified file
- [ ] Verify in production after merge

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_