### PR TITLE
fix(mc/search): qualify ORT wasmPaths to absolute URL so esm.sh-loaded transformers fetches /ort/ from our origin

### DIFF
--- a/public/mc/search.html
+++ b/public/mc/search.html
@@ -220,8 +220,16 @@
       trf.env.allowLocalModels = false;
       trf.env.useBrowserCache = true;
       // Self-host of ORT WASM lives at /ort/ (scripts/copy-ort-assets.mjs).
-      // From a /mc/ page, that's "../ort/".
-      trf.env.backends.onnx.wasm.wasmPaths = '../ort/';
+      // Because transformers.js is loaded from esm.sh (cross-origin), the
+      // ORT loader's internal `import.meta.url` resolves to esm.sh — any
+      // relative wasmPaths ("../ort/") it tries gets routed back to esm.sh
+      // and 404s the .mjs glue. Force a fully-qualified URL pointing at
+      // our own deployment instead. For /mc/search.html → strip "/mc/…"
+      // and append "/ort/". Works on rizzleroc.github.io/pursue-console/
+      // and on any local mirror.
+      var ortBase = window.location.origin +
+        window.location.pathname.replace(/\/mc\/[^/]*$/, '/ort/');
+      trf.env.backends.onnx.wasm.wasmPaths = ortBase;
       trf.env.backends.onnx.wasm.numThreads = 1;
       trf.env.backends.onnx.wasm.proxy = false;
       meaningNote.textContent = '∿ Loading model (int8)…';


### PR DESCRIPTION
## Summary

Production MEANING MATCH still failing after #275 — but with a different error now (verified live via MCP `whipgen_web_eval`):

```
∿ MEANING MATCH failed: no available backend found.
ERR: [wasm] TypeError: Failed to fetch dynamically imported module:
https://esm.sh/onnxruntime-web@1.26.0-dev.../ort/ort-wasm-simd-threaded.asyncify.mjs
```

## Root cause

`transformers.js` is imported from esm.sh (cross-origin). Its embedded `onnxruntime-web`'s `import.meta.url` points to esm.sh. The relative `wasmPaths = '../ort/'` I set gets URL-resolved against `esm.sh/...`, so ORT tries to fetch `.mjs` glue files from there — esm.sh doesn't host the matching artefacts and 404s.

## Fix

Compute a fully-qualified URL to our own deployment's `/ort/` before init:

```js
var ortBase = window.location.origin +
  window.location.pathname.replace(/\/mc\/[^/]*$/, '/ort/');
trf.env.backends.onnx.wasm.wasmPaths = ortBase;
```

For `/mc/search.html` on `rizzleroc.github.io/pursue-console/`, this becomes `https://rizzleroc.github.io/pursue-console/ort/` — same path the React app's `SemanticSearchView` uses successfully (because Vite bundles transformers.js into the app origin, so its relative paths already resolve to the deployment).

The `/ort/` directory already ships all 8 ORT WASM variants (`scripts/copy-ort-assets.mjs` runs in `npm build`): asyncify, jsep, jspi, plain — both `.wasm` and `.mjs` files for each.

## Test plan

- [x] Inline JS parses
- [x] MCP `whipgen_web_eval` on production confirmed the previous fix's WebAssembly LinkError is gone; only the path needed an absolute override
- [ ] Verify in production after merge — MEANING MATCH should now load the model and run cosine queries

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_