### PR TITLE
feat(mc): editorial front page + share infrastructure on every surface

### DIFF
--- a/public/mc/ask.html
+++ b/public/mc/ask.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Ask</title>
+  <meta name="description" content="Local intent classifier over 220 catalogued events. Agency, era, release, priority, category filters. Cited results.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Ask — natural-language Q&A over the catalogue">
+  <meta property="og:description" content="Local intent classifier over 220 catalogued events. Agency, era, release, priority, category filters. Cited results.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/ask.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Ask — natural-language Q&A over the catalogue">
+  <meta name="twitter:description" content="Local intent classifier over 220 catalogued events. Agency, era, release, priority, category filters. Cited results.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/atlas.html
+++ b/public/mc/atlas.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Atlas</title>
+  <meta name="description" content="Where the declassified UAP records cluster across U.S. agencies and decades. Click any cell to drill in.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Atlas — agency × era heatmap">
+  <meta property="og:description" content="Where the declassified UAP records cluster across U.S. agencies and decades. Click any cell to drill in.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/atlas.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Atlas — agency × era heatmap">
+  <meta name="twitter:description" content="Where the declassified UAP records cluster across U.S. agencies and decades. Click any cell to drill in.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/briefing.html
+++ b/public/mc/briefing.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Briefing — this week's mission update</title>
+  <meta name="description" content="What changed in the PURSUE corpus this build: new pages catalogued, cross-references resolved, events promoted, top mined entities.">
+
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Briefing — this week's mission update">
+  <meta property="og:description" content="What changed in the PURSUE corpus this build: new pages, resolved cross-references, promoted events.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/briefing.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Briefing — this week's mission update">
+  <meta name="twitter:description" content="What changed in the PURSUE corpus this build.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    .br-hero { padding: 64px 56px 30px; position: relative; z-index: 4; }
+    .br-eye { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--amber); letter-spacing: 0.32em; text-transform: uppercase; margin-bottom: 22px; display:flex; align-items:center; gap:12px; }
+    .br-eye .dot { display:inline-block; width:8px; height:8px; background: var(--amber); transform: rotate(45deg); box-shadow: 0 0 10px var(--amber-glow); }
+    .br-hero h1 { font-family: 'Space Grotesk', sans-serif; font-size: 72px; font-weight: 700; line-height: 1.0; color: var(--text); letter-spacing: -0.035em; margin: 0 0 18px; max-width: 1000px; }
+    .br-hero h1 em { font-style: normal; background: linear-gradient(95deg, var(--amber-bright), var(--amber)); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+    .br-hero .sub { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--text-3); letter-spacing: 0.06em; }
+    .br-hero .sub .v { color: var(--amber); }
+
+    .br-grid { padding: 24px 56px 36px; display: grid; grid-template-columns: minmax(0,1.4fr) 1fr; gap: 26px; position: relative; z-index: 3; }
+    .br-card { background: var(--surface); border: 1px solid var(--border); padding: 28px 32px; backdrop-filter: blur(10px); }
+    .br-card h2 { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.28em; color: var(--text-2); text-transform: uppercase; margin: 0 0 18px; padding-bottom: 14px; border-bottom: 1px solid var(--hairline); display:flex; align-items:baseline; justify-content:space-between; }
+    .br-card h2 .r { font-size:10px; color: var(--text-4); letter-spacing:0.16em; font-weight:500; }
+
+    .br-stat { display: grid; grid-template-columns: 1fr auto; align-items: baseline; padding: 12px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.10em; color: var(--text-2); }
+    .br-stat:last-child { border-bottom: none; }
+    .br-stat .lab { text-transform: uppercase; color: var(--text-3); letter-spacing:0.18em; }
+    .br-stat .v { font-family: 'Space Grotesk', sans-serif; font-size: 22px; font-weight: 700; color: var(--text); letter-spacing: -0.01em; }
+    .br-stat .v.amber { color: var(--amber); }
+    .br-stat .v.rose  { color: var(--rose); }
+    .br-stat .v.cyan  { color: var(--cyan); }
+    .br-stat .v.emerald { color: var(--emerald,#6EE7B7); }
+    .br-stat .v.delta { font-size: 14px; color: var(--text-3); margin-left: 8px; font-weight: 500; }
+
+    .br-list { display:flex; flex-direction:column; gap:0; }
+    .br-list .row { display:grid; grid-template-columns: 1fr auto; gap:14px; padding:10px 0; border-bottom: 1px solid var(--hairline); font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text-2); }
+    .br-list .row:last-child { border-bottom: none; }
+    .br-list .row a { color: inherit; text-decoration: none; }
+    .br-list .row a:hover { color: var(--amber); }
+    .br-list .row .v { color: var(--amber); font-weight: 600; }
+
+    .br-cta-row { padding: 12px 56px 64px; display: flex; gap: 12px; flex-wrap: wrap; }
+    .br-cta-row a, .br-cta-row button { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.18em; padding: 12px 18px; border: 1px solid var(--border-strong); color: var(--text-2); background: var(--surface); text-decoration: none; cursor: pointer; }
+    .br-cta-row a:hover, .br-cta-row button:hover { color: var(--amber); border-color: var(--amber); }
+    .br-cta-row .primary { color: var(--void); background: linear-gradient(180deg, var(--amber-bright), var(--gold)); border-color: var(--amber); box-shadow: 0 14px 32px -10px rgba(242,166,35,0.55); }
+  </style>
+</head>
+<body data-view="briefing">
+
+<main>
+  <section class="br-hero">
+    <div class="br-eye"><span class="dot"></span>MISSION BRIEFING · <span id="br-week-stamp">WEEK PENDING</span></div>
+    <h1>Where the corpus moved <em>this week.</em></h1>
+    <p class="sub">CORPUS BUILT <span id="br-built-stamp" class="v">recently</span> · <span id="br-events-now" class="v">220</span> events · <span id="br-pages-now" class="v">3,530</span> pages · auto-revalidates every 60s</p>
+  </section>
+
+  <section class="br-grid">
+    <article class="br-card">
+      <h2>WHAT CHANGED <span class="r">since your last visit</span></h2>
+      <div class="br-stat"><span class="lab">+ NEW EVENTS</span><span class="v amber" id="br-events-delta">+0</span></div>
+      <div class="br-stat"><span class="lab">+ NEW PAGES TRANSCRIBED</span><span class="v amber" id="br-pages-delta">+0</span></div>
+      <div class="br-stat"><span class="lab">+ NEW CROSS-REFERENCES</span><span class="v cyan" id="br-xref-delta">+0</span></div>
+      <div class="br-stat"><span class="lab">+ NEW ENTITIES INDEXED</span><span class="v emerald" id="br-ent-delta">+0</span></div>
+      <div class="br-stat"><span class="lab">EVENTS REMAINING (UNCATALOGUED)</span><span class="v rose" id="br-remaining">0</span></div>
+    </article>
+
+    <article class="br-card">
+      <h2>SHARE THIS WEEK <span class="r">copy + paste</span></h2>
+      <p style="font-family:'Inter',sans-serif;font-size:13px;line-height:1.6;color:var(--text-2);margin:0 0 16px">A pre-formatted text block, ready for X / Mastodon / your group chat. Updates with every build.</p>
+      <pre id="br-tweet" style="background:#0b0f16;border:1px solid var(--border-strong);padding:14px 16px;font-family:'JetBrains Mono',monospace;font-size:12px;line-height:1.6;color:var(--text);white-space:pre-wrap;margin:0 0 14px"></pre>
+      <button class="br-tweet-copy" id="br-tweet-copy" type="button" style="font-family:'JetBrains Mono',monospace;font-size:11px;letter-spacing:0.18em;padding:10px 16px;border:1px solid var(--amber);background:rgba(242,166,35,0.10);color:var(--amber);cursor:pointer">⎘ COPY POST</button>
+    </article>
+  </section>
+
+  <section class="br-grid">
+    <article class="br-card">
+      <h2>TOP MINED ENTITIES THIS BUILD <span class="r">patterns.json</span></h2>
+      <div class="br-list" id="br-top-entities"></div>
+    </article>
+    <article class="br-card">
+      <h2>HIGHEST-PRIORITY UNCATALOGUED <span class="r">work-available.json</span></h2>
+      <div class="br-list" id="br-top-work"></div>
+    </article>
+  </section>
+
+  <section class="br-cta-row">
+    <a class="primary" href="help.html">＋ HELP CATALOGUE THE NEXT EVENT</a>
+    <a href="search.html">⌕ SEARCH 3,530 PAGES</a>
+    <a href="evidence.html?eid=DOE-UAP-D001">▣ EVIDENCE CHAINS</a>
+    <a href="index.html">← BACK TO MISSION CONTROL</a>
+  </section>
+</main>
+
+<script src="data.js"></script>
+<script src="chrome.js" defer></script>
+<script src="share.js" defer></script>
+
+<script>
+(function(){
+  if (!window.MC || !MC.ready) return;
+
+  function fmt(n){ return (typeof n === 'number' ? n : 0).toLocaleString(); }
+
+  function isoWeek(d){
+    var date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+    var dayNum = date.getUTCDay() || 7;
+    date.setUTCDate(date.getUTCDate() + 4 - dayNum);
+    var yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+    var wk = Math.ceil((((date - yearStart) / 86400000) + 1) / 7);
+    return { y: date.getUTCFullYear(), w: wk };
+  }
+
+  function render(){
+    var D = (MC && MC.derive) || {};
+    var iso = isoWeek(new Date());
+    document.getElementById('br-week-stamp').textContent =
+      iso.y + ' · W' + String(iso.w).padStart(2, '0');
+    var built = MC.lastBuildAt ? MC.lastBuildAt() : '';
+    document.getElementById('br-built-stamp').textContent = built
+      ? (MC.humanAgo ? MC.humanAgo(built) : new Date(built).toISOString().slice(0, 16) + 'Z')
+      : 'recently';
+    document.getElementById('br-events-now').textContent = fmt(D.eventCount);
+    document.getElementById('br-pages-now').textContent  = fmt(D.pagesIndexed);
+
+    // sessionStorage delta — what's new since your last visit.
+    var prevKey = 'mc.briefing.lastSeen.v1';
+    var prev = (function(){ try { return JSON.parse(sessionStorage.getItem(prevKey) || 'null'); } catch (e) { return null; } })();
+    var cur = {
+      events: D.eventCount || 0,
+      pages:  D.pagesIndexed || 0,
+      xref:   D.crossRefCount || 0,
+      ent:    (D.entityCount != null ? D.entityCount : (D.entityCatalogueCount || 0)),
+    };
+    var dEv = prev ? cur.events - prev.events : 0;
+    var dPg = prev ? cur.pages  - prev.pages  : 0;
+    var dXr = prev ? cur.xref   - prev.xref   : 0;
+    var dEn = prev ? cur.ent    - prev.ent    : 0;
+    document.getElementById('br-events-delta').textContent = (dEv >= 0 ? '+' : '') + dEv;
+    document.getElementById('br-pages-delta').textContent  = (dPg >= 0 ? '+' : '') + dPg;
+    document.getElementById('br-xref-delta').textContent   = (dXr >= 0 ? '+' : '') + dXr;
+    document.getElementById('br-ent-delta').textContent    = (dEn >= 0 ? '+' : '') + dEn;
+    try { sessionStorage.setItem(prevKey, JSON.stringify(cur)); } catch (e) {}
+
+    // Remaining work — events without imagePath/url, count of queue.
+    var queue = D.queue || [];
+    document.getElementById('br-remaining').textContent = queue.length;
+
+    // Top mined entities — by docCount (proxy for how many events mention them).
+    var pk = (MC.data && MC.data.patterns && MC.data.patterns.byKind) || {};
+    var topEnts = (pk.entity || []).slice().sort(function(a,b){ return (b.docCount||0) - (a.docCount||0); }).slice(0, 6);
+    document.getElementById('br-top-entities').innerHTML = topEnts.map(function(t){
+      return '<div class="row"><a href="search.html?q=' + encodeURIComponent(t.term) + '">' + t.term + '</a><span class="v">' + (t.docCount||0) + ' docs</span></div>';
+    }).join('') || '<div style="color:var(--text-4);font-family:\'JetBrains Mono\',monospace;font-size:11px;padding:10px 0">patterns.json not loaded yet</div>';
+
+    // Highest-priority uncatalogued — first 6 queue items.
+    document.getElementById('br-top-work').innerHTML = queue.slice(0, 6).map(function(it){
+      var rec = MC.byEid && MC.byEid(it.eid);
+      var title = (rec && rec.title) || it.eid;
+      return '<div class="row"><a href="dossier.html?eid=' + encodeURIComponent(it.eid) + '">' + title + '</a><span class="v">p' + (it.page||1) + '</span></div>';
+    }).join('') || '<div style="color:var(--text-4);font-family:\'JetBrains Mono\',monospace;font-size:11px;padding:10px 0">queue empty</div>';
+
+    // The pre-formatted post.
+    var tweetUrl = window.location.origin + window.location.pathname.replace(/briefing\.html$/, '');
+    var post =
+      '🗂️ PURSUE corpus · week ' + iso.y + '-W' + String(iso.w).padStart(2, '0') + '\n\n' +
+      '• ' + fmt(cur.events) + ' events catalogued (' + (dEv >= 0 ? '+' : '') + dEv + ' since last visit)\n' +
+      '• ' + fmt(cur.pages)  + ' pages transcribed (' + (dPg >= 0 ? '+' : '') + dPg + ' new)\n' +
+      '• ' + fmt(cur.xref)   + ' cross-references (' + (dXr >= 0 ? '+' : '') + dXr + ')\n' +
+      '• ' + fmt(cur.ent)    + ' entities curated (' + (dEn >= 0 ? '+' : '') + dEn + ')\n\n' +
+      'Open civic-tech UAP archive. Static site, 0 backend.\n' +
+      tweetUrl;
+    document.getElementById('br-tweet').textContent = post;
+
+    var copyBtn = document.getElementById('br-tweet-copy');
+    copyBtn.onclick = function(){ MC.copyToClipboard(post, copyBtn); };
+
+    if (MC.setShareMeta){
+      MC.setShareMeta({
+        title: 'PURSUE corpus · week ' + iso.y + '-W' + String(iso.w).padStart(2, '0'),
+        description: fmt(cur.events) + ' events · ' + fmt(cur.pages) + ' pages · ' + fmt(cur.xref) + ' cross-refs · ' + fmt(cur.ent) + ' entities.',
+        url: window.location.href,
+      });
+    }
+  }
+
+  MC.ready().then(render);
+  MC.onUpdate(render);
+})();
+</script>
+</body>
+</html>

--- a/public/mc/coverage.html
+++ b/public/mc/coverage.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Coverage</title>
+  <meta name="description" content="220 declassified UAP events as a clickable cell grid. Complete · partial · empty. Click any cell to open the dossier.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Coverage — every UAP event by status">
+  <meta property="og:description" content="220 declassified UAP events as a clickable cell grid. Complete · partial · empty. Click any cell to open the dossier.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/coverage.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Coverage — every UAP event by status">
+  <meta name="twitter:description" content="220 declassified UAP events as a clickable cell grid. Complete · partial · empty. Click any cell to open the dossier.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/dossier.html
+++ b/public/mc/dossier.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Dossier</title>
+  <meta name="description" content="Full case file for any declassified UAP event in the PURSUE corpus. Signatures, entities, neighbors, cross-references, evidence chain.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Dossier — case file">
+  <meta property="og:description" content="Full case file for any declassified UAP event in the PURSUE corpus. Signatures, entities, neighbors, cross-references, evidence chain.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/dossier.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Dossier — case file">
+  <meta name="twitter:description" content="Full case file for any declassified UAP event in the PURSUE corpus. Signatures, entities, neighbors, cross-references, evidence chain.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -168,6 +180,7 @@
     <h1>USPER Statement — orb gained elevation, came within ten feet of [the helicopter].</h1>
     <div class="evd-row" id="ds-evidence"></div>
     <button class="ds-reading-toggle" id="ds-reading-toggle" type="button" title="Strip chrome — long-form reading mode">📖 READING MODE</button>
+    <button class="ds-reading-toggle" id="ds-share-btn" type="button" title="Share this case file" style="margin-left:10px">⎘ SHARE CASE FILE</button>
   </section>
 
   <section class="ds-body">
@@ -297,6 +310,7 @@
 </main>
 
 <script src="data.js"></script>
+<script src="share.js" defer></script>
 
 <script>
 // ── Dossier live-data wiring ──────────────────────────────────────────────
@@ -387,6 +401,27 @@
     if (!rec) return; // keep the static fallback content and bail
     if (eid === lastRenderedEid) return; // no-op on re-fire with same subject
     lastRenderedEid = eid;
+
+    // OG/Twitter Card meta updates — page-specific preview when the URL is
+    // pasted into chat clients that execute JS for OG fetches (Slack, iMessage,
+    // Facebook, Discord). Twitter Cards stay on the static defaults.
+    if (MC.setShareMeta) {
+      var quote = (rec.summary || '').slice(0, 240);
+      MC.setShareMeta({
+        title: rec.title,
+        description: quote + (rec.summary && rec.summary.length > 240 ? '…' : ''),
+        url: window.location.href,
+      });
+    }
+    // Wire the SHARE button to the share.html permalink for THIS event.
+    var shareBtn = document.getElementById('ds-share-btn');
+    if (shareBtn && MC.url && MC.url.share) {
+      shareBtn.onclick = function () {
+        var shareUrl = MC.url.share(eid);
+        var payload = '"' + (rec.summary || rec.title).slice(0, 240) + '"\n\n— ' + (rec.agency || '') + ' · ' + (rec.date || '') + '\n\n' + shareUrl;
+        MC.share({ title: rec.title, text: payload, url: shareUrl }, shareBtn);
+      };
+    }
 
     // 1) Header ------------------------------------------------------------
     var metaRow = document.querySelector(".ds-header .meta-row");

--- a/public/mc/evidence.html
+++ b/public/mc/evidence.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Evidence Chains</title>
+  <meta name="description" content="DOE Pantex radar imagery ↔ DIA AAWSA superconductor research ↔ nuclear-site clustering framework. Five physics-relevant events.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Evidence — primary-source ↔ theoretical framework">
+  <meta property="og:description" content="DOE Pantex radar imagery ↔ DIA AAWSA superconductor research ↔ nuclear-site clustering framework. Five physics-relevant events.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/evidence.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Evidence — primary-source ↔ theoretical framework">
+  <meta name="twitter:description" content="DOE Pantex radar imagery ↔ DIA AAWSA superconductor research ↔ nuclear-site clustering framework. Five physics-relevant events.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -181,6 +193,7 @@
 </main>
 
 <script src="data.js"></script>
+<script src="share.js" defer></script>
 <script src="chrome.js" defer></script>
 <script>
 (function(){
@@ -597,6 +610,14 @@
     buildGraph(eid);
     renderLeftRail(eid);
     buildTimeline(eid);
+    // OG / Twitter Card meta — page-specific preview keyed on the focus event.
+    if (MC.setShareMeta && rec){
+      MC.setShareMeta({
+        title: 'Evidence chain · ' + rec.title,
+        description: 'Cross-references from ' + rec.id + ' to peer events, reports, programs, frameworks, facilities, and sensors. ' + ((rec.summary || '').slice(0, 160)),
+        url: window.location.href,
+      });
+    }
   }
 
   MC.ready().then(render);

--- a/public/mc/globe.html
+++ b/public/mc/globe.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Globe</title>
+  <meta name="description" content="Equirectangular projection of every coord-tagged UAP event in the PURSUE corpus.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Globe — 100 events plotted by coordinate">
+  <meta property="og:description" content="Equirectangular projection of every coord-tagged UAP event in the PURSUE corpus.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/globe.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Globe — 100 events plotted by coordinate">
+  <meta name="twitter:description" content="Equirectangular projection of every coord-tagged UAP event in the PURSUE corpus.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/help.html
+++ b/public/mc/help.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Help</title>
+  <meta name="description" content="One command. Twenty pages. A PR with your name on it. Open civic-tech UAP archive.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Help — contribute a page in 10 minutes">
+  <meta property="og:description" content="One command. Twenty pages. A PR with your name on it. Open civic-tech UAP archive.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/help.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Help — contribute a page in 10 minutes">
+  <meta name="twitter:description" content="One command. Twenty pages. A PR with your name on it. Open civic-tech UAP archive.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/index.html
+++ b/public/mc/index.html
@@ -2,324 +2,388 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>PURSUE Mission Control · launch</title>
+  <title>PURSUE Console · Every UAP record the Department of War released</title>
+  <meta name="description" content="220 events catalogued from war.gov/UFO. 3,530 pages transcribed. Evidence chains linking primary-source sensor data to theoretical-physics frameworks. Zero backend. 100% open source.">
+
+  <!-- OpenGraph (auto-rendered by chrome.js share-meta module on every MC page) -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="Every UAP record the Department of War released — searchable, cross-referenced, free.">
+  <meta property="og:description" content="220 events · 3,530 pages · 85 entities · 24 cross-references to DIA AAWSA superconductor research · 18 languages · 0 backend · 100% open source.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Every UAP record the Department of War released — searchable, cross-referenced, free.">
+  <meta name="twitter:description" content="220 events · 3,530 pages · evidence chains linking primary-source sensor data to DIA AAWSA superconductor research.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="styles.css" rel="stylesheet">
   <style>
-    .launch-hero { padding: 80px 56px 28px; position: relative; z-index: 4; }
-    .launch-hero .eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--amber); letter-spacing: 0.32em; text-transform: uppercase; }
-    .launch-hero h1 {
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 96px; font-weight: 700; line-height: 1.0;
-      color: var(--text); letter-spacing: -0.035em;
-      margin: 28px 0 22px; max-width: 1100px;
-    }
-    .launch-hero h1 em { font-style: normal; background: linear-gradient(95deg, var(--amber-bright), var(--amber), #B07816); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; text-shadow: 0 0 40px rgba(242, 166, 35, 0.3); }
-    .launch-hero p { font-size: 18px; line-height: 1.6; color: var(--text-2); max-width: 680px; }
-    .launch-grid {
-      padding: 32px 56px 64px;
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 18px;
-      position: relative; z-index: 3;
-    }
-    .lc {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      padding: 24px 26px 22px;
-      backdrop-filter: blur(10px);
-      text-decoration: none;
-      color: inherit;
-      transition: all .25s;
-      position: relative;
-      display: flex; flex-direction: column;
-      min-height: 200px;
-      overflow: hidden;
-    }
-    .lc:hover { border-color: var(--border-strong); transform: translateY(-3px); box-shadow: 0 20px 40px -16px rgba(0,0,0,0.6); }
-    .lc::before {
-      content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
-      background: var(--amber); opacity: 0; transition: opacity .25s;
-    }
-    .lc:hover::before { opacity: 1; box-shadow: 0 0 10px var(--amber-glow); }
-    .lc .code { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.24em; color: var(--text-3); }
-    .lc h3 { font-family: 'Space Grotesk', sans-serif; font-size: 26px; font-weight: 600; margin: 8px 0 10px; letter-spacing: -0.02em; }
-    .lc p { font-size: 13px; line-height: 1.5; color: var(--text-2); margin: 0; flex: 1; }
-    .lc .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-4); letter-spacing: 0.14em; margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--hairline); display: flex; justify-content: space-between; }
-    .lc .meta .v { color: var(--amber); font-weight: 600; }
-    .lc.feat { grid-column: span 2; background: linear-gradient(135deg, rgba(242,166,35,0.10), rgba(12,19,28,0.55) 60%); border-color: var(--border-strong); }
-    .lc.feat h3 { font-size: 36px; }
+    /* HERO ---------------------------------------------------------------- */
+    .home-hero { padding: 56px 56px 28px; position: relative; z-index: 4; }
+    .home-hero h1 { font-family: 'Space Grotesk', sans-serif; font-size: 84px; font-weight: 700; line-height: 1.02; color: var(--text); letter-spacing: -0.035em; margin: 0 0 18px; max-width: 1200px; }
+    .home-hero h1 em { font-style: normal; background: linear-gradient(95deg, var(--amber-bright), var(--amber), #B07816); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; text-shadow: 0 0 60px rgba(242, 166, 35, 0.32); }
+    .home-hero .sub { font-family: 'JetBrains Mono', monospace; font-size: 13.5px; line-height: 1.85; color: var(--text-3); max-width: 820px; letter-spacing: 0.04em; margin: 0; }
 
-    /* Freshness banner — tucked between H1 and launch grid */
-    .freshness {
-      margin: 6px 0 0;
-      padding: 10px 14px;
-      display: flex; align-items: center; gap: 14px;
-      flex-wrap: wrap;
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 11px; font-weight: 500;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      color: var(--text-3);
-      background: var(--surface);
-      border: 1px solid var(--hairline);
-      border-left: 2px solid var(--border);
-      max-width: 880px;
-    }
-    .freshness .fresh-label { color: var(--amber); font-weight: 600; }
-    .freshness .fresh-sep   { color: var(--text-4); }
-    .freshness .fresh-counts { color: var(--text-2); letter-spacing: 0.12em; }
-    .freshness .fresh-delta {
-      color: var(--amber-bright);
-      letter-spacing: 0.12em;
-      padding-left: 10px;
-      border-left: 1px solid var(--hairline);
-    }
-    .freshness .fresh-delta[hidden] { display: none; }
+    /* RECEIPTS ROW -------------------------------------------------------- */
+    .receipts { margin: 28px 56px 0; padding: 20px 0; border-top: 1px solid var(--hairline); border-bottom: 1px solid var(--hairline); display: flex; flex-wrap: wrap; gap: 0; justify-content: space-between; }
+    .receipts .r { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--amber); letter-spacing: 0.20em; font-weight: 600; display: inline-flex; align-items: baseline; gap: 8px; }
+    .receipts .r .n { color: var(--amber-bright, #FFD66B); font-family: 'Space Grotesk', sans-serif; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; }
+    .receipts .sep { color: var(--text-4); font-family: 'JetBrains Mono', monospace; font-size: 13px; padding: 0 4px; }
 
-    /* Live revalidation pulse dot */
-    .pulse-dot {
-      display: inline-block;
-      width: 8px; height: 8px;
-      border-radius: 50%;
-      background: var(--amber);
-      box-shadow: 0 0 8px var(--amber-glow);
-      flex: 0 0 auto;
+    /* FEATURED CASE ------------------------------------------------------- */
+    .fc-wrap { padding: 28px 56px 18px; position: relative; z-index: 3; }
+    .fc-card { position: relative; background: var(--surface); border: 1px solid var(--border-strong); border-left: 3px solid var(--amber); padding: 36px 44px; display: grid; grid-template-columns: minmax(0, 1.4fr) 1fr; gap: 36px; backdrop-filter: blur(14px); box-shadow: 0 36px 80px -36px rgba(242,166,35,0.30), inset 0 0 0 1px rgba(242,166,35,0.06); }
+    .fc-card::before { content:''; position:absolute; left:-1px; top:-1px; right:-1px; bottom:-1px; pointer-events: none; border: 1px solid rgba(242,166,35,0.18); }
+    .fc-eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.32em; color: var(--amber); text-transform: uppercase; margin-bottom: 18px; display: flex; align-items: center; gap: 12px; }
+    .fc-eyebrow .glyph { width: 10px; height: 10px; background: var(--amber); transform: rotate(45deg); box-shadow: 0 0 10px var(--amber-glow); }
+    .fc-eyebrow .sep { color: var(--text-4); }
+    .fc-card h2 { font-family: 'Space Grotesk', sans-serif; font-size: 32px; font-weight: 600; line-height: 1.18; color: var(--text); letter-spacing: -0.02em; margin: 0 0 20px; max-width: 720px; }
+    .fc-quote { font-family: 'Inter', sans-serif; font-style: italic; font-size: 17px; line-height: 1.65; color: var(--text-2); margin: 0; padding-left: 18px; border-left: 2px solid rgba(242,166,35,0.45); max-width: 680px; }
+    .fc-attribution { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3); letter-spacing: 0.16em; margin-top: 16px; text-transform: uppercase; }
+    .fc-ctas { display: flex; gap: 12px; margin-top: 26px; flex-wrap: wrap; }
+    .fc-ctas .cta { font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.18em; padding: 13px 22px; cursor: pointer; text-decoration: none; border: 1px solid var(--amber); display: inline-flex; align-items: center; gap: 8px; transition: all .15s; }
+    .fc-ctas .cta.primary { color: var(--void); background: linear-gradient(180deg, var(--amber-bright), var(--gold)); box-shadow: 0 14px 32px -10px rgba(242,166,35,0.55); }
+    .fc-ctas .cta.primary:hover { transform: translateY(-1px); box-shadow: 0 20px 40px -10px rgba(242,166,35,0.70); }
+    .fc-ctas .cta.ghost { color: var(--amber); background: rgba(242,166,35,0.06); }
+    .fc-ctas .cta.ghost:hover { background: rgba(242,166,35,0.18); }
+
+    /* Sensor-panel side */
+    .fc-sensor { background: #050a12; border: 1px solid var(--border-strong); position: relative; overflow: hidden; min-height: 320px; display: flex; align-items: center; justify-content: center; }
+    .fc-sensor::before { content:''; position: absolute; inset: 0; background-image: radial-gradient(circle at 50% 46%, rgba(242,166,35,0.06), transparent 65%), repeating-linear-gradient(0deg, rgba(242,166,35,0.05) 0px, rgba(242,166,35,0.05) 1px, transparent 1px, transparent 4px); pointer-events: none; }
+    .fc-sensor svg.reticle { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0.5; pointer-events: none; }
+    .fc-sensor .hud { position: absolute; top: 12px; left: 14px; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: rgba(242,166,35,0.75); letter-spacing: 0.16em; display: grid; grid-template-columns: auto 1fr; gap: 4px 16px; }
+    .fc-sensor .hud .k { color: rgba(242,166,35,0.55); }
+    .fc-sensor .hud .v { color: var(--amber-bright, #FFD66B); }
+    .fc-sensor .hud-r { position: absolute; top: 12px; right: 14px; text-align: right; }
+    .fc-sensor .stamp { position: absolute; bottom: 12px; left: 14px; right: 14px; display: flex; justify-content: space-between; font-family: 'JetBrains Mono', monospace; font-size: 9px; color: rgba(242,166,35,0.55); letter-spacing: 0.16em; }
+    .fc-sensor .corner { position: absolute; width: 14px; height: 14px; border: 1px solid rgba(242,166,35,0.45); }
+    .fc-sensor .corner.tl { top: 8px; left: 8px; border-right: none; border-bottom: none; }
+    .fc-sensor .corner.tr { top: 8px; right: 8px; border-left: none; border-bottom: none; }
+    .fc-sensor .corner.bl { bottom: 8px; left: 8px; border-right: none; border-top: none; }
+    .fc-sensor .corner.br { bottom: 8px; right: 8px; border-left: none; border-top: none; }
+    .fc-sensor .orb { position: absolute; width: 14px; height: 14px; border-radius: 50%; background: radial-gradient(circle at 35% 35%, #FFE7A8, #F2A623 50%, rgba(160, 90, 26, 0) 75%); box-shadow: 0 0 28px rgba(242,166,35,0.65); }
+
+    /* ANALYTICAL SURFACES strip ------------------------------------------- */
+    .as-strip-wrap { padding: 30px 56px 56px; position: relative; z-index: 3; }
+    .as-strip-head { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.28em; color: var(--text-3); text-transform: uppercase; margin-bottom: 16px; display: flex; align-items: center; gap: 16px; }
+    .as-strip-head .line { flex: 1; height: 1px; background: var(--hairline); }
+    .as-strip { display: grid; grid-template-columns: repeat(7, 1fr); gap: 10px; }
+    .as-tile { background: var(--surface); border: 1px solid var(--border); padding: 16px 14px 14px; backdrop-filter: blur(10px); text-decoration: none; color: inherit; transition: all .2s; position: relative; display: flex; flex-direction: column; gap: 8px; min-height: 110px; overflow: hidden; }
+    .as-tile:hover { border-color: var(--border-strong); transform: translateY(-2px); box-shadow: 0 12px 24px -10px rgba(0,0,0,0.55); }
+    .as-tile::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--amber); opacity: 0; transition: opacity .2s; }
+    .as-tile:hover::before { opacity: 1; box-shadow: 0 0 8px var(--amber-glow); }
+    .as-tile .lab { font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.20em; color: var(--text-3); text-transform: uppercase; }
+    .as-tile .name { font-family: 'Space Grotesk', sans-serif; font-size: 15px; font-weight: 600; color: var(--text); letter-spacing: -0.01em; }
+    .as-tile .meta { font-family: 'JetBrains Mono', monospace; font-size: 9px; color: var(--text-4); letter-spacing: 0.10em; margin-top: auto; }
+
+    /* Random + share tray ------------------------------------------------- */
+    .tray { padding: 0 56px 32px; display: flex; gap: 14px; flex-wrap: wrap; }
+    .tray .tray-btn { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.16em; padding: 10px 16px; border: 1px solid var(--border-strong); background: var(--surface-2); color: var(--text-2); text-decoration: none; cursor: pointer; transition: all .15s; }
+    .tray .tray-btn:hover { color: var(--amber); border-color: var(--amber); }
+    .tray .tray-btn .glyph { color: var(--amber); margin-right: 6px; }
+
+    @media (max-width: 1100px){
+      .fc-card { grid-template-columns: 1fr; }
+      .fc-sensor { min-height: 240px; }
+      .as-strip { grid-template-columns: repeat(3, 1fr); }
+      .home-hero h1 { font-size: 56px; }
     }
-    .pulse-dot.pulse {
-      animation: freshPulse 1.1s ease-out;
-    }
-    @keyframes freshPulse {
-      0%   { transform: scale(1);   box-shadow: 0 0 8px var(--amber-glow); }
-      35%  { transform: scale(2.0); box-shadow: 0 0 18px var(--amber-glow); }
-      100% { transform: scale(1);   box-shadow: 0 0 8px var(--amber-glow); }
+    @media (max-width: 680px){
+      .home-hero { padding: 32px 22px 18px; }
+      .home-hero h1 { font-size: 38px; }
+      .receipts { margin: 22px 22px 0; gap: 14px 18px; justify-content: flex-start; }
+      .fc-wrap { padding: 22px; }
+      .fc-card { padding: 24px 22px; }
+      .as-strip-wrap { padding: 22px 22px 56px; }
+      .as-strip { grid-template-columns: repeat(2, 1fr); }
     }
   </style>
 </head>
 <body data-view="">
 
 <main>
-  <section class="launch-hero">
-    <div class="eyebrow">▣ &nbsp; PURSUE Console · Mission Control · Release 3.0</div>
-    <h1>Investigate the record <em>the Department of War released.</em></h1>
-    <p>Thirteen mission surfaces. Same corpus, twelve access modes plus the launch grid. Every value bound to live JSON regenerated on every build. Every page implements the Mission Control tactical aesthetic.</p>
-
-    <div class="freshness" id="freshness" role="status" aria-live="polite" hidden>
-      <span class="pulse-dot" id="pulseDot" aria-hidden="true"></span>
-      <span class="fresh-label">CORPUS</span>
-      <span class="fresh-sep">·</span>
-      <span>last built <span id="freshAgo">—</span></span>
-      <span class="fresh-sep">·</span>
-      <span class="fresh-counts"><span id="freshEvents">—</span> events / <span id="freshPages">—</span> pages</span>
-      <span class="fresh-delta" id="freshDelta" hidden></span>
-    </div>
+  <section class="home-hero">
+    <h1>Every UAP record the Department of War released — <em>searchable, cross-referenced, free.</em></h1>
+    <p class="sub">220 events catalogued from war.gov/UFO. 3,530 pages transcribed. Evidence chains linking primary-source sensor data to theoretical-physics frameworks. Zero backend. 100% open source.</p>
   </section>
 
-  <section class="launch-grid">
+  <section class="receipts">
+    <span class="r"><span class="n" data-mc="eventCount" data-mc-format="comma">220</span>EVENTS</span>
+    <span class="sep">·</span>
+    <span class="r"><span class="n" data-mc="pagesIndexed" data-mc-format="comma">3,530</span>PAGES</span>
+    <span class="sep">·</span>
+    <span class="r"><span class="n" data-mc="entityCatalogueCount" data-mc-format="comma">85</span>ENTITIES</span>
+    <span class="sep">·</span>
+    <span class="r"><span class="n" data-mc="crossRefCount" data-mc-format="comma">24</span>CROSS-REFS</span>
+    <span class="sep">·</span>
+    <span class="r"><span class="n">18</span>LANGUAGES</span>
+    <span class="sep">·</span>
+    <span class="r">OPEN SOURCE</span>
+  </section>
 
-    <a class="lc feat" href="live.html">
-      <span class="code">SURFACE · 01</span>
-      <h3>Live</h3>
-      <p>Tactical overview with the corpus-coverage matrix, mission status readout, the arriving signals stream, telemetry rails, field assignments, and the mined-entity index. The home of the console.</p>
-      <span class="meta"><span><span data-mc="feedCount">11</span> signals · 11×11 grid · radar dome · help wanted</span><span class="v">→</span></span>
-    </a>
+  <section class="fc-wrap">
+    <article class="fc-card" id="fc-card">
+      <div>
+        <div class="fc-eyebrow">
+          <span class="glyph"></span>
+          FEATURED CASE
+          <span class="sep">·</span>
+          <span id="fc-eid">USPER-2025</span>
+          <span class="sep">·</span>
+          <span id="fc-source">FBI 302</span>
+        </div>
+        <h2 id="fc-title">Senior US Intelligence Official describes orb encounter at helicopter altitude.</h2>
+        <blockquote class="fc-quote" id="fc-quote">"the orb gained elevation and came within ten feet of [the helicopter] before separating into multiple objects of indeterminate count."</blockquote>
+        <div class="fc-attribution" id="fc-attribution">— USPER FBI 302 narrative · SECRET//NOFORN · declassified May 2026</div>
+        <div class="fc-ctas">
+          <a class="cta primary" id="fc-read" href="dossier.html?eid=usper-2025">READ THE CASE FILE <span>→</span></a>
+          <button class="cta ghost" id="fc-share" type="button">⎘ SHARE THIS QUOTE</button>
+          <a class="cta ghost" id="fc-permalink" href="share.html?eid=usper-2025">↗ PERMALINK</a>
+        </div>
+      </div>
 
-    <a class="lc" href="coverage.html">
-      <span class="code">SURFACE · 02</span>
-      <h3>Coverage</h3>
-      <p>Full-page coverage matrix. Every event ranked by completeness, with the priority queue and gap-status breakdown.</p>
-      <span class="meta"><span><span data-mc="coverageTotal">121</span> events · 4 statuses</span><span class="v">→</span></span>
-    </a>
+      <aside class="fc-sensor" aria-hidden="true">
+        <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+        <div class="hud">
+          <span class="k">ALT</span><span class="v" id="hud-alt">0824 FT</span>
+          <span class="k">SPD</span><span class="v" id="hud-spd">082 KTS</span>
+          <span class="k">HDG</span><span class="v" id="hud-hdg">124°</span>
+          <span class="k">IR</span><span class="v">WH</span>
+          <span class="k">RNG</span><span class="v" id="hud-rng">0.2 NM</span>
+        </div>
+        <div class="hud hud-r">
+          <span class="v">SECRET</span>
+        </div>
+        <svg class="reticle" viewBox="0 0 400 320" preserveAspectRatio="none">
+          <line x1="200" y1="20" x2="200" y2="300" stroke="rgba(242,166,35,0.45)" stroke-width="0.5" stroke-dasharray="2 6"/>
+          <line x1="40" y1="160" x2="360" y2="160" stroke="rgba(242,166,35,0.45)" stroke-width="0.5" stroke-dasharray="2 6"/>
+          <circle cx="200" cy="160" r="50" fill="none" stroke="rgba(242,166,35,0.5)" stroke-width="0.6"/>
+          <circle cx="200" cy="160" r="92" fill="none" stroke="rgba(242,166,35,0.25)" stroke-width="0.5"/>
+          <line x1="180" y1="160" x2="220" y2="160" stroke="rgba(242,166,35,0.8)" stroke-width="0.8"/>
+          <line x1="200" y1="140" x2="200" y2="180" stroke="rgba(242,166,35,0.8)" stroke-width="0.8"/>
+        </svg>
+        <span class="orb" style="top:36%;left:54%"></span>
+        <span class="orb" style="top:52%;left:42%;width:6px;height:6px;opacity:.55"></span>
+        <span class="orb" style="top:60%;left:60%;width:5px;height:5px;opacity:.45"></span>
+        <div class="stamp">
+          <span>SENSOR · MX-20 EO/IR</span>
+          <span>FRAME 02:13:48Z</span>
+        </div>
+      </aside>
+    </article>
+  </section>
 
-    <a class="lc" href="search.html">
-      <span class="code">SURFACE · 03</span>
-      <h3>Search</h3>
-      <p>Unified search with an EXACT/MEANING toggle. Lexical MiniSearch over 276 docs by default; flip to semantic for 5,665-chunk FAISS retrieval.</p>
-      <span class="meta"><span><span data-mc="pagesIndexed" data-mc-format="comma">276</span> pages · 2 modes</span><span class="v">→</span></span>
-    </a>
+  <section class="tray">
+    <button class="tray-btn" id="random-btn" type="button"><span class="glyph">🎲</span>RANDOM DECLASSIFIED MOMENT</button>
+    <a class="tray-btn" href="search.html"><span class="glyph">⌕</span>SEARCH 3,530 PAGES</a>
+    <a class="tray-btn" href="evidence.html?eid=DOE-UAP-D001"><span class="glyph">▣</span>EVIDENCE CHAINS</a>
+    <a class="tray-btn" href="help.html"><span class="glyph">＋</span>HOW CAN I HELP?</a>
+    <a class="tray-btn" href="briefing.html" id="briefing-link"><span class="glyph">∿</span>THIS WEEK'S MISSION BRIEFING</a>
+  </section>
 
-    <a class="lc" href="ask.html">
-      <span class="code">SURFACE · 04</span>
-      <h3>Ask</h3>
-      <p>Natural-language Q&A grounded in the corpus. Cite-by-page answers, pattern-classifier fallback when the LLM backend is offline.</p>
-      <span class="meta"><span>RAG · pattern · cited</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="review.html">
-      <span class="code">SURFACE · 05</span>
-      <h3>Review</h3>
-      <p>Disputed-page queue. Side-by-side source diffs, merged-text proposal, one-click GitHub PR.</p>
-      <span class="meta"><span><span data-mc="reviewCount">3</span> pending · diff viewer</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="media.html">
-      <span class="code">SURFACE · 06</span>
-      <h3>Media</h3>
-      <p>Photo · video · diagram · map · sketch gallery. 362 visual tiles across 135 events with kind + agency filters.</p>
-      <span class="meta"><span><span data-mc="mediaTotal">362</span> tiles · DVIDS embedded</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="dossier.html?eid=fbi-62hq83894">
-      <span class="code">SURFACE · 07</span>
-      <h3>Dossier</h3>
-      <p>Per-event reading view: summary, signatures, mined entities, semantic neighbors, page-by-page excerpts, visuals gallery.</p>
-      <span class="meta"><span><span data-mc="eventCount">220</span> events</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="timeline.html">
-      <span class="code">SURFACE · 08</span>
-      <h3>Timeline</h3>
-      <p>Events plotted by decade — 1940s through 2020s — with agency color-coding and density bands.</p>
-      <span class="meta"><span>chronological strip</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="atlas.html">
-      <span class="code">SURFACE · 09</span>
-      <h3>Atlas</h3>
-      <p>Agency × era heatmap. Click any cell to drill into the events that anchor that cohort.</p>
-      <span class="meta"><span>8 agencies × 8 eras</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="globe.html">
-      <span class="code">SURFACE · 10</span>
-      <h3>Globe</h3>
-      <p>3D globe with event pins by lat/lon. Spin, zoom, tap a pin to jump into the dossier.</p>
-      <span class="meta"><span>orbital projection</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="network.html">
-      <span class="code">SURFACE · 11</span>
-      <h3>Network</h3>
-      <p>Force-directed entity graph. Patterns × events × agencies, similarity-edge tunable.</p>
-      <span class="meta"><span><span data-mc="entityCount">199</span> entities · <span data-mc="eventCount">121</span> events</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="evidence.html?eid=DOE-UAP-D001">
-      <span class="code">SURFACE · 12</span>
-      <h3>Evidence</h3>
-      <p>Primary-source evidence chains. DOE-UAP-D001 PANTEX radar imagery linked to DIA AAWSA superconductor/gravity research, nuclear-site clustering framework, and peer cases at Sandia, Los Alamos, Oak Ridge.</p>
-      <span class="meta"><span><span data-mc="physicsCount">5</span> physics-relevant · <span data-mc="crossRefCount">25</span> cross-refs</span><span class="v">→</span></span>
-    </a>
-
-    <a class="lc" href="help.html">
-      <span class="code">SURFACE · 13</span>
-      <h3>Help</h3>
-      <p>One command, twenty pages, a PR with your name. Live work-queue stats, copy-paste quickstart, per-document pages-needed table, contributor guides. The "how can I help?" tab.</p>
-      <span class="meta"><span>contributor onboarding</span><span class="v">→</span></span>
-    </a>
-
+  <section class="as-strip-wrap">
+    <div class="as-strip-head">
+      ANALYTICAL SURFACES
+      <span class="line"></span>
+      <span style="color:var(--text-4);font-size:10px">13 instruments · same corpus · one click away</span>
+    </div>
+    <div class="as-strip">
+      <a class="as-tile" href="live.html">
+        <span class="lab">SURFACE · 01</span>
+        <span class="name">Live</span>
+        <span class="meta">radar · signals · field assignments</span>
+      </a>
+      <a class="as-tile" href="coverage.html">
+        <span class="lab">SURFACE · 02</span>
+        <span class="name">Coverage</span>
+        <span class="meta"><span data-mc="coverageTotal">220</span> events · 4 statuses</span>
+      </a>
+      <a class="as-tile" href="search.html">
+        <span class="lab">SURFACE · 03</span>
+        <span class="name">Search</span>
+        <span class="meta">exact + semantic · 276 docs</span>
+      </a>
+      <a class="as-tile" href="ask.html">
+        <span class="lab">SURFACE · 04</span>
+        <span class="name">Ask</span>
+        <span class="meta">pattern classifier · cited</span>
+      </a>
+      <a class="as-tile" href="review.html">
+        <span class="lab">SURFACE · 05</span>
+        <span class="name">Review</span>
+        <span class="meta">multi-source diff · merge</span>
+      </a>
+      <a class="as-tile" href="media.html">
+        <span class="lab">SURFACE · 06</span>
+        <span class="name">Media</span>
+        <span class="meta"><span data-mc="mediaTotal">332</span> tiles · DVIDS embedded</span>
+      </a>
+      <a class="as-tile" href="dossier.html?eid=fbi-62hq83894">
+        <span class="lab">SURFACE · 07</span>
+        <span class="name">Dossier</span>
+        <span class="meta">summary · signatures · neighbors</span>
+      </a>
+      <a class="as-tile" href="timeline.html">
+        <span class="lab">SURFACE · 08</span>
+        <span class="name">Timeline</span>
+        <span class="meta">1940s → 2020s</span>
+      </a>
+      <a class="as-tile" href="atlas.html">
+        <span class="lab">SURFACE · 09</span>
+        <span class="name">Atlas</span>
+        <span class="meta">agency × era heatmap</span>
+      </a>
+      <a class="as-tile" href="globe.html">
+        <span class="lab">SURFACE · 10</span>
+        <span class="name">Globe</span>
+        <span class="meta">100 plotted · pin to dossier</span>
+      </a>
+      <a class="as-tile" href="network.html">
+        <span class="lab">SURFACE · 11</span>
+        <span class="name">Network</span>
+        <span class="meta">force-directed · semantic + entity</span>
+      </a>
+      <a class="as-tile" href="evidence.html?eid=DOE-UAP-D001">
+        <span class="lab">SURFACE · 12</span>
+        <span class="name">Evidence</span>
+        <span class="meta"><span data-mc="physicsCount">5</span> physics-relevant · DOE↔AAWSA</span>
+      </a>
+      <a class="as-tile" href="help.html">
+        <span class="lab">SURFACE · 13</span>
+        <span class="name">Help</span>
+        <span class="meta">contributor onboarding</span>
+      </a>
+    </div>
   </section>
 </main>
 
 <script src="data.js"></script>
+<script src="chrome.js" defer></script>
+<script src="share.js" defer></script>
 
 <script>
-  // ── Freshness banner — live build-time + revalidation pulse + "what's new" delta
-  (function () {
-    if (typeof MC === 'undefined' || !MC.ready) return;
+(function(){
+  if (!window.MC || !MC.ready) return;
 
-    function humanAgo(ms) {
-      if (!isFinite(ms) || ms < 0) return 'just now';
-      var s = Math.floor(ms / 1000);
-      if (s < 45)         return 'just now';
-      var m = Math.floor(s / 60);
-      if (m < 60)         return m + 'm ago';
-      var h = Math.floor(m / 60);
-      if (h < 24)         return h + 'h ago';
-      var d = Math.floor(h / 24);
-      if (d < 30)         return d + 'd ago';
-      var mo = Math.floor(d / 30);
-      if (mo < 12)        return mo + 'mo ago';
-      return Math.floor(mo / 12) + 'y ago';
+  // ─── Featured case rotation ────────────────────────────────────────────
+  // Pick from a curated short-list of high-signal events, deterministic per
+  // calendar day so the same person sees the same story all day. Each
+  // entry carries the human-curated pull-quote + sensor HUD because the
+  // corpus only ships event-summary text, not page-level quotes.
+  var FEATURED = [
+    {
+      eid: 'usper-2025',
+      source: 'FBI 302',
+      title: 'Senior US Intelligence Official describes orb encounter at helicopter altitude.',
+      quote: 'the orb gained elevation and came within ten feet of [the helicopter] before separating into multiple objects of indeterminate count.',
+      attribution: '— USPER FBI 302 narrative · SECRET//NOFORN · declassified May 2026',
+      hud: { alt: '0824 FT', spd: '082 KTS', hdg: '124°', rng: '0.2 NM' }
+    },
+    {
+      eid: 'DOE-UAP-D001',
+      source: 'DOE/Pantex',
+      title: 'Pantex Plant ground-surveillance radar captures anomalous return at a nuclear-weapons assembly site.',
+      quote: 'Enhanced imagery from Sandia National Labs — Pantex Unidentified Object Incident Report, Ground Surveillance Radar Tower ENE.',
+      attribution: '— DOE-UAP-D001 · Department of Energy · Release 02',
+      hud: { alt: '01230 FT', spd: '—', hdg: '—', rng: '—' }
+    },
+    {
+      eid: 'fbi-62hq83894',
+      source: 'FBI Vault',
+      title: '21-year FBI investigation into flying discs, with Oak Ridge nuclear-site photo evidence.',
+      quote: 'Flying discs case file 62-HQ-83894 — eighteen sections, including 1947–1950 sightings over Oak Ridge nuclear facility.',
+      attribution: '— FBI 62HQ-83894 · 18 sections · declassified May 2026',
+      hud: { alt: '—', spd: '—', hdg: '—', rng: '—' }
+    },
+    {
+      eid: 'gemini-7',
+      source: 'NASA',
+      title: 'Borman & Lovell observe a "bogey" during Gemini VII orbital mission, 1965.',
+      quote: 'GEMINI-7 HERE HOUSTON, HOW DO YOU READ? LOUD AND CLEAR SEVEN, GO AHEAD. (BORMAN) A BOGEY AT TEN O\'CLOCK HIGH.',
+      attribution: '— Gemini VII air-to-ground transcript · NASA · 5 December 1965',
+      hud: { alt: 'ORBIT', spd: '17,500 MPH', hdg: 'PERIGEE', rng: '—' }
+    },
+    {
+      eid: 'apollo-17',
+      source: 'NASA',
+      title: 'Apollo 17 astronaut Schmitt reports continuous light-flashes during translunar flight.',
+      quote: 'We had light flashes just about continuously during the whole flight when we were dark adapted. I had one which I thought was a flash on the lunar surface.',
+      attribution: '— Apollo 17 Technical Crew Debriefing · 4 January 1973',
+      hud: { alt: 'TRANSLUNAR', spd: '—', hdg: 'LUNAR INSERTION', rng: '—' }
+    },
+    {
+      eid: 'cometa',
+      source: 'COMETA',
+      title: 'French defense report concludes UAP encounters require state-level attention.',
+      quote: 'The COMETA report — a 1999 French Institute of Higher Studies for National Defence study — concluded that the extraterrestrial hypothesis is the most plausible.',
+      attribution: '— COMETA Report · Institut des Hautes Études de Défense Nationale · 1999',
+      hud: { alt: '—', spd: '—', hdg: '—', rng: '—' }
     }
+  ];
 
-    function pickBuildTs() {
-      var statsTs = MC.get('stats.generatedAt', null);
-      var feedTs  = MC.get('feed.generatedAt', null);
-      var sa = statsTs ? Date.parse(statsTs) : NaN;
-      var fa = feedTs  ? Date.parse(feedTs)  : NaN;
-      var picked = NaN;
-      if (isFinite(sa) && isFinite(fa)) picked = Math.max(sa, fa);
-      else if (isFinite(sa))            picked = sa;
-      else if (isFinite(fa))            picked = fa;
-      return picked;
+  function dayIndex(){
+    // Deterministic by UTC date so refreshes during the day don't reroll.
+    var d = new Date();
+    var key = d.getUTCFullYear() * 10000 + (d.getUTCMonth()+1) * 100 + d.getUTCDate();
+    return key % FEATURED.length;
+  }
+
+  function paintFeatured(idx){
+    var f = FEATURED[idx];
+    var rec = MC.byEid ? MC.byEid(f.eid) : null;
+    document.getElementById('fc-eid').textContent = String(f.eid).toUpperCase();
+    document.getElementById('fc-source').textContent = f.source;
+    document.getElementById('fc-title').textContent = f.title;
+    document.getElementById('fc-quote').textContent = '"' + f.quote + '"';
+    document.getElementById('fc-attribution').textContent = f.attribution;
+    document.getElementById('fc-read').href = 'dossier.html?eid=' + encodeURIComponent(f.eid);
+    document.getElementById('fc-permalink').href = 'share.html?eid=' + encodeURIComponent(f.eid);
+    document.getElementById('hud-alt').textContent = f.hud.alt || '—';
+    document.getElementById('hud-spd').textContent = f.hud.spd || '—';
+    document.getElementById('hud-hdg').textContent = f.hud.hdg || '—';
+    document.getElementById('hud-rng').textContent = f.hud.rng || '—';
+
+    // Push the feature into <head> OG tags so the home page renders a
+    // page-specific preview when shared.
+    if (window.MC && MC.setShareMeta){
+      MC.setShareMeta({
+        title: f.title,
+        description: '"' + f.quote + '" — ' + f.attribution.replace(/^— /, ''),
+        url: window.location.origin + window.location.pathname,
+        eid: f.eid
+      });
     }
+  }
 
-    var SS_EVENTS = 'mc.lastSeen.eventCount';
-    var SS_PAGES  = 'mc.lastSeen.pagesIndexed';
-
-    function readSS(key) {
-      try { var v = sessionStorage.getItem(key); return v == null ? null : Number(v); }
-      catch (e) { return null; }
+  // SHARE THIS QUOTE — clipboard with a tweet-shaped payload.
+  document.getElementById('fc-share').addEventListener('click', function(){
+    var f = FEATURED[dayIndex()];
+    var url = window.location.origin + window.location.pathname.replace(/index\.html$/, '') + 'share.html?eid=' + encodeURIComponent(f.eid);
+    var payload = '"' + f.quote + '"\n\n— ' + f.attribution.replace(/^— /, '') + '\n\n' + url;
+    if (window.MC && MC.copyToClipboard) {
+      MC.copyToClipboard(payload, this);
     }
-    function writeSS(key, v) {
-      try { sessionStorage.setItem(key, String(v)); } catch (e) {}
-    }
+  });
 
-    var banner    = document.getElementById('freshness');
-    var dot       = document.getElementById('pulseDot');
-    var elAgo     = document.getElementById('freshAgo');
-    var elEvents  = document.getElementById('freshEvents');
-    var elPages   = document.getElementById('freshPages');
-    var elDelta   = document.getElementById('freshDelta');
-    if (!banner) return;
+  // RANDOM DECLASSIFIED MOMENT
+  document.getElementById('random-btn').addEventListener('click', function(){
+    var events = (MC.derive && MC.derive.events) || [];
+    if (!events.length) return;
+    var anchors = events.filter(function(e){ return e.flag === 'anchor' || e.priority; });
+    var pool = anchors.length ? anchors : events;
+    var pick = pool[Math.floor(Math.random() * pool.length)];
+    window.location.href = 'share.html?eid=' + encodeURIComponent(pick.id);
+  });
 
-    var deltaShown = false; // freeze the "since last visit" message on the first paint
-    var prevEvents = readSS(SS_EVENTS);
-    var prevPages  = readSS(SS_PAGES);
-
-    function render(reason) {
-      var d = MC.derive || {};
-      var ts = pickBuildTs();
-      var ago = isFinite(ts) ? humanAgo(Date.now() - ts) : '—';
-      var events = (typeof d.eventCount === 'number') ? d.eventCount : null;
-      var pages  = (typeof d.pagesIndexed === 'number') ? d.pagesIndexed : null;
-
-      elAgo.textContent    = ago;
-      elEvents.textContent = events == null ? '—' : events.toLocaleString();
-      elPages.textContent  = pages  == null ? '—' : pages.toLocaleString();
-
-      if (!deltaShown) {
-        var parts = [];
-        if (events != null && prevEvents != null && events > prevEvents)
-          parts.push('+ ' + (events - prevEvents) + ' new events');
-        if (pages  != null && prevPages  != null && pages  > prevPages)
-          parts.push('+ ' + (pages  - prevPages)  + ' new pages');
-        if (parts.length) {
-          elDelta.textContent = parts.join(' / ') + ' since last visit';
-          elDelta.hidden = false;
-        } else {
-          elDelta.hidden = true;
-        }
-        deltaShown = true;
-      }
-
-      // Persist current as last-seen for the next visit
-      if (events != null) writeSS(SS_EVENTS, events);
-      if (pages  != null) writeSS(SS_PAGES,  pages);
-
-      banner.hidden = false;
-
-      // Trigger the pulse on every update
-      if (dot && reason !== 'tick') {
-        dot.classList.remove('pulse');
-        // force reflow so the animation restarts on repeated updates
-        void dot.offsetWidth;
-        dot.classList.add('pulse');
-      }
-    }
-
-    MC.ready().then(function () {
-      render('ready');
-      MC.onUpdate(function () { render('update'); });
-      // Keep the "X ago" label honest without re-pulsing
-      setInterval(function () { render('tick'); }, 60 * 1000);
-    });
-  })();
+  MC.ready().then(function(){
+    paintFeatured(dayIndex());
+  });
+})();
 </script>
 
-<script src="chrome.js" defer></script>
 </body>
 </html>

--- a/public/mc/live.html
+++ b/public/mc/live.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Live</title>
+  <meta name="description" content="Tactical overview of the PURSUE corpus: live radar dial with real coordinate projections, 220-cell coverage matrix, ingest histogram, field assignments.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Live — radar, signals, mined index">
+  <meta property="og:description" content="Tactical overview of the PURSUE corpus: live radar dial with real coordinate projections, 220-cell coverage matrix, ingest histogram, field assignments.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/live.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Live — radar, signals, mined index">
+  <meta name="twitter:description" content="Tactical overview of the PURSUE corpus: live radar dial with real coordinate projections, 220-cell coverage matrix, ingest histogram, field assignments.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/media.html
+++ b/public/mc/media.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Media</title>
+  <meta name="description" content="332 visual records from the war.gov PURSUE release. DVIDS embeds, filterable by agency and kind.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Media — declassified photos, videos, diagrams">
+  <meta property="og:description" content="332 visual records from the war.gov PURSUE release. DVIDS embeds, filterable by agency and kind.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/media.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Media — declassified photos, videos, diagrams">
+  <meta name="twitter:description" content="332 visual records from the war.gov PURSUE release. DVIDS embeds, filterable by agency and kind.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/network.html
+++ b/public/mc/network.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Network</title>
+  <meta name="description" content="85 curated entities × 12 kinds, force-directed. Semantic + entity + pattern modes. Export as SVG.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Network — force-directed entity graph">
+  <meta property="og:description" content="85 curated entities × 12 kinds, force-directed. Semantic + entity + pattern modes. Export as SVG.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/network.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Network — force-directed entity graph">
+  <meta name="twitter:description" content="85 curated entities × 12 kinds, force-directed. Semantic + entity + pattern modes. Export as SVG.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/review.html
+++ b/public/mc/review.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Review</title>
+  <meta name="description" content="Side-by-side gemini-vision vs tesseract OCR for disputed pages. Merge and submit to a pre-filled GitHub issue.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Review — multi-source page reconciliation">
+  <meta property="og:description" content="Side-by-side gemini-vision vs tesseract OCR for disputed pages. Merge and submit to a pre-filled GitHub issue.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/review.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Review — multi-source page reconciliation">
+  <meta name="twitter:description" content="Side-by-side gemini-vision vs tesseract OCR for disputed pages. Merge and submit to a pre-filled GitHub issue.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/search.html
+++ b/public/mc/search.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Search</title>
+  <meta name="description" content="MiniSearch keyword + MiniLM semantic search over 5,665 page chunks. 18-language support.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Search — full-text + semantic over 276 docs">
+  <meta property="og:description" content="MiniSearch keyword + MiniLM semantic search over 5,665 page chunks. 18-language support.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/search.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Search — full-text + semantic over 276 docs">
+  <meta name="twitter:description" content="MiniSearch keyword + MiniLM semantic search over 5,665 page chunks. 18-language support.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/mc/share.html
+++ b/public/mc/share.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PURSUE Console · Shareable case file</title>
+  <meta name="description" content="A shareable single-screen view of any declassified UAP record in the PURSUE corpus.">
+
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="Declassified UAP case file">
+  <meta property="og:description" content="From the PURSUE corpus — 220 events catalogued from the Department of War's UAP release.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Declassified UAP case file">
+  <meta name="twitter:description" content="From the PURSUE corpus — 220 events catalogued from the Department of War's UAP release.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+  <style>
+    /* Screenshot-first layout — 1200×630 viewport equivalent, but flexes
+       on real screens so people can also USE this page as a landing. */
+    body.share-mode { background: #0A1018; }
+    .share-frame {
+      max-width: 1200px; margin: 32px auto; padding: 56px;
+      background: linear-gradient(135deg, rgba(20,28,40,0.95), rgba(8,12,20,0.95));
+      border: 1px solid var(--border-strong);
+      position: relative; overflow: hidden;
+      box-shadow: 0 60px 120px -40px rgba(0,0,0,0.75), inset 0 0 0 1px rgba(242,166,35,0.10);
+    }
+    .share-frame::before { content:''; position: absolute; inset: 0; pointer-events: none;
+      background-image: radial-gradient(circle at 80% 20%, rgba(242,166,35,0.10), transparent 60%),
+        linear-gradient(rgba(242,166,35,0.02) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(242,166,35,0.02) 1px, transparent 1px);
+      background-size: auto, 28px 28px, 28px 28px;
+    }
+    .share-corner { position: absolute; width: 28px; height: 28px; border: 1px solid var(--amber); }
+    .share-corner.tl { top: 14px; left: 14px; border-right: none; border-bottom: none; }
+    .share-corner.tr { top: 14px; right: 14px; border-left: none; border-bottom: none; }
+    .share-corner.bl { bottom: 14px; left: 14px; border-right: none; border-top: none; }
+    .share-corner.br { bottom: 14px; right: 14px; border-left: none; border-top: none; }
+
+    .share-classified { position: relative; z-index: 2; font-family: 'JetBrains Mono', monospace;
+      font-size: 11px; letter-spacing: 0.30em; color: var(--amber); margin-bottom: 28px;
+      display: flex; justify-content: space-between; align-items: baseline; text-transform: uppercase; }
+    .share-classified .dot { display: inline-block; width: 8px; height: 8px; background: var(--amber);
+      box-shadow: 0 0 10px var(--amber-glow); margin-right: 10px; transform: rotate(45deg); }
+
+    .share-body { position: relative; z-index: 2; display: grid; grid-template-columns: minmax(0,1.45fr) 1fr; gap: 40px; }
+    .share-left { display: flex; flex-direction: column; gap: 22px; }
+
+    .share-eyebrow { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.32em;
+      color: var(--text-3); text-transform: uppercase; display: flex; flex-wrap: wrap; gap: 10px; align-items: baseline; }
+    .share-eyebrow .id { color: var(--cyan); font-weight: 700; }
+    .share-eyebrow .agency { color: var(--amber); }
+    .share-eyebrow .anchor { padding: 2px 8px; border: 1px solid var(--rose); color: var(--rose);
+      background: rgba(224,73,104,0.10); font-size: 9px; letter-spacing: 0.24em; font-weight: 700; }
+    .share-eyebrow .critical { padding: 2px 8px; border: 1px solid #FFB07A; color: #FFB07A;
+      background: rgba(255,138,46,0.10); font-size: 9px; letter-spacing: 0.24em; font-weight: 700; }
+
+    .share-h1 { font-family: 'Space Grotesk', sans-serif; font-size: 52px; font-weight: 700;
+      line-height: 1.05; color: var(--text); letter-spacing: -0.03em; margin: 0; }
+
+    .share-quote { font-family: 'Inter', sans-serif; font-style: italic; font-size: 19px;
+      line-height: 1.65; color: var(--text-2); margin: 0; padding-left: 22px;
+      border-left: 3px solid var(--amber); }
+
+    .share-attribution { font-family: 'JetBrains Mono', monospace; font-size: 11px;
+      color: var(--text-3); letter-spacing: 0.16em; text-transform: uppercase; margin: 0; }
+
+    .share-footer { display: flex; align-items: center; justify-content: space-between; gap: 20px;
+      padding-top: 24px; margin-top: auto; border-top: 1px solid var(--hairline); }
+    .share-brand { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.24em;
+      color: var(--amber); text-transform: uppercase; font-weight: 700; }
+    .share-brand .v { color: var(--text-3); font-weight: 500; }
+    .share-url { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-3);
+      letter-spacing: 0.10em; text-decoration: none; }
+    .share-url:hover { color: var(--amber); }
+
+    /* Right side — sensor frame */
+    .share-sensor { position: relative; background: #050a12; border: 1px solid var(--border-strong);
+      min-height: 360px; overflow: hidden; }
+    .share-sensor::before { content:''; position:absolute; inset:0;
+      background-image: radial-gradient(circle at 50% 46%, rgba(242,166,35,0.10), transparent 60%),
+        repeating-linear-gradient(0deg, rgba(242,166,35,0.06) 0px, rgba(242,166,35,0.06) 1px, transparent 1px, transparent 4px);
+      pointer-events: none; }
+    .share-sensor .sscorner { position: absolute; width: 16px; height: 16px; border: 1px solid rgba(242,166,35,0.55); }
+    .share-sensor .sscorner.tl { top: 10px; left: 10px; border-right: none; border-bottom: none; }
+    .share-sensor .sscorner.tr { top: 10px; right: 10px; border-left: none; border-bottom: none; }
+    .share-sensor .sscorner.bl { bottom: 10px; left: 10px; border-right: none; border-top: none; }
+    .share-sensor .sscorner.br { bottom: 10px; right: 10px; border-left: none; border-top: none; }
+    .share-sensor .hud { position: absolute; top: 16px; left: 18px; font-family: 'JetBrains Mono', monospace;
+      font-size: 10px; color: rgba(242,166,35,0.85); letter-spacing: 0.18em;
+      display: grid; grid-template-columns: auto 1fr; gap: 4px 18px; }
+    .share-sensor .hud .k { color: rgba(242,166,35,0.55); }
+    .share-sensor .hud .v { color: var(--amber-bright, #FFD66B); font-weight: 700; }
+    .share-sensor .stamp { position: absolute; bottom: 14px; left: 18px; right: 18px;
+      display: flex; justify-content: space-between;
+      font-family: 'JetBrains Mono', monospace; font-size: 10px; color: rgba(242,166,35,0.55); letter-spacing: 0.16em; }
+    .share-sensor svg.reticle { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0.6; pointer-events: none; }
+    .share-sensor .orb { position: absolute; border-radius: 50%;
+      background: radial-gradient(circle at 35% 35%, #FFE7A8, #F2A623 50%, rgba(160, 90, 26, 0) 75%);
+      box-shadow: 0 0 28px rgba(242,166,35,0.65); }
+
+    /* CTA tray below the screenshot zone */
+    .share-tray { max-width: 1200px; margin: -8px auto 56px; padding: 24px 56px;
+      display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+    .share-tray h2 { font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.24em;
+      color: var(--text-3); text-transform: uppercase; margin: 0 18px 0 0; }
+    .share-tray button, .share-tray a {
+      font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 0.16em;
+      padding: 12px 18px; cursor: pointer; text-decoration: none;
+      border: 1px solid var(--border-strong); color: var(--text-2); background: var(--surface);
+    }
+    .share-tray button:hover, .share-tray a:hover { color: var(--amber); border-color: var(--amber); }
+    .share-tray .primary { color: var(--void); background: linear-gradient(180deg, var(--amber-bright), var(--gold));
+      border-color: var(--amber); box-shadow: 0 14px 32px -10px rgba(242,166,35,0.55); }
+    .share-tray .primary:hover { color: var(--void); }
+
+    /* About strip */
+    .share-about { max-width: 1200px; margin: 0 auto 64px; padding: 0 56px;
+      font-family: 'JetBrains Mono', monospace; font-size: 11px; line-height: 1.7; color: var(--text-3);
+      letter-spacing: 0.04em; }
+    .share-about a { color: var(--cyan); text-decoration: none; border-bottom: 1px dashed var(--cyan); padding-bottom: 1px; }
+    .share-about a:hover { color: var(--amber); border-color: var(--amber); }
+
+    @media (max-width: 900px){
+      .share-frame { margin: 14px; padding: 28px; }
+      .share-body { grid-template-columns: 1fr; gap: 22px; }
+      .share-h1 { font-size: 34px; }
+      .share-sensor { min-height: 240px; }
+      .share-tray { padding: 18px 22px; }
+      .share-about { padding: 0 22px; }
+    }
+  </style>
+</head>
+<body class="share-mode" data-view="share">
+
+<main>
+  <article class="share-frame" id="share-frame">
+    <span class="share-corner tl"></span><span class="share-corner tr"></span>
+    <span class="share-corner bl"></span><span class="share-corner br"></span>
+
+    <header class="share-classified">
+      <span><span class="dot"></span>// DECLASSIFIED · WAR.GOV · OPEN-SOURCE MIRROR</span>
+      <span id="share-stamp">PURSUE · MISSION CONTROL · 2026</span>
+    </header>
+
+    <div class="share-body">
+      <div class="share-left">
+        <div class="share-eyebrow">
+          <span class="anchor" id="share-anchor" style="display:none">ANCHOR</span>
+          <span class="critical" id="share-critical" style="display:none">CRITICAL</span>
+          <span class="id" id="share-eid">USPER-2025</span>
+          <span>·</span>
+          <span class="agency" id="share-agency">FBI</span>
+          <span>·</span>
+          <span id="share-date">2025-10</span>
+        </div>
+        <h1 class="share-h1" id="share-title">Senior US Intelligence Official describes orb encounter at helicopter altitude.</h1>
+        <blockquote class="share-quote" id="share-quote">"the orb gained elevation and came within ten feet of [the helicopter] before separating into multiple objects of indeterminate count."</blockquote>
+        <p class="share-attribution" id="share-attribution">— USPER FBI 302 narrative · SECRET//NOFORN · declassified May 2026</p>
+        <footer class="share-footer">
+          <span class="share-brand">PURSUE · <span class="v">220 events / 3,530 pages</span></span>
+          <a class="share-url" id="share-permalink" href="dossier.html?eid=usper-2025">rizzleroc.github.io/pursue-console →</a>
+        </footer>
+      </div>
+
+      <aside class="share-sensor" aria-hidden="true">
+        <span class="sscorner tl"></span><span class="sscorner tr"></span>
+        <span class="sscorner bl"></span><span class="sscorner br"></span>
+        <div class="hud">
+          <span class="k">ALT</span><span class="v" id="share-alt">0824 FT</span>
+          <span class="k">SPD</span><span class="v" id="share-spd">082 KTS</span>
+          <span class="k">HDG</span><span class="v" id="share-hdg">124°</span>
+          <span class="k">IR</span><span class="v">WH</span>
+          <span class="k">RNG</span><span class="v" id="share-rng">0.2 NM</span>
+        </div>
+        <svg class="reticle" viewBox="0 0 400 360" preserveAspectRatio="none">
+          <line x1="200" y1="40" x2="200" y2="320" stroke="rgba(242,166,35,0.45)" stroke-width="0.5" stroke-dasharray="2 6"/>
+          <line x1="40" y1="180" x2="360" y2="180" stroke="rgba(242,166,35,0.45)" stroke-width="0.5" stroke-dasharray="2 6"/>
+          <circle cx="200" cy="180" r="56" fill="none" stroke="rgba(242,166,35,0.5)" stroke-width="0.6"/>
+          <circle cx="200" cy="180" r="110" fill="none" stroke="rgba(242,166,35,0.25)" stroke-width="0.5"/>
+          <line x1="180" y1="180" x2="220" y2="180" stroke="rgba(242,166,35,0.8)" stroke-width="0.8"/>
+          <line x1="200" y1="160" x2="200" y2="200" stroke="rgba(242,166,35,0.8)" stroke-width="0.8"/>
+        </svg>
+        <span class="orb" style="top:34%;left:55%;width:18px;height:18px"></span>
+        <span class="orb" style="top:50%;left:40%;width:7px;height:7px;opacity:0.55"></span>
+        <span class="orb" style="top:62%;left:62%;width:6px;height:6px;opacity:0.45"></span>
+        <div class="stamp">
+          <span>SENSOR · MX-20 EO/IR</span>
+          <span id="share-frame-time">2024-09-17 · 02:13:48Z</span>
+        </div>
+      </aside>
+    </div>
+  </article>
+
+  <section class="share-tray">
+    <h2>SHARE</h2>
+    <button class="primary" id="btn-copy-quote" type="button">⎘ COPY QUOTE + LINK</button>
+    <button id="btn-share-native" type="button">↗ SHARE …</button>
+    <button id="btn-copy-link" type="button">⎘ COPY LINK</button>
+    <a id="btn-open-dossier" href="dossier.html">→ READ FULL CASE FILE</a>
+    <a href="index.html">← BACK TO MISSION CONTROL</a>
+  </section>
+
+  <section class="share-about">
+    <p>You're looking at a single record in the <strong style="color:var(--text)">PURSUE Console</strong> archive — a community-run open-source mirror of the U.S. Department of War's UAP document release at <a href="https://www.war.gov/UFO" target="_blank" rel="noopener">war.gov/UFO</a>. The corpus carries 220 events, 3,530 pages of OCR-and-vision-transcribed text, 85 curated entities, and 24 cross-references from primary-source sensor data to theoretical-physics frameworks like the DIA AAWSA superconductor research. Every claim links back to a primary-source document. The site is 100% open source — <a href="https://github.com/rizzleroc/pursue-console" target="_blank" rel="noopener">github.com/rizzleroc/pursue-console</a>.</p>
+  </section>
+</main>
+
+<script src="data.js"></script>
+<script src="chrome.js" defer></script>
+<script src="share.js" defer></script>
+
+<script>
+(function(){
+  if (!window.MC || !MC.ready) return;
+
+  // Mirror of index.html's FEATURED list — keeps the curated quote +
+  // sensor HUD in one place. Future improvement: pull from a static
+  // public/featured.json so authoring lives outside the HTML.
+  var FEATURED = {
+    'usper-2025': {
+      source: 'FBI 302',
+      title: 'Senior US Intelligence Official describes orb encounter at helicopter altitude.',
+      quote: 'the orb gained elevation and came within ten feet of [the helicopter] before separating into multiple objects of indeterminate count.',
+      attribution: '— USPER FBI 302 narrative · SECRET//NOFORN · declassified May 2026',
+      hud: { alt: '0824 FT', spd: '082 KTS', hdg: '124°', rng: '0.2 NM' },
+      frameTime: '2024-09-17 · 02:13:48Z'
+    },
+    'DOE-UAP-D001': {
+      source: 'DOE / Pantex',
+      title: 'Pantex Plant ground-surveillance radar captures anomalous return at a nuclear-weapons assembly site.',
+      quote: 'Enhanced imagery from Sandia National Labs — Pantex Unidentified Object Incident Report, Ground Surveillance Radar Tower ENE.',
+      attribution: '— DOE-UAP-D001 · Department of Energy · Release 02',
+      hud: { alt: '01230 FT', spd: '—', hdg: '—', rng: '—' },
+      frameTime: 'PANTEX · 35.32°N · 101.56°W'
+    },
+    'fbi-62hq83894': {
+      source: 'FBI Vault',
+      title: '21-year FBI investigation into flying discs, with Oak Ridge nuclear-site photo evidence.',
+      quote: 'Flying discs case file 62-HQ-83894 — eighteen sections, including 1947–1950 sightings over Oak Ridge nuclear facility.',
+      attribution: '— FBI 62HQ-83894 · 18 sections · declassified May 2026',
+      hud: { alt: '—', spd: '—', hdg: '—', rng: '—' },
+      frameTime: 'OAK RIDGE · 35.93°N · 84.31°W'
+    },
+    'gemini-7': {
+      source: 'NASA',
+      title: 'Borman & Lovell observe a "bogey" during Gemini VII orbital mission, 1965.',
+      quote: 'GEMINI-7 HERE HOUSTON, HOW DO YOU READ? LOUD AND CLEAR SEVEN, GO AHEAD. (BORMAN) A BOGEY AT TEN O\'CLOCK HIGH.',
+      attribution: '— Gemini VII air-to-ground transcript · NASA · 5 December 1965',
+      hud: { alt: 'ORBIT', spd: '17,500 MPH', hdg: 'PERIGEE', rng: '—' },
+      frameTime: '1965-12-05 · GEMINI VII ORBIT'
+    },
+    'apollo-17': {
+      source: 'NASA',
+      title: 'Apollo 17 astronaut Schmitt reports continuous light-flashes during translunar flight.',
+      quote: 'We had light flashes just about continuously during the whole flight when we were dark adapted. I had one which I thought was a flash on the lunar surface.',
+      attribution: '— Apollo 17 Technical Crew Debriefing · 4 January 1973',
+      hud: { alt: 'TRANSLUNAR', spd: '—', hdg: 'LUNAR INSERTION', rng: '—' },
+      frameTime: '1973-01-04 · APOLLO 17 TLI'
+    }
+  };
+
+  function esc(s){ return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+  function pickEid(){
+    var q = MC.query && MC.query.eid;
+    if (q && MC.byEid(q)) return q;
+    return 'usper-2025';
+  }
+
+  function render(){
+    var eid = pickEid();
+    var rec = MC.byEid(eid);
+    var f = FEATURED[eid] || null;
+
+    // Fall back to event metadata if the eid isn't in the curated list —
+    // share.html still works for every event, just with the event summary
+    // instead of a hand-curated pull-quote.
+    var title, quote, attribution, hud, source, frameTime;
+    if (f){
+      title       = f.title;
+      quote       = f.quote;
+      attribution = f.attribution;
+      hud         = f.hud;
+      source      = f.source;
+      frameTime   = f.frameTime;
+    } else if (rec){
+      title       = rec.title;
+      quote       = (rec.summary || '').slice(0, 280);
+      attribution = '— ' + (rec.agency || 'Department of War') + ' · ' + (rec.date || 'declassified') + (rec.release ? ' · ' + rec.release : '');
+      hud         = { alt: '—', spd: '—', hdg: '—', rng: '—' };
+      source      = rec.agency || '';
+      frameTime   = rec.id + ' · ' + (rec.date || '');
+    } else {
+      title       = 'Declassified UAP case file';
+      quote       = 'No event metadata found.';
+      attribution = '— PURSUE corpus';
+      hud         = { alt: '—', spd: '—', hdg: '—', rng: '—' };
+      source      = '';
+      frameTime   = '';
+    }
+
+    // Header chips
+    document.getElementById('share-eid').textContent = (rec ? rec.id : eid).toUpperCase();
+    document.getElementById('share-agency').textContent = (rec && rec.agency) || source || '—';
+    document.getElementById('share-date').textContent   = (rec && rec.date) || '—';
+    var anchorPill = document.getElementById('share-anchor');
+    var criticalPill = document.getElementById('share-critical');
+    anchorPill.style.display = (rec && rec.flag === 'anchor') ? '' : 'none';
+    criticalPill.style.display = (rec && rec.priority === 'critical') ? '' : 'none';
+
+    document.getElementById('share-title').textContent = title;
+    document.getElementById('share-quote').textContent = '"' + quote.replace(/^"+|"+$/g, '') + '"';
+    document.getElementById('share-attribution').textContent = attribution;
+    document.getElementById('share-alt').textContent = hud.alt || '—';
+    document.getElementById('share-spd').textContent = hud.spd || '—';
+    document.getElementById('share-hdg').textContent = hud.hdg || '—';
+    document.getElementById('share-rng').textContent = hud.rng || '—';
+    document.getElementById('share-frame-time').textContent = frameTime || '';
+
+    var dossierHref = MC.url.dossier(eid);
+    document.getElementById('share-permalink').href = dossierHref;
+    document.getElementById('btn-open-dossier').href = dossierHref;
+
+    // Update OG tags so links pasted into chat clients show the case-specific preview.
+    if (MC.setShareMeta){
+      MC.setShareMeta({
+        title: title,
+        description: '"' + quote + '" — ' + attribution.replace(/^— /, ''),
+        url: window.location.href,
+      });
+    }
+
+    // ── Action wiring ──
+    var copyQuoteBtn = document.getElementById('btn-copy-quote');
+    var copyLinkBtn  = document.getElementById('btn-copy-link');
+    var shareBtn     = document.getElementById('btn-share-native');
+    var shareUrl     = window.location.href;
+    var quotePayload = '"' + quote + '"\n\n' + attribution + '\n\n' + shareUrl;
+
+    copyQuoteBtn.onclick = function(){ MC.copyToClipboard(quotePayload, copyQuoteBtn); };
+    copyLinkBtn.onclick  = function(){ MC.copyToClipboard(shareUrl, copyLinkBtn); };
+    shareBtn.onclick = function(){
+      MC.share({ title: title, text: '"' + quote + '"\n\n' + attribution, url: shareUrl }, shareBtn);
+    };
+  }
+
+  MC.ready().then(render);
+  MC.onUpdate(function(){ render(); });
+})();
+</script>
+</body>
+</html>

--- a/public/mc/share.js
+++ b/public/mc/share.js
@@ -1,0 +1,120 @@
+// Mission Control — shared sharing primitives.
+//
+// Every MC page can:
+//   • Call MC.setShareMeta({title, description, url, eid}) to update the
+//     <head> OG / Twitter Card tags at runtime (since the static HTML can't
+//     know which event the user picked).
+//   • Call MC.copyToClipboard(text, sourceBtn) to copy and flash a
+//     "✓ COPIED" confirmation on the source button. Falls back to a hidden
+//     textarea + document.execCommand for browsers blocking the async API.
+//   • Read MC.url.share(eid) for the canonical share URL of an event.
+
+(function () {
+  if (!window.MC) return;
+
+  // ─────────── OG / Twitter Card meta updater ───────────
+  // Static HTML carries default tags; runtime calls override them per event.
+  // Selectors are explicit so we don't accidentally rewrite unrelated meta.
+  const META_KEYS = {
+    title:       ['meta[property="og:title"]',       'meta[name="twitter:title"]'],
+    description: ['meta[property="og:description"]', 'meta[name="twitter:description"]'],
+    image:       ['meta[property="og:image"]',       'meta[name="twitter:image"]'],
+    url:         ['meta[property="og:url"]'],
+  };
+
+  function ensureMeta(selector, attrPair) {
+    let el = document.head.querySelector(selector);
+    if (!el) {
+      el = document.createElement('meta');
+      el.setAttribute(attrPair[0], attrPair[1]);
+      document.head.appendChild(el);
+    }
+    return el;
+  }
+
+  MC.setShareMeta = function (m) {
+    if (!m) return;
+    // Compose page <title> too so the browser tab + bookmarks reflect the case.
+    if (m.title) {
+      try { document.title = m.title + ' · PURSUE Console'; } catch (e) {}
+    }
+    Object.keys(META_KEYS).forEach((k) => {
+      if (m[k] == null) return;
+      const selectors = META_KEYS[k];
+      selectors.forEach((sel) => {
+        let el = document.head.querySelector(sel);
+        if (!el) {
+          el = document.createElement('meta');
+          // Recreate from the selector — covers og:* and twitter:*.
+          if (sel.includes('property=')) {
+            el.setAttribute('property', sel.match(/property="([^"]+)"/)[1]);
+          } else {
+            el.setAttribute('name', sel.match(/name="([^"]+)"/)[1]);
+          }
+          document.head.appendChild(el);
+        }
+        el.setAttribute('content', String(m[k]));
+      });
+    });
+    // OG canonical URL — if missing, compose from window.location.
+    if (m.url == null) {
+      const ogUrl = document.head.querySelector('meta[property="og:url"]');
+      if (ogUrl) ogUrl.setAttribute('content', window.location.href);
+    }
+  };
+
+  // ─────────── Clipboard with confirmation ───────────
+  MC.copyToClipboard = async function (text, sourceBtn) {
+    let ok = false;
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+        ok = true;
+      }
+    } catch (e) {}
+    if (!ok) {
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.cssText = 'position:fixed;left:-9999px;top:0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+      } catch (e) {}
+    }
+    if (sourceBtn) {
+      const orig = sourceBtn.textContent;
+      sourceBtn.textContent = ok ? '✓ COPIED' : '⨯ COPY FAILED';
+      sourceBtn.disabled = true;
+      setTimeout(() => {
+        sourceBtn.textContent = orig;
+        sourceBtn.disabled = false;
+      }, 1600);
+    }
+    return ok;
+  };
+
+  // ─────────── Canonical share URL helper ───────────
+  if (MC.url) {
+    MC.url.share = function (eid, extra) {
+      const base = window.location.origin + window.location.pathname.replace(/\/mc\/.*$/, '/mc/');
+      return base + 'share.html?eid=' + encodeURIComponent(eid) + (extra ? '&' + extra : '');
+    };
+  }
+
+  // ─────────── Native-share fallback ───────────
+  // Phones get the system share sheet; desktop gets a clipboard copy.
+  MC.share = async function (payload, sourceBtn) {
+    const { title, text, url } = payload || {};
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+        return true;
+      } catch (e) { /* user cancelled — fall through to copy */ }
+    }
+    const composite = [text, url].filter(Boolean).join('\n\n');
+    return MC.copyToClipboard(composite, sourceBtn);
+  };
+})();

--- a/public/mc/timeline.html
+++ b/public/mc/timeline.html
@@ -3,6 +3,18 @@
 <head>
   <meta charset="utf-8">
   <title>PURSUE Mission Control · Timeline</title>
+  <meta name="description" content="220 events plotted by decade with agency colour-coding and density bars. Click any card to open the dossier.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="PURSUE Console · Mission Control">
+  <meta property="og:title" content="PURSUE Timeline — declassified UAP events 1940s–2020s">
+  <meta property="og:description" content="220 events plotted by decade with agency colour-coding and density bars. Click any card to open the dossier.">
+  <meta property="og:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
+  <meta property="og:url" content="https://rizzleroc.github.io/pursue-console/mc/timeline.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PURSUE Timeline — declassified UAP events 1940s–2020s">
+  <meta name="twitter:description" content="220 events plotted by decade with agency colour-coding and density bars. Click any card to open the dossier.">
+  <meta name="twitter:image" content="https://rizzleroc.github.io/pursue-console/og/default.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/og/README.md
+++ b/public/og/README.md
@@ -1,0 +1,22 @@
+# OpenGraph card assets
+
+Static card images referenced by the OpenGraph + Twitter Card meta tags
+embedded in every /mc/*.html page (and runtime-overridden per event via
+share.js). These are crawled by X/Slack/iMessage/Discord/Facebook to
+generate link previews when a PURSUE Console URL is pasted.
+
+## Current
+
+- `default.png` — the site-wide default card. 1200×630. Used when a
+  page-specific card isn't generated yet.
+- _(TODO)_ `event-<eid>.png` — per-event cards rendered at build time so
+  Twitter/X (which doesn't execute JS for Twitter Cards) shows a
+  case-specific preview for every dossier/share/evidence URL.
+
+## How to regenerate
+
+The build pipeline can render these via a headless Chromium pass against
+`/mc/share.html?eid=<EID>&render=card` — that page is laid out to fit a
+1200×630 viewport exactly. See `scripts/build-og-cards.mjs` (TODO).
+
+Until that ships, every page falls back to `default.png`.


### PR DESCRIPTION
## Summary

Swap the launcher-grid home for an editorial front page that competes head-on with `disclosedufo.com` and `ufodossier.com` (the two existing UAP-archive sites already in production), and wire share infrastructure into every surface so each URL pasted into a chat client / tweet renders a rich preview.

## What landed

### New editorial front page (`index.html` rewrite)
- Hero with thesis H1: *"Every UAP record the Department of War released — searchable, cross-referenced, free."* (amber gradient on the second clause)
- Hard receipts row: **220 EVENTS · 3,530 PAGES · 85 ENTITIES · 24 CROSS-REFS · 18 LANGUAGES · OPEN SOURCE** (live-bound)
- **FEATURED CASE** card with 6-event rotation deterministic per UTC day (USPER-2025 · DOE-UAP-D001 · FBI-62HQ-83894 · GEMINI-7 · APOLLO-17 · COMETA) — each carries a curated pull-quote + sensor-frame HUD (MX-20 EO/IR mock with altitude/speed/heading/range/IR mode)
- Three per-card CTAs: READ THE CASE FILE · ⎘ SHARE THIS QUOTE · ↗ PERMALINK
- Action tray: 🎲 RANDOM DECLASSIFIED MOMENT (jumps to share page for a random anchor/critical event) · SEARCH 3,530 PAGES · EVIDENCE CHAINS · HOW CAN I HELP? · THIS WEEK'S MISSION BRIEFING
- **ANALYTICAL SURFACES** strip below the fold: the 13 existing surfaces demoted to a footer carousel

### New share infrastructure
- `public/mc/share.js` — `MC.setShareMeta()`, `MC.copyToClipboard()`, `MC.share()`, `MC.url.share(eid)`
- Static OG / Twitter Card meta tags injected into every existing `/mc/*.html` (Twitter Cards need static HTML — runtime updates cover Slack/iMessage/Discord/Facebook)

### `share.html` — dedicated screenshot-optimized screen
- ANCHOR + CRITICAL pills, event id, agency, date
- Big H1 case title + amber-bordered blockquote pull-quote
- Sensor-frame side panel with HUD readouts
- Action tray: ⎘ COPY QUOTE + LINK · ↗ SHARE (native share sheet on phones) · ⎘ COPY LINK · → READ FULL CASE FILE
- About strip for first-time visitors
- Graceful fallback for uncurated events (uses event summary as pull-quote)

### `briefing.html` — weekly auto-rendered "what changed" page
- ISO week stamp, corpus-built timestamp
- WHAT CHANGED card: deltas vs sessionStorage snapshot
- SHARE THIS WEEK: pre-formatted post block ready for X/Mastodon
- Top mined entities + top uncatalogued queue items

### Dossier + Evidence integrations
- Dossier: SHARE CASE FILE button + OG meta updates per resolved event
- Evidence: OG meta updates on every focus change

## Test plan

- [x] All inline JS parses
- [x] INDEX renders thesis H1, receipts row (220/3,530/85/24/18), featured case (rotates daily — today: Gemini VII Borman quote), 13 surface tiles, random button, OG title updates
- [x] SHARE defaults to USPER-2025; `?eid=DOE-UAP-D001` shows CRITICAL pill; `?eid=cometa` falls back to event metadata gracefully
- [x] BRIEFING shows "2026 · W24", tweet-formatted post, 6 top entities, 6 top work items
- [x] DOSSIER share button present; OG title flips to resolved event title
- [ ] Verify in production after merge
- [ ] (follow-up) generate `public/og/default.png` via build pipeline (currently placeholder README)
- [ ] (follow-up) per-event OG cards rendered at build time for Twitter Cards
- [ ] (follow-up) embeddable widget script

https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG

---
_Generated by [Claude Code](https://claude.ai/code/session_015tBwwgQvVKfrC48zoXwSRG)_