### PR TITLE
docs(changelog): catalog cleanup sweep (#366 #367 #368 #369 #370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## Catalog cleanup sweep (2026-06-20)
+
+Six small surgical PRs against `src/data/events.js` + `src/data/events-auto.js` to fix field-level bugs accumulated across the R02 + R03 ingestions. Net effect: timeline, atlas, globe, and facet dropdowns all subset correctly where they previously over- or under-counted. Catalog count drops 293 → 291 (2 duplicate Apollo 17 auto-stubs removed). No content changes, no schema changes.
+
+### Wrong sort dates + placeholder coords on 8 R03 events (#366)
+
+The #285 WHIP ingestion landed five R03 entries with `sort: 20260612` (today's date when ingested) instead of the actual incident date — pinned them to the right-edge present on the timeline. Four NASA debriefs also had `coords: [0, 0]` (null-island) despite carrying real KSC / JSC / North Atlantic recovery locations. Fixed:
+
+- `NASA-UAP-D016/D017` Gemini 4 debriefs: sort `20260612` → `19650609`, era `20s` → `60s`, coords `[0, 0]` → `[27.73, -75.95]`
+- `NASA-UAP-D019/D020/D021` Gemini 5 + 7 debriefs: coords `[0, 0]` → `[28.4889, -80.5778]` (KSC LC-39)
+- `NASA-UAP-D024/D025` Apollo 16 audio: sort `20260612` → `19720501/02`, era `20s` → `70s`, coords `[0, 0]` → `[29.5502, -95.0972]` (JSC), date `"Undated"` → `"May, 1972"`
+- `CIA-UAP-009`: region `"Asia"` → `"Europe"` (Budapest)
+
+### 75 events with `[0, 0]` placeholder coords (#367)
+
+Same class of bug at 10× scale — mostly auto-generated R02 DOW DVIDS PR records from the `data-raw/uap-data.csv` ingestion. 25% of the entire catalog was pinned to null-island (Gulf of Guinea). Assigned regional centroids consistent with existing curated entries:
+
+- 24 events at CENTCOM AOR → `[25.0, 50.0]` (Persian Gulf centroid)
+- 8 events at Arabian Gulf → `[26.5, 51.5]`
+- Plus regional fixes for Iraq (matches `iraq-may-2022`), Syria (matches `syria-july-2022`), Greece, UAE, Yellow Sea, AFRICOM, Mediterranean, Strait of Hormuz, Gulf of Oman, East China Sea, Pacific, Aegean, Iran, Kazakhstan, Texas, North Atlantic, and Pacific Time Zone.
+- 9 events with `loc: "N/A"` / `"(unknown)"` intentionally kept at `[0, 0]` — no defensible guess; the marker now flags them as needing human attention.
+
+Patch: `scripts/patch-r02-coords.mjs` committed for reproducibility.
+
+### Duplicate Apollo 17 stubs + IC/USG agency palette (#368)
+
+Two auto-generated NASA Apollo 17 stub records in `events-auto.js` (`nasa-uap-d5-apollo-17-…`, `nasa-uap-d6-apollo-17-…`) were duplicating the curated `NASA-UAP-D005` + `NASA-UAP-D006` entries in `events.js` RAW. The dedup match in `EVENTS = [...RAW, ..._autoMinusDupes]` uses string-equal IDs, but the curated forms use uppercase while the gemini auto-import uses lowercase semantic ids — so both copies survived to the published catalog. Removed.
+
+Same removal also fixed the agency palette: the two duplicate stubs carried `agency: "Unknown"`, and combined with `ICA-UAP-D001` (`"Intelligence Community"`) + `USG-UAP-D001` (`"U.S. Government"`), four catalog records weren't rendering in the agency dropdown. Dropped the stubs (-2), added two palette entries (-2 unmapped). Catalog: 293 → 291.
+
+### Tag normalization (#369, #370)
+
+Two passes:
+
+1. The PURSUE Release 02 + Release 03 disclosure anchors tagged themselves with `"release 02"` / `"release 03"` (space-separated) while every other R02/R03 event uses the hyphenated form. Filter-invisible bug — the anchors weren't surfacing in their own release groupings. Two-character fix.
+
+2. Case-token normalization across **142 tag instances** in `events.js` + `events-auto.js`. The same tag appeared in both upper- and lowercase across the catalog (`FBI` + `fbi`, `CIA` + `cia`, `DOW` + `dow` + `DoW`, `NASA` + `nasa`, `USSR`, `UAP`, `CENTCOM`, `AFRICOM`, `INDOPACOM`, `Borman`, `Lovell`, `Conrad`, `Cernan`, `Djibouti`, `Army`, `Propulsion`, `Radar`) — 17 case-variant pairs total. Each pair rendered as **separate filter chips** in facet dropdowns, so selecting "FBI" gave a strict subset of selecting "fbi". Convention: acronyms uppercase, proper nouns Title Case, common nouns lowercase. After: 0 variant pairs.
+
+Also surfaced 6 R02 events with `loc` strings but `region: "Unknown"` — inferred correct regions:
+
+- 2× UAE → Middle East
+- 1× Indo-PACOM → Asia-Pacific
+- 2× Yellow Sea → Asia-Pacific
+- 1× Kazakhstan → Asia
+
+Patches: `scripts/patch-tag-case.mjs` committed for reproducibility.
+
+### Remaining `region: "Unknown"` audit
+
+6 events kept at `region: "Unknown"` post-sweep, all with `loc: "(unknown)"` or `"N/A"`. No defensible geographic inference — left as discoverable markers for human attention rather than papering over with fake values.
+
 ## DVIDS-via-MCP video collector (2026-05-26, `@unverified`)
 
 The same Akamai-style TLS-fingerprint block that makes us route war.gov traffic through a real Chrome tab also afflicts `dvidshub.net`: yt-dlp returns `ConnectionResetError(10054)` against every DVIDS video URL we tried. Rather than chase yt-dlp config flags, we retired the yt-dlp path and reused the trick the rest of the MCP already uses.


### PR DESCRIPTION
## Summary

Single-section CHANGELOG entry that summarizes the catalog cleanup sweep just landed across **#366, #367, #368, #369, #370**.

Net effect across the six PRs:
- 293 → 291 events (2 duplicate Apollo 17 auto-stubs removed)
- 75 fewer null-island `[0, 0]` placeholder coordinates
- 8 fewer wrong-decade timeline entries (R03 entries with today's date as sort)
- 142 tag-token case fixes → 0 case-variant pairs in facet dropdowns
- 4 fewer unmapped agency dropdown items
- 6 events with `region: "Unknown"` → inferred to real regions

No code change. Just documenting the work for the next CHANGELOG reader.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BsvHdGWw1GLBSAsSVgwVQS)_