### PR TITLE
fix(mc/search): pin esm.sh transformers.js to 4.2.0 to match ORT WASM artefacts

### DIFF
--- a/public/mc/search.html
+++ b/public/mc/search.html
@@ -210,7 +210,13 @@
     if (_semanticLoading) return _semanticLoading;
     _semanticLoading = (async function(){
       meaningNote.textContent = '∿ Fetching MiniLM model from CDN…';
-      var trf = await import('https://esm.sh/@huggingface/transformers@3.0.2');
+      // Pin to the same major version used by the React app's bundled
+      // transformers.js (see package.json "@huggingface/transformers": "^4.2.0").
+      // The ORT WASM artefacts shipped in /ort/ (copied via
+      // scripts/copy-ort-assets.mjs from onnxruntime-web@1.26-dev) match the
+      // transformers.js v4 ABI — pinning a v3 here triggers a WebAssembly
+      // LinkError at instantiate time ("function import requires a callable").
+      var trf = await import('https://esm.sh/@huggingface/transformers@4.2.0');
       trf.env.allowLocalModels = false;
       trf.env.useBrowserCache = true;
       // Self-host of ORT WASM lives at /ort/ (scripts/copy-ort-assets.mjs).


### PR DESCRIPTION
## Summary

The deployed Semantic Search MEANING MATCH fails with:

```
∿ MEANING MATCH failed: no available backend found.
ERR: [wasm] RuntimeError: Aborted(LinkError:
WebAssembly.instantiate(): Import #80 "a" "Ba":
function import requires a callable). — falling back to EXACT
```

## Root cause

`public/mc/search.html` imports `@huggingface/transformers@3.0.2` from esm.sh, but:

| | Version |
|---|---|
| `package.json` pins | `@huggingface/transformers@^4.2.0` |
| `node_modules/onnxruntime-web` (used by ORT WASM copy script) | `1.26.0-dev` |
| `public/ort/*.wasm` (deployed) | matches v4.x ABI |
| my esm.sh import | **3.0.2** (mismatch) |

transformers.js v3 expects v1.20-era ORT WASM imports; the deployed v1.26 WASM exports a different surface → `LinkError` at instantiate.

## Fix

Pin the esm.sh import to `4.2.0` so the JS matches the WASM. One-line change in `public/mc/search.html`. The React app's `SemanticSearchView` already uses bundled 4.x and works correctly — this aligns `/mc/` with the same version.

## Test plan

- [x] Inline JS parses
- [ ] Verify in production after merge — MEANING MATCH should now load the model and run cosine queries

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_