### PR TITLE
fix(ask): 3-iter /loop hardening of PATTERN intent classifier

### DIFF
--- a/src/lib/askEngine.js
+++ b/src/lib/askEngine.js
@@ -103,7 +103,10 @@ function topicTerms(qLower) {
 // Stem-match prefixes (no trailing \b) so "changed", "changing", "updated",
 // "newest" all hit. The leading \b keeps "ranch" from matching "chang".
 function isChanges(q) {
-  return /\b(chang|new|added|since|latest|recently|update|fresh|just dropped|incoming|release 02|release 2|release ii|r02|rel 2)/.test(q);
+  // Bare "new" was too greedy — "Papua New Guinea" matched and routed
+  // to Release 02 deltas. Require "new" in a "what's new" / "anything
+  // new" / "what is new" context so proper nouns containing it slide by.
+  return /\b(chang|added|since|latest|recently|updated?|fresh|just dropped|incoming|release 02|release 2|release ii|r02|rel 2|whats new|what'?s new|anything new|new in|new since)/.test(q);
 }
 function isClassifiedBefore(q) {
   return /\b(classified before|classified beforehand|previously classified|was classified|still classified|still redacted|still secret|redacted|secret|withheld|blacked out|black bars|censored)\b/.test(q);

--- a/src/lib/askEngine.js
+++ b/src/lib/askEngine.js
@@ -43,7 +43,13 @@ const STOPWORDS = new Set([
   "so","can","be","been","has","have","had","there","its","any","i","me",
   "tell","show","find","list","all","into","across","records","record",
   "documents","document","docs","doc","files","file","reports","report",
-  "anything","everything","things","stuff","please","me","us"
+  "anything","everything","things","stuff","please","me","us",
+  // Interrogatives + comparators (added by /loop iter — these words
+  // leaked into keyword AND-match and forced no-result on real questions):
+  "how","why","when","where","who","whom","whose","which",
+  "differ","different","differs","compare","compared","comparing",
+  "vs","versus","between","summarize","summary","describe","described",
+  "discussed","discusses","mean","actually","really","still"
 ]);
 
 function lc(q) { return (q || "").toLowerCase().trim(); }
@@ -320,15 +326,34 @@ function answerFilter({ events, agency, release, era, media, terms }) {
   if (media === "audio") { slice = slice.filter(e => /audio|transcript|debrief/i.test(e.type || "")); filters.push("audio"); }
   if (media === "image") { slice = slice.filter(e => /image|imagery|photo|sketch/i.test(e.type || "")); filters.push("image"); }
   if (terms && terms.length) {
-    slice = slice.filter(e => {
-      // Include the `date` field in the haystack so a year term ("1958")
-      // matches records whose year only shows up in metadata, not in the
-      // descriptive text. Without this, "FBI 1958" zeroes out detroit-1958
-      // (date: "1958-04-17") because its title is "Detroit FBI UFO Memo".
-      const hay = (e.title + " " + (e.summary || "") + " " + (e.tags || []).join(" ") + " " + (e.loc || "") + " " + (e.date || "")).toLowerCase();
-      return terms.every(t => hay.includes(t));
-    });
-    filters.push(`matching "${terms.join(" ")}"`);
+    // Include `date` so year terms hit records whose year is only in
+    // metadata. Strict AND-match by default — that's the right
+    // precision for "FBI 1958". But if AND returns nothing, fall back
+    // to ranked OR: count how many terms each record hits, keep the
+    // top-N. This rescues comparative / multi-topic questions like
+    // "How does the SWIR diamond differ from the bouncy ball Syria
+    // report?" where no single record matches every term.
+    const hayOf = (e) => (e.title + " " + (e.summary || "") + " "
+      + (e.tags || []).join(" ") + " " + (e.loc || "") + " "
+      + (e.date || "")).toLowerCase();
+    const andHit = slice.filter(e => terms.every(t => hayOf(e).includes(t)));
+    if (andHit.length > 0) {
+      slice = andHit;
+      filters.push(`matching "${terms.join(" ")}"`);
+    } else {
+      // OR-fallback: at least 2 terms (or all of them, if fewer) must hit.
+      const minHits = Math.min(terms.length, 2);
+      const scored = slice
+        .map(e => {
+          const hay = hayOf(e);
+          const hits = terms.filter(t => hay.includes(t)).length;
+          return { e, hits };
+        })
+        .filter(x => x.hits >= minHits)
+        .sort((a, b) => b.hits - a.hits);
+      slice = scored.map(x => x.e);
+      filters.push(`mentioning "${terms.join(" ")}" (any)`);
+    }
   }
   return {
     intent: "filter",
@@ -378,7 +403,7 @@ export function ask(question, opts = {}) {
   if (isClassifiedBefore(q))     answer = answerClassifiedBefore({ events });
   else if (isUnclassified(q))    answer = answerUnclassified({ events });
   else if (isChanges(q))         answer = answerChanges({ events });
-  else if (isDifferent(q))       answer = answerDifferent({ events, agency });
+  else if (isDifferent(q) && agency) answer = answerDifferent({ events, agency });
   else if (isCount(q))           answer = answerCount({ events, agency, release, era, media });
   else if (agency || release || era || media || year) {
     const terms = year ? [year] : [];

--- a/src/lib/askEngine.js
+++ b/src/lib/askEngine.js
@@ -321,7 +321,11 @@ function answerFilter({ events, agency, release, era, media, terms }) {
   if (media === "image") { slice = slice.filter(e => /image|imagery|photo|sketch/i.test(e.type || "")); filters.push("image"); }
   if (terms && terms.length) {
     slice = slice.filter(e => {
-      const hay = (e.title + " " + (e.summary || "") + " " + (e.tags || []).join(" ") + " " + (e.loc || "")).toLowerCase();
+      // Include the `date` field in the haystack so a year term ("1958")
+      // matches records whose year only shows up in metadata, not in the
+      // descriptive text. Without this, "FBI 1958" zeroes out detroit-1958
+      // (date: "1958-04-17") because its title is "Detroit FBI UFO Memo".
+      const hay = (e.title + " " + (e.summary || "") + " " + (e.tags || []).join(" ") + " " + (e.loc || "") + " " + (e.date || "")).toLowerCase();
       return terms.every(t => hay.includes(t));
     });
     filters.push(`matching "${terms.join(" ")}"`);


### PR DESCRIPTION
## Summary

`/loop 10m` ran the ASK eval subagent on random samples of the eval set, fixing the bugs each iteration surfaced. **Stop condition met**: 2 consecutive runs at 80% pass rate.

## Loop progress

| Run | Pass rate | Citation | Headline | Bug surfaced | Fix in this PR |
|---|---|---|---|---|---|
| 1 | 60% (3/5) | 0.60 | 0.60/2 | year filter ignored `date` metadata | `+ e.date` in haystack |
| 2 | 80% (4/5) | 0.80 | 0.80/2 | comparative dead-end + stopword AND-noise | isDifferent gated on agency; STOPWORDS expanded; answerFilter AND→OR fallback |
| 3 | 80% (4/5) | 0.80 | 1.20/2 | `\bnew\b` matched "Papua **New** Guinea" → Release 02 | isChanges requires "new" in "what's/anything/new in" context |

## What changed in `src/lib/askEngine.js`

1. **Year filter searches `date` field** — was `title + summary + tags + loc`; now includes `date`. Fixes `detroit-1958` (date `"1958-04-17"`, title without "1958") returning empty for "FBI 1958".

2. **STOPWORDS expanded** — `how`, `why`, `differ`, `compare`, `between`, `summarize`, `describe`, etc. were leaking into AND-match and forcing zero results on any natural-language question that included them.

3. **isDifferent without agency falls through** — was dead-ending on "I need an agency or topic". Comparative questions between named cases (no agency mentioned) now route to keyword search.

4. **answerFilter AND→OR fallback** — when strict AND-match returns zero, fall back to ranked OR-match (count term hits, keep records hitting ≥2, sort by hit count). Rescues multi-topic comparatives without sacrificing single-topic AND precision.

5. **isChanges no longer matches bare "new"** — requires explicit "what's new" / "new in" / "anything new" context. Proper nouns like Papua **New** Guinea, **New** Mexico, **New** Orleans slide past.

## Verified

```
"What did the Detroit FBI memo describe in 1958?"            → detroit-1958   ✅
"How does the SWIR diamond differ from the bouncy ball?"     → greece-jan-2024 ✅
"Compare Western US 2023 cluster to USPER orb case"          → western-us-2023 ✅
"What did the Papua New Guinea cable describe?"              → papua-1985     ✅
"what changed in Release 02"                                 → R02 records    ✅ (regression)
"what's different about NASA"                                → NASA slice     ✅ (regression)
```

## Test plan

- [x] 3 loop iterations, deterministic + subagent-judged eval against random samples
- [x] All previously-passing eval items still pass after each fix
- [x] PATTERN mode no longer fails on year-only queries, comparative-no-agency, or proper-noun-containing-"new"

PATTERN remains a navigator (surfaces candidate records), not an answer synthesizer — for content questions like "did NASA declassify X", the in-browser model / hosted backend remain the path to real synthesized answers. This PR just makes the navigator honest.

https://claude.ai/code/session_01KDn3C4nm4UVEoscHMzgSpj